### PR TITLE
Added is_truthy to Matrix

### DIFF
--- a/pictorus-traits/src/lib.rs
+++ b/pictorus-traits/src/lib.rs
@@ -575,14 +575,8 @@ where
     }
 
     pub fn is_truthy(&self) -> bool {
-        for col in 0..NCOLS {
-            for row in 0..NROWS {
-                if self.data[col][row] != T::default() {
-                    return true;
-                }
-            }
-        }
-        false
+        let default = T::default();
+        self.data.iter().flatten().any(|x| *x != default)
     }
 }
 

--- a/pictorus-traits/src/lib.rs
+++ b/pictorus-traits/src/lib.rs
@@ -410,7 +410,7 @@ where
 /// "Scalar" types
 ///
 /// Marker trait for small primitives like floats, integers and booleans
-pub trait Scalar: Sealed + Copy + 'static + Default + Into<f64> {}
+pub trait Scalar: Sealed + Copy + 'static + Default + Into<f64> + PartialEq {}
 
 impl Scalar for bool {}
 impl Sealed for bool {}
@@ -572,6 +572,17 @@ where
         Self {
             data: unsafe { mem::zeroed() },
         }
+    }
+
+    pub fn is_truthy(&self) -> bool {
+        for col in 0..NCOLS {
+            for row in 0..NROWS {
+                if self.data[col][row] != T::default() {
+                    return true;
+                }
+            }
+        }
+        false
     }
 }
 


### PR DESCRIPTION
Adds `is_truthy()` to Matrix; used in cases where a Matrix needs to be checked if it is "true" or "false". If all values are T::default(), the matrix is "false", otherwise "true".