### PR TITLE
CSV Logging Improvements

### DIFF
--- a/pictorus-internal/Cargo.toml
+++ b/pictorus-internal/Cargo.toml
@@ -30,7 +30,7 @@ env_logger = { version = "0.11.8", optional = true }
 rtt-target = { git = "https://github.com/Pictorus-Labs/rtt-target", branch = "alignment-fix", optional = true }
 postcard = { version = "1.1.1" }
 serde = { version = "1.0.219", default-features = false, features = ["derive", "alloc"]}
-serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
+serde_json = { version = "1.0", default-features = false, features = ["alloc", "preserve_order"], optional = true }
 heapless = { version = "0.7.0" }
 
 [dev-dependencies]

--- a/pictorus-internal/Cargo.toml
+++ b/pictorus-internal/Cargo.toml
@@ -30,7 +30,7 @@ env_logger = { version = "0.11.8", optional = true }
 rtt-target = { git = "https://github.com/Pictorus-Labs/rtt-target", branch = "alignment-fix", optional = true }
 postcard = { version = "1.1.1" }
 serde = { version = "1.0.219", default-features = false, features = ["derive", "alloc"]}
-serde_json = { version = "1.0", default-features = false, features = ["alloc", "preserve_order"], optional = true }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 heapless = { version = "0.7.0" }
 
 [dev-dependencies]

--- a/pictorus-internal/src/loggers/csv_logger.rs
+++ b/pictorus-internal/src/loggers/csv_logger.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use core::time::Duration;
 use log::info;
-use std::io::Write;
+use std::io::{Write, BufWriter};
 use std::{fs::File, string::String};
 
 use super::Logger;
@@ -14,7 +14,7 @@ use super::Logger;
 pub struct CsvLogger {
     last_csv_log_time: Option<Duration>,
     pub csv_log_period: Duration,
-    pub file: std::fs::File,
+    pub writer: BufWriter<File>,
     pub output_path: std::path::PathBuf,
     pub app_start_epoch: Duration,
 }
@@ -33,7 +33,7 @@ impl CsvLogger {
         CsvLogger {
             last_csv_log_time: None,
             csv_log_period,
-            file: file_obj,
+            writer: BufWriter::with_capacity(65536, file_obj),
             output_path,
             app_start_epoch: Duration::from_micros(
                 Utc::now()
@@ -59,9 +59,9 @@ impl Logger for CsvLogger {
             let sample = format_samples_csv(log_data);
             if self.last_csv_log_time.is_none() {
                 let header = format_header_csv(log_data);
-                writeln!(self.file, "{header}").ok();
+                writeln!(self.writer, "{header}").ok();
             }
-            writeln!(self.file, "{sample}").ok();
+            writeln!(self.writer, "{sample}").ok();
             self.last_csv_log_time = Some(app_time);
         }
     }

--- a/pictorus-internal/src/loggers/csv_logger.rs
+++ b/pictorus-internal/src/loggers/csv_logger.rs
@@ -17,6 +17,7 @@ pub struct CsvLogger {
     pub writer: BufWriter<File>,
     pub output_path: std::path::PathBuf,
     pub app_start_epoch: Duration,
+    /// Reusable buffer for formatting CSV samples to avoid repeated allocations.
     buffer: String
 }
 

--- a/pictorus-internal/src/loggers/csv_logger.rs
+++ b/pictorus-internal/src/loggers/csv_logger.rs
@@ -186,7 +186,7 @@ mod tests {
             csv_header,
             "state_id,timestamp,utctime,vector,scalar,matrix,bytesarray".to_string()
         );
-         let mut csv_data = String::new();
+        let mut csv_data = String::new();
         format_samples_csv(&log_data, &mut csv_data);
         assert_eq!(csv_data, ("\"main_state\",1.234,2.234,,,,"));
     }

--- a/pictorus-internal/src/loggers/udp_logger.rs
+++ b/pictorus-internal/src/loggers/udp_logger.rs
@@ -57,7 +57,7 @@ impl Logger for UdpLogger {
     }
 
     fn log(&mut self, log_data: &impl serde::Serialize, app_time: Duration) {
-        if self.should_log(app_time) {
+        if self.socket.is_some()  && self.should_log(app_time) {
             let encoded_data = self.encoder.encode::<UDP_ENCODER_BUFFER_SIZE>(log_data);
 
             if let Some(socket) = &mut self.socket {


### PR DESCRIPTION
This is derived from the changes introduced in #22 

See the thread there for details on how performance on this branch compares to the current state of main

One variation from #22 is that I do not implement Drop for CSVLogger that flushes the BufWriter, however I believe this to be redundant since BufWriter already does that in[ it's implementation of Drop](https://doc.rust-lang.org/src/std/io/buffered/bufwriter.rs.html#682-687)