### PR TITLE
Changes to Support Codegen Changes

### DIFF
--- a/block-data/src/lib.rs
+++ b/block-data/src/lib.rs
@@ -38,6 +38,16 @@ pub struct BlockData {
     _type: BlockDataType,
 }
 
+impl BlockDataRead for BlockData {
+    fn get_scalar(&self) -> f64 {
+        self.scalar()
+    }
+
+    fn get_matrix(&self) -> (usize, usize, &[f64]) {
+        (self.nrows(), self.ncols(), self._data.as_slice())
+    }
+}
+
 impl BlockDataRead for &BlockData {
     fn get_scalar(&self) -> f64 {
         self.scalar()

--- a/pictorus-blocks/src/core_blocks/change_detection_block.rs
+++ b/pictorus-blocks/src/core_blocks/change_detection_block.rs
@@ -182,6 +182,7 @@ impl<T> Parameters<T> {
 mod tests {
     use super::*;
     use crate::testing::StubContext;
+    use crate::traits::Scalar as _;
     use paste::paste;
 
     macro_rules! test_scalars {
@@ -195,15 +196,15 @@ mod tests {
 
                     // No change - false
                     let output = block.process(&params, &context, [<1 $type>]);
-                    assert!(!output);
+                    assert!(!output.is_truthy());
 
                     //Falling -false
                     let output = block.process(&params, &context, [<0 $type>]);
-                    assert!(!output);
+                    assert!(!output.is_truthy());
 
                     // Rising - true
                     let output = block.process(&params, &context, [<1 $type>]);
-                    assert!(output);
+                    assert!(output.is_truthy());
                 }
 
                 #[test]
@@ -214,15 +215,15 @@ mod tests {
 
                     // No change - false
                     let output = block.process(&params, &context, [<1 $type>]);
-                    assert!(!output);
+                    assert!(!output.is_truthy());
 
                     //Falling -true
                     let output = block.process(&params, &context, [<0 $type>]);
-                    assert!(output);
+                    assert!(output.is_truthy());
 
                     // Rising - false
                     let output = block.process(&params, &context, [<1 $type>]);
-                    assert!(!output);
+                    assert!(!output.is_truthy());
                 }
 
 
@@ -234,15 +235,15 @@ mod tests {
 
                     // No change - false
                     let output = block.process(&params, &context, [<1 $type>]);
-                    assert!(!output);
+                    assert!(!output.is_truthy());
 
                     //Falling -true
                     let output = block.process(&params, &context, [<0 $type>]);
-                    assert!(output);
+                    assert!(output.is_truthy());
 
                     // Rising - true
                     let output = block.process(&params, &context, [<1 $type>]);
-                    assert!(output);
+                    assert!(output.is_truthy());
                 }
             }
         };
@@ -282,7 +283,7 @@ mod tests {
                     assert_eq!(
                         output,
                         &Matrix {
-                            data: [[true; 8]; 11]
+                            data: [[1.0; 8]; 11]
                         }
                     );
 
@@ -296,7 +297,7 @@ mod tests {
                     // Falling just one element
                     input.data[3][5] = [<4 $type>];
                     let mut expected_output = Matrix::zeroed();
-                    expected_output.data[3][5] = true;
+                    expected_output.data[3][5] = 1.0;
                     let output = block.process(&params, &context, &input);
                     assert_eq!(output, &expected_output);
 
@@ -335,7 +336,7 @@ mod tests {
                     assert_eq!(
                         output,
                         &Matrix {
-                            data: [[true; 8]; 11]
+                            data: [[1.0; 8]; 11]
                         }
                     );
 
@@ -347,7 +348,7 @@ mod tests {
                     // Rising just one element
                     input.data[6][2] = [<42 $type>];
                     let mut expected_output = Matrix::zeroed();
-                    expected_output.data[6][2] = true;
+                    expected_output.data[6][2] = 1.0;
                     let output = block.process(&params, &context, &input);
                     assert_eq!(output, &expected_output);
                 }
@@ -374,7 +375,7 @@ mod tests {
                     assert_eq!(
                         output,
                         &Matrix {
-                            data: [[true; 8]; 11]
+                            data: [[1.0; 8]; 11]
                         }
                     );
 
@@ -386,21 +387,21 @@ mod tests {
                     assert_eq!(
                         output,
                         &Matrix {
-                            data: [[true; 8]; 11]
+                            data: [[1.0; 8]; 11]
                         }
                     );
 
                     // Falling just one element
                     input.data[3][5] = [<4 $type>];
                     let mut expected_output = Matrix::zeroed();
-                    expected_output.data[3][5] = true;
+                    expected_output.data[3][5] = 1.0;
                     let output = block.process(&params, &context, &input);
                     assert_eq!(output, &expected_output);
 
                     // Rising just one element
                     input.data[6][2] = [<42 $type>];
                     let mut expected_output = Matrix::zeroed();
-                    expected_output.data[6][2] = true;
+                    expected_output.data[6][2] = 1.0;
                     let output = block.process(&params, &context, &input);
                     assert_eq!(output, &expected_output);
                 }
@@ -425,15 +426,15 @@ mod tests {
 
         // No change
         let output = block.process(&params, &context, false);
-        assert_eq!(output, true);
+        assert!(output.is_truthy());
 
         // Falling for all values
         let output = block.process(&params, &context, false);
-        assert_eq!(output, false);
+        assert!(!output.is_truthy());
 
         //Rising all values
         let output = block.process(&params, &context, true);
-        assert_eq!(output, true);
+        assert!(output.is_truthy());
     }
 
     #[test]
@@ -444,15 +445,15 @@ mod tests {
 
         // No change
         let output = block.process(&params, &context, true);
-        assert_eq!(output, false);
+        assert!(!output.is_truthy());
 
         // Falling for all values
         let output = block.process(&params, &context, false);
-        assert_eq!(output, false);
+        assert!(!output.is_truthy());
 
         //Rising all values
         let output = block.process(&params, &context, true);
-        assert_eq!(output, true);
+        assert!(output.is_truthy());
     }
 
     #[test]
@@ -463,14 +464,14 @@ mod tests {
 
         // No change
         let output = block.process(&params, &context, true);
-        assert_eq!(output, false);
+        assert!(!output.is_truthy());
 
         // Falling for all values
         let output = block.process(&params, &context, false);
-        assert_eq!(output, true);
+        assert!(output.is_truthy());
 
         //Rising all values
         let output = block.process(&params, &context, true);
-        assert_eq!(output, false);
+        assert!(!output.is_truthy());
     }
 }

--- a/pictorus-blocks/src/core_blocks/delay_control_block.rs
+++ b/pictorus-blocks/src/core_blocks/delay_control_block.rs
@@ -222,32 +222,32 @@ mod tests {
         let parameters = Parameters::new(0.3, "Throttle");
 
         let output = block.process(&parameters, &runtime.context(), 0.0);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
 
         runtime.tick(); // Time is 100ms
         let output = block.process(&parameters, &runtime.context(), 0.5);
-        assert!(output);
+        assert!(output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(true));
 
         runtime.tick(); // Time is 200ms
         let output = block.process(&parameters, &runtime.context(), 1.0);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
 
         runtime.tick(); // Time is 300ms
         let output = block.process(&parameters, &runtime.context(), 1.5);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
 
         runtime.tick(); // Time is 400ms
         let output = block.process(&parameters, &runtime.context(), 2.0);
-        assert!(output);
+        assert!(output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(true));
 
         runtime.tick(); // Time is 500ms
         let output = block.process(&parameters, &runtime.context(), 2.5);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
     }
 
@@ -259,59 +259,59 @@ mod tests {
 
         // T= 0  we receive false
         let output = block.process(&parameters, &runtime.context(), 0.0);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
 
         runtime.tick(); // T = 0.1s we receive true but still expect false
         let output = block.process(&parameters, &runtime.context(), -2.0);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
 
         runtime.tick(); // T = 0.2s we receive false but still expect false until the delay cooldown is over
         let output = block.process(&parameters, &runtime.context(), 0.0);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
 
         runtime.tick(); // T = 0.3s we receive false but still expect false until the delay cooldown is over
         let output = block.process(&parameters, &runtime.context(), 0.0);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
 
         runtime.tick(); // T = 0.4s we receive false but expect true because delay cooldown is over
         let output = block.process(&parameters, &runtime.context(), 0.0);
-        assert!(output);
+        assert!(output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(true));
 
         runtime.tick(); // T = 0.5s we receive false and expect false since we already emitted true
         let output = block.process(&parameters, &runtime.context(), 0.0);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
 
         runtime.tick(); // T = 0.6s we receive false and expect false since we already emitted true
         let output = block.process(&parameters, &runtime.context(), 0.0);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
 
         // Show we can do it again
         runtime.tick(); // T = 0.7s we receive true but still expect false
         let output = block.process(&parameters, &runtime.context(), 1.0);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
 
         runtime.tick(); // T = 0.8s we receive false setting the debounce cooldown in motion
         let output = block.process(&parameters, &runtime.context(), 0.0);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
 
         // Fast forward to 0.3 seconds after the last true input
         runtime.context.time += Duration::from_secs_f64(0.3);
         let output = block.process(&parameters, &runtime.context(), 0.0);
-        assert!(output);
+        assert!(output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(true));
 
         runtime.tick();
         let output = block.process(&parameters, &runtime.context(), 0.0);
-        assert!(!output);
+        assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
     }
 }

--- a/pictorus-blocks/src/core_blocks/delay_control_block.rs
+++ b/pictorus-blocks/src/core_blocks/delay_control_block.rs
@@ -67,7 +67,7 @@ pub trait Apply: Pass {
 
 impl<S: Scalar> Apply for S {
     type State = Option<Duration>;
-    type Output = bool;
+    type Output = f64;
 
     fn init_state() -> Self::State {
         None
@@ -95,7 +95,7 @@ impl<S: Scalar> Apply for S {
 }
 
 impl<S: Scalar, const NROWS: usize, const NCOLS: usize> Apply for Matrix<NROWS, NCOLS, S> {
-    type Output = Matrix<NROWS, NCOLS, bool>;
+    type Output = Matrix<NROWS, NCOLS, f64>;
     type State = [[Option<Duration>; NROWS]; NCOLS];
 
     fn init_state() -> Self::State {
@@ -146,7 +146,7 @@ fn debounce(
     state: &mut Option<Duration>,
     delay: Duration,
     curr_time: Duration,
-) -> bool {
+) -> f64 {
     let mut output = false;
     if input {
         *state = Some(curr_time);
@@ -156,7 +156,11 @@ fn debounce(
             *state = None;
         }
     }
-    output
+    if output {
+        1.0
+    } else {
+        0.0
+    }
 }
 
 /// If state is Some(d) and current_time - d >= delay then set state to None
@@ -167,7 +171,7 @@ fn throttle(
     state: &mut Option<Duration>,
     delay: Duration,
     curr_time: Duration,
-) -> bool {
+) -> f64 {
     let mut output = false;
     if let Some(d) = state {
         if curr_time - *d >= delay {
@@ -178,7 +182,11 @@ fn throttle(
         output = true;
         *state = Some(curr_time);
     }
-    output
+    if output {
+        1.0
+    } else {
+        0.0
+    }
 }
 
 #[derive(strum::EnumString, Clone, Copy, Debug)]

--- a/pictorus-blocks/src/core_blocks/integral_block.rs
+++ b/pictorus-blocks/src/core_blocks/integral_block.rs
@@ -33,7 +33,7 @@ impl<F: Float> ProcessBlock for IntegralBlock<F>
 where
     OldBlockData: FromPass<F>,
 {
-    type Inputs = (F, bool);
+    type Inputs = (F, F);
     type Output = F;
     type Parameters = Parameters<F>;
 
@@ -44,7 +44,7 @@ where
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         let (sample, reset) = inputs;
-        if reset {
+        if reset.is_truthy() {
             // Reset all state
             self.output = None;
             self.previous_sample = None;
@@ -98,7 +98,7 @@ impl<F: Float, const NROWS: usize, const NCOLS: usize> ProcessBlock
 where
     OldBlockData: FromPass<Matrix<NROWS, NCOLS, F>>,
 {
-    type Inputs = (Matrix<NROWS, NCOLS, F>, bool);
+    type Inputs = (Matrix<NROWS, NCOLS, F>, F);
     type Output = Matrix<NROWS, NCOLS, F>;
     type Parameters = Parameters<Matrix<NROWS, NCOLS, F>>;
 
@@ -109,7 +109,7 @@ where
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         let (sample, reset) = inputs;
-        if reset {
+        if reset.is_truthy() {
             self.output = None;
             self.previous_sample = None;
         } else {

--- a/pictorus-blocks/src/core_blocks/not_block.rs
+++ b/pictorus-blocks/src/core_blocks/not_block.rs
@@ -275,20 +275,20 @@ mod tests {
         let parameters = Parameters::new("Logical");
 
         let res = block.process(&parameters, &context, true);
-        assert_eq!(res, false);
+        assert!(!res);
         assert_eq!(block.data.scalar(), 0.0);
 
         let res = block.process(&parameters, &context, false);
-        assert_eq!(res, true);
+        assert!(res);
         assert_eq!(block.data.scalar(), 1.0);
 
         let parameters = Parameters::new("Bitwise");
         let res = block.process(&parameters, &context, true);
-        assert_eq!(res, false);
+        assert!(!res);
         assert_eq!(block.data.scalar(), 0.0);
 
         let res = block.process(&parameters, &context, false);
-        assert_eq!(res, true);
+        assert!(res);
         assert_eq!(block.data.scalar(), 1.0);
     }
 

--- a/pictorus-blocks/src/core_blocks/not_block.rs
+++ b/pictorus-blocks/src/core_blocks/not_block.rs
@@ -61,6 +61,48 @@ pub trait Apply: Pass {
     ) -> PassBy<'s, Self::Output>;
 }
 
+impl Apply for bool {
+    type Output = bool;
+
+    fn apply<'s>(
+        store: &'s mut Option<Self::Output>,
+        input: PassBy<Self>,
+        method: NotMethod,
+    ) -> PassBy<'s, Self::Output> {
+        let output = match method {
+            NotMethod::Logical => !input,
+            NotMethod::Bitwise => !input,
+        };
+        *store = Some(output);
+        output
+    }
+}
+
+impl<const NROWS: usize, const NCOLS: usize> Apply for Matrix<NROWS, NCOLS, bool> {
+    type Output = Matrix<NROWS, NCOLS, bool>;
+
+    fn apply<'s>(
+        store: &'s mut Option<Self::Output>,
+        input: PassBy<Self>,
+        method: NotMethod,
+    ) -> PassBy<'s, Self::Output> {
+        let output = store.insert(Matrix::zeroed());
+        output
+            .data
+            .as_flattened_mut()
+            .iter_mut()
+            .enumerate()
+            .for_each(|(i, lhs)| {
+                let input_val = input.data.as_flattened()[i];
+                *lhs = match method {
+                    NotMethod::Logical => !input_val,
+                    NotMethod::Bitwise => !input_val,
+                };
+            });
+        output
+    }
+}
+
 macro_rules! impl_not_apply {
     ($type:ty, $cast_type:ty) => {
         impl Apply for $type {
@@ -225,4 +267,45 @@ mod tests {
 
     test_not_block!(f32);
     test_not_block!(f64);
+
+    #[test]
+    fn test_scalar_bool() {
+        let mut block = NotBlock::<bool>::default();
+        let context = StubContext::default();
+        let parameters = Parameters::new("Logical");
+
+        let res = block.process(&parameters, &context, true);
+        assert_eq!(res, false);
+        assert_eq!(block.data.scalar(), 0.0);
+
+        let res = block.process(&parameters, &context, false);
+        assert_eq!(res, true);
+        assert_eq!(block.data.scalar(), 1.0);
+
+        let parameters = Parameters::new("Bitwise");
+        let res = block.process(&parameters, &context, true);
+        assert_eq!(res, false);
+        assert_eq!(block.data.scalar(), 0.0);
+
+        let res = block.process(&parameters, &context, false);
+        assert_eq!(res, true);
+        assert_eq!(block.data.scalar(), 1.0);
+    }
+
+    #[test]
+    fn test_matrix_bool() {
+        let mut block = NotBlock::<Matrix<2, 2, bool>>::default();
+        let context = StubContext::default();
+        let parameters = Parameters::new("Logical");
+
+        let input = Matrix {
+            data: [[true, false], [false, true]],
+        };
+        let res = block.process(&parameters, &context, &input);
+        assert_eq!(res.data, [[false, true], [true, false]]);
+        assert_eq!(
+            block.data.get_data().as_slice(),
+            [[0.0, 1.0], [1.0, 0.0]].as_flattened()
+        );
+    }
 }

--- a/pictorus-blocks/src/core_blocks/pid_block.rs
+++ b/pictorus-blocks/src/core_blocks/pid_block.rs
@@ -87,9 +87,9 @@ where
     DerivativeBlock<T, ND_SAMPLES>:
         ProcessBlock<Output = T, Inputs = T, Parameters = DerivativeParameters<T>>,
     IntegralBlock<T>:
-        ProcessBlock<Output = T, Inputs = (T, bool), Parameters = IntegralParameters<T>>,
+        ProcessBlock<Output = T, Inputs = (T, f64), Parameters = IntegralParameters<T>>,
 {
-    type Inputs = (T, bool);
+    type Inputs = (T, f64);
     type Output = T;
     type Parameters = Parameters<T>;
 

--- a/pictorus-blocks/src/lib.rs
+++ b/pictorus-blocks/src/lib.rs
@@ -22,6 +22,7 @@ pub mod byte_data;
 mod nalgebra_interop;
 mod stale_tracker;
 pub(crate) mod traits;
+pub use traits::Scalar;
 
 #[cfg(any(test, doctest))]
 mod testing;

--- a/pictorus-traits/src/custom_blocks.rs
+++ b/pictorus-traits/src/custom_blocks.rs
@@ -113,6 +113,15 @@ macro_rules! scalar_block_data_read_impl {
                         unimplemented!("Can not get matrix of scalar {} value", stringify!($t))
                     }
                 }
+
+                 impl BlockDataRead for $t {
+                    fn get_scalar(&self) -> f64 {
+                        (*self).into()
+                    }
+                    fn get_matrix(&self) -> (usize, usize, &[f64]) {
+                        unimplemented!("Can not get matrix of scalar {} value", stringify!($t))
+                    }
+                }
             )+
         };
     }


### PR DESCRIPTION
These changes primarily make the input types of blocks more flexible. Blocks that previously only accepted `bool` input can now take in any Scalar value. In those cases `0` is False and all other values are true. 

We also return a float in lieu of a `bool` in a few places, this is to support codegen changes in the main application, but will not be permanent. 