### PR TITLE
Update VectorIndex and BytesUnpack to match other blocks better

### DIFF
--- a/pictorus-internal/src/utils.rs
+++ b/pictorus-internal/src/utils.rs
@@ -231,11 +231,10 @@ cfg_if::cfg_if! {
                     String::from("{}")
                 }
             };
-            let diagram_params = json::from_str(input_params_json.as_str()).unwrap_or_else(|_| {
+            json::from_str(input_params_json.as_str()).unwrap_or_else(|_| {
                 warn!("Error parsing params file, using empty params map.");
                 HashMap::<String, HashMap<String, String>>::new()
-            });
-            diagram_params
+            })
         }
 
         pub fn get_pictorus_vars() -> PictorusVars {

--- a/pictorus-traits/src/lib.rs
+++ b/pictorus-traits/src/lib.rs
@@ -22,6 +22,8 @@ use sealed::Sealed;
 pub mod custom_blocks;
 pub use custom_blocks::*;
 
+pub mod tuple_array_interop;
+
 /// A processing block
 pub trait ProcessBlock: Default {
     // NOTE because of the `Inputs` trait bound; all blocks must have at least *one* input
@@ -216,7 +218,7 @@ promotions! {
 pub type Promotion<L, R> = <L as Promote<R>>::Output;
 
 // a fixed-size array is like a mathematical vector
-// NOTE the `Pod` trait bound prevents the creation of nested vectors
+// NOTE the `Scalar` trait bound prevents the creation of nested vectors
 impl<const N: usize, T> Pass for [T; N]
 where
     T: Scalar,

--- a/pictorus-traits/src/tuple_array_interop.rs
+++ b/pictorus-traits/src/tuple_array_interop.rs
@@ -1,0 +1,73 @@
+//! Traits to attempt to bridge tuples of a single type with fixed-size arrays of that type.
+
+use crate::{Pass, Scalar};
+
+pub trait TupleEquivalent<T: Scalar, const N: usize>: Sized {
+    type TupleEquivalent: Sized + Default + Pass;
+
+    fn into_tuple(self) -> Self::TupleEquivalent;
+}
+
+impl<T: Scalar> TupleEquivalent<T, 1> for [T; 1] {
+    type TupleEquivalent = T;
+
+    fn into_tuple(self) -> Self::TupleEquivalent {
+        self[0]
+    }
+}
+
+impl<T: Scalar> TupleEquivalent<T, 2> for [T; 2] {
+    type TupleEquivalent = (T, T);
+
+    fn into_tuple(self) -> Self::TupleEquivalent {
+        self.into()
+    }
+}
+
+impl<T: Scalar> TupleEquivalent<T, 3> for [T; 3] {
+    type TupleEquivalent = (T, T, T);
+
+    fn into_tuple(self) -> Self::TupleEquivalent {
+        self.into()
+    }
+}
+
+impl<T: Scalar> TupleEquivalent<T, 4> for [T; 4] {
+    type TupleEquivalent = (T, T, T, T);
+
+    fn into_tuple(self) -> Self::TupleEquivalent {
+        self.into()
+    }
+}
+
+impl<T: Scalar> TupleEquivalent<T, 5> for [T; 5] {
+    type TupleEquivalent = (T, T, T, T, T);
+
+    fn into_tuple(self) -> Self::TupleEquivalent {
+        self.into()
+    }
+}
+
+impl<T: Scalar> TupleEquivalent<T, 6> for [T; 6] {
+    type TupleEquivalent = (T, T, T, T, T, T);
+
+    fn into_tuple(self) -> Self::TupleEquivalent {
+        self.into()
+    }
+}
+
+impl<T: Scalar> TupleEquivalent<T, 7> for [T; 7] {
+    type TupleEquivalent = (T, T, T, T, T, T, T);
+
+    fn into_tuple(self) -> Self::TupleEquivalent {
+        self.into()
+    }
+}
+
+impl<T: Scalar> TupleEquivalent<T, 8> for [T; 8] {
+    type TupleEquivalent = (T, T, T, T, T, T, T, T);
+
+    fn into_tuple(self) -> Self::TupleEquivalent {
+        self.into()
+    }
+}


### PR DESCRIPTION
Vector Index outputs tuples and BytesUnpack type signature updated to match other similar blocks (that is looks like `BytesUnpack<(f64,f64)>` instead of `BytesUnpack<(f64,f64,bool)>`