### PR TITLE
Use same source for all embassy deps

### DIFF
--- a/pictorus-stm32/Cargo.toml
+++ b/pictorus-stm32/Cargo.toml
@@ -14,7 +14,7 @@ embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
   "unproven",
 ] }
 embedded-io = "0.6.1"
-embassy-futures = "0.1.1"
+embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "68c8238" }
 embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "68c8238" }
 embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "68c8238" }
 embedded-io-async = "0.6.1"


### PR DESCRIPTION
Use consistent embassy dependencies. This allows downstream crates to vendor deps