### PR TITLE
Updated embassy_hal dependency

### DIFF
--- a/pictorus-renesas/Cargo.toml
+++ b/pictorus-renesas/Cargo.toml
@@ -16,7 +16,7 @@ pictorus-internal = { path = "../pictorus-internal", version = "0.0.0" }
 embedded-time = "0.12.1"
 embedded-hal = "1.0.0"
 embedded-io = "0.6.1"
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "68c8238" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "0e82b7d" }
 heapless = "0.8.0"
 log = "0.4.21"
 ra4m2-hal = { git = "https://github.com/Pictorus-Labs/ra4m2-hal" }

--- a/pictorus-stm32/CHANGELOG.md
+++ b/pictorus-stm32/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.1] - 2025-08-04
 
-Updated version of `embassy-stm`, `embassy-time`, and `embassy-futures` to latest release commit
+Updated version of `embassy-stm`, `embassy-time`, and `embassy-futures` to latest release commit for new STM32 boards
+Updated i2c implementation to run in Master mode
+Updated serial implementation to new start func name
+Updated adc implementation to call blocking func
 
 ## [0.0.0] - 2025-05-29
 

--- a/pictorus-stm32/CHANGELOG.md
+++ b/pictorus-stm32/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1] - 2025-08-04
+
+Updated version of `embassy-stm`, `embassy-time`, and `embassy-futures` to latest release commit
+
 ## [0.0.0] - 2025-05-29
 
 Initial release.

--- a/pictorus-stm32/Cargo.toml
+++ b/pictorus-stm32/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pictorus-stm32"
 edition = "2024"
 description = "STM32 implementations of Pictorus traits."
-version = "0.0.0"
+version = "0.0.1"
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -19,9 +19,9 @@ embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
   "unproven",
 ] }
 embedded-io = "0.6.1"
-embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "68c8238" }
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "68c8238" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "68c8238" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "876ad00" }
+embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "876ad00" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "876ad00" }
 embedded-io-async = "0.6.1"
 heapless = "0.8.0"
 embedded-can = { version = "0.4.1", optional = true }

--- a/pictorus-stm32/Cargo.toml
+++ b/pictorus-stm32/Cargo.toml
@@ -19,9 +19,9 @@ embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
   "unproven",
 ] }
 embedded-io = "0.6.1"
-embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "876ad00" }
-embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "876ad00" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "876ad00" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "0e82b7d" }
+embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "0e82b7d" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "0e82b7d" }
 embedded-io-async = "0.6.1"
 heapless = "0.8.0"
 embedded-can = { version = "0.4.1", optional = true }

--- a/pictorus-stm32/src/adc_protocol.rs
+++ b/pictorus-stm32/src/adc_protocol.rs
@@ -22,7 +22,7 @@ where
         _context: &dyn Context,
     ) -> PassBy<'_, Self::Output> {
         if self.buffer.is_none() {
-            self.buffer = Some(self.adc.read(&mut self.channel));
+            self.buffer = Some(self.adc.blocking_read(&mut self.channel));
         }
 
         self.buffer.unwrap_or(0)

--- a/pictorus-stm32/src/dac_protocol.rs
+++ b/pictorus-stm32/src/dac_protocol.rs
@@ -5,17 +5,19 @@ use pictorus_traits::{Matrix, OutputBlock};
 pub struct DacWrapper<
     'a,
     T: embassy_stm32::dac::Instance,
+    M: embassy_stm32::mode::Mode,
     const CHANNELS: usize,
     const SAMPLES: usize,
 > {
-    dac: Dac<'a, T>,
+    dac: Dac<'a, T, M>,
 }
 
-impl<'a, T, const CHANNELS: usize, const SAMPLES: usize> DacWrapper<'a, T, CHANNELS, SAMPLES>
+impl<'a, T, M, const CHANNELS: usize, const SAMPLES: usize> DacWrapper<'a, T, M, CHANNELS, SAMPLES>
 where
     T: embassy_stm32::dac::Instance,
+    M: embassy_stm32::mode::Mode,
 {
-    pub fn new(dac: Dac<'a, T>) -> Self {
+    pub fn new(dac: Dac<'a, T, M>) -> Self {
         Self { dac }
     }
 
@@ -37,10 +39,11 @@ where
     }
 }
 
-impl<const CHANNELS: usize, const SAMPLES: usize, T> OutputBlock
-    for DacWrapper<'_, T, CHANNELS, SAMPLES>
+impl<const CHANNELS: usize, const SAMPLES: usize, T, M> OutputBlock
+    for DacWrapper<'_, T, M, CHANNELS, SAMPLES>
 where
     T: embassy_stm32::dac::Instance,
+    M: embassy_stm32::mode::Mode,
 {
     type Inputs = Matrix<SAMPLES, CHANNELS, f64>;
     type Parameters = DacBlockParams;

--- a/pictorus-stm32/src/i2c_protocol.rs
+++ b/pictorus-stm32/src/i2c_protocol.rs
@@ -1,17 +1,18 @@
 use alloc::vec::Vec;
 use embassy_stm32::i2c::I2c;
 use embassy_stm32::mode::Blocking;
+use embassy_stm32::i2c::Master;
 use embedded_hal::i2c::I2c as I2cTrait;
 use pictorus_blocks::{I2cInputBlockParams, I2cOutputBlockParams};
 use pictorus_traits::{ByteSliceSignal, InputBlock, OutputBlock};
 
 pub struct I2cWrapper<'a> {
-    i2c: I2c<'a, Blocking>,
+    i2c: I2c<'a, Blocking, Master>,
     buffer: Vec<u8>,
 }
 
 impl<'a> I2cWrapper<'a> {
-    pub fn new(i2c: I2c<'a, Blocking>) -> Self {
+    pub fn new(i2c: I2c<'a, Blocking, Master>) -> Self {
         Self {
             i2c,
             buffer: Vec::new(),

--- a/pictorus-stm32/src/serial_protocol.rs
+++ b/pictorus-stm32/src/serial_protocol.rs
@@ -42,7 +42,7 @@ impl<'a> SerialWrapper<'a> {
     pub fn new(uart: Uart<'a, Async>, rx_buf: &'a mut [u8]) -> Self {
         let (tx, rx) = uart.split();
         let mut rx = rx.into_ring_buffered(rx_buf);
-        rx.start().unwrap();
+        rx.start_uart();
         Self {
             tx,
             rx,


### PR DESCRIPTION
This is necessitated by [PR #3275 in the Pictorus repo](https://github.com/Pictorus-Labs/pictorus/pull/3275). The embassy_hal dependency had to be moved up to a more recent git commit to enable support for new targets. This PR mostly just updates the commit hashes but some minor changes had to be made to some protocol drivers to support API changes over the last year since our last embassy_hal dependency was released.

API changes:

* ADC got async support but to align with prior functionality I opted for the blocking read function.
* DAC also now has a Mode input, which can be async or blocking.
* I2C now supports master and multi-master modes. I opted for master mode for backwards compatibility.