### PR TITLE
Rust 1.88 Clippy updates

### DIFF
--- a/pictorus-blocks/src/core_blocks/serial_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/serial_receive_block.rs
@@ -240,9 +240,9 @@ impl ProcessBlock for SerialReceiveBlock {
 
         if let Ok((start_idx, end_idx)) = self.parse_data(parameters) {
             let val = &self.buffer[start_idx..end_idx];
-            debug!("Parsed value: {:?}", val);
+            debug!("Parsed value: {val:?}");
             if start_idx != 0 {
-                debug!("Discarding {} bytes", start_idx);
+                debug!("Discarding {start_idx} bytes");
             }
             self.data.set_bytes(val);
             self.output = val.to_vec();

--- a/pictorus-internal/src/loggers/csv_logger.rs
+++ b/pictorus-internal/src/loggers/csv_logger.rs
@@ -24,7 +24,7 @@ impl CsvLogger {
     pub fn new(csv_log_period: Duration, output_path: std::path::PathBuf) -> Self {
         let mut file_obj = File::create("/dev/null").unwrap();
         if !csv_log_period.is_zero() {
-            info!("DataLogger CSV output period: {:?}", csv_log_period);
+            info!("DataLogger CSV output period: {csv_log_period:?}");
             info!("Streaming data output to file: {}", output_path.display());
             file_obj = File::create(std::path::PathBuf::from(&output_path)).unwrap();
         } else {
@@ -69,7 +69,7 @@ impl Logger for CsvLogger {
     }
 
     fn log(&mut self, app_time: Duration, data: &str) {
-        writeln!(self.file, "{}", data).ok();
+        writeln!(self.file, "{data}").ok();
         self.last_csv_log_time = Some(app_time);
     }
 }

--- a/pictorus-internal/src/loggers/rtt_logger.rs
+++ b/pictorus-internal/src/loggers/rtt_logger.rs
@@ -38,10 +38,7 @@ impl RttLogger {
             let used_f32 = used as f32 / 1000.0;
             let percent_used = (used_f32 / (used_f32 + free_f32)) * 100.0;
             log::info!(
-                "Heap Used: {:.3}kB, Heap Free: {:.3}kB, Heap Usage: {:.3}%",
-                used_f32,
-                free_f32,
-                percent_used
+                "Heap Used: {used_f32:.3}kB, Heap Free: {free_f32:.3}kB, Heap Usage: {percent_used:.3}%",
             );
             self.previous_heap_used = used;
             self.last_heap_log_time = app_time;

--- a/pictorus-internal/src/timing.rs
+++ b/pictorus-internal/src/timing.rs
@@ -53,8 +53,7 @@ impl<C: Clock<T = u64>, D: DelayNs> Timing<C, D> {
         delay: D,
     ) -> Timing<C, D> {
         info!(
-            "Timing settings: Run time: {:?}, frequency: {} hz, realtime: {}",
-            run_time, hertz, use_realtime
+            "Timing settings: Run time: {run_time:?}, frequency: {hertz} hz, realtime: {use_realtime}",
         );
         let now = clock.try_now().unwrap();
         Timing {

--- a/pictorus-internal/src/utils.rs
+++ b/pictorus-internal/src/utils.rs
@@ -19,13 +19,13 @@ pub struct PictorusVars {
 // TODO Can we create an error type for these functions? Could we use Option<> instead?
 #[allow(clippy::result_unit_err)]
 pub fn buffer_to_scalar(buf: &[u8]) -> Result<f64, ()> {
-    debug!("Converting buffer to scalar: {:?}", buf);
+    debug!("Converting buffer to scalar: {buf:?}");
     string_to_scalar(str::from_utf8(buf).or(Err(()))?)
 }
 
 #[allow(clippy::result_unit_err)]
 pub fn string_to_scalar(val: &str) -> Result<f64, ()> {
-    debug!("Converting string to scalar: {:?}", val);
+    debug!("Converting string to scalar: {val:?}");
     val.trim().parse().or(Err(()))
 }
 
@@ -169,7 +169,7 @@ cfg_if::cfg_if! {
             // Try loading from ENV
             if let Ok(env_var) = std::env::var(&env_var_name) {
                 if let Some(parsed) = T::parse(&env_var, Some(&default)) {
-                    info!("Found env variable {} with value '{:?}'", env_var_name, parsed);
+                    info!("Found env variable {env_var_name} with value '{parsed:?}'");
                     return parsed;
                 }
             }
@@ -177,10 +177,7 @@ cfg_if::cfg_if! {
             // Try loading from DiagramParams
             if let Some(params_map) = blocks_map.get(block_name).and_then(|map| map.get(var_name)) {
                 if let Some(parsed) = T::parse(params_map, Some(&default)) {
-                    info!(
-                        "Parsing and loading {}_{} from params file with value {:?}",
-                        block_name, var_name, parsed
-                    );
+                    info!("Parsing and loading {block_name}_{var_name} from params file with value {parsed:?}");
                     return parsed;
                 }
             }
@@ -256,7 +253,7 @@ cfg_if::cfg_if! {
 
         pub fn dump_error(err: &PictorusError, run_path: &str) {
             let path = std::path::PathBuf::from(run_path).join("pictorus_errors.json");
-            info!("Error log path: {:?}", path);
+            info!("Error log path: {path:?}");
             fs::write(path, json::to_string(err)).ok();
         }
 
@@ -297,7 +294,7 @@ cfg_if::cfg_if! {
                 })
                 .filter(None, log_level)
                 .init();
-            log::info!("Log level: {}", log_level);
+            log::info!("Log level: {log_level}");
         }
     }
 }


### PR DESCRIPTION
Variables can be used in print macros now instead of comma separated after the macro string.