### PR TITLE
Add macro for implementing the Pass trait out to 16 elements.

### DIFF
--- a/pictorus-px4/src/message_impls.rs
+++ b/pictorus-px4/src/message_impls.rs
@@ -1519,7 +1519,7 @@ define_topics! {
 // Manual message impls below here
 // --------------------------------------------------------------------------------
 
-/// Manual Implementation for Manual Control Setpoint; Manual Control Setpoint 
+/// Manual Implementation for Manual Control Setpoint; Manual Control Setpoint
 /// currently has more than 8 fields but is highly useful for controls.
 impl ToPassType for manual_control_setpoint_s {
     type PassType = (f64, f64, f64, f64, f64);

--- a/pictorus-traits/src/lib.rs
+++ b/pictorus-traits/src/lib.rs
@@ -616,236 +616,52 @@ impl Pass for () {
 
 impl Sealed for () {}
 
-impl<A, B> Pass for (A, B)
-where
-    A: Pass,
-    B: Pass,
-{
-    type By<'a> = (PassBy<'a, A>, PassBy<'a, B>);
+/// Generates `Pass` impls for tuples of various sizes of types that impl `Pass`
+/// Example expansion for (A 0, B 1):
+/// ``` rust ignore
+/// impl<A, B> Pass for (A, B)
+/// where
+///     A: Pass,
+///     B: Pass,
+/// {
+///     type By<'a> = (PassBy<'a, A>, PassBy<'a, B>);
+///
+///     fn as_by(&self) -> Self::By<'_> {
+///         (self.0.as_by(), self.1.as_by())
+///     }
+/// }
+/// ```
+macro_rules! impl_pass_for_tuples {
+    ( $( ( $( $T:ident $i:tt ),+ ) ),+ $(,)? ) => {
+        $(
+            impl<$( $T: Pass ),+> Pass for ( $( $T ),+ ) {
+                type By<'a> = ( $( PassBy<'a, $T> ),+ );
 
-    fn as_by(&self) -> Self::By<'_> {
-        (self.0.as_by(), self.1.as_by())
-    }
+                fn as_by(&self) -> Self::By<'_> {
+                    ( $( self.$i.as_by() ),+ )
+                }
+            }
+
+            impl<$( $T: Pass ),+> Sealed for ( $( $T ),+ ) {}
+        )+
+    };
 }
 
-impl<A, B> Sealed for (A, B)
-where
-    A: Pass,
-    B: Pass,
-{
-}
-
-impl<A, B, C> Pass for (A, B, C)
-where
-    A: Pass,
-    B: Pass,
-    C: Pass,
-{
-    type By<'a> = (PassBy<'a, A>, PassBy<'a, B>, PassBy<'a, C>);
-
-    fn as_by(&self) -> Self::By<'_> {
-        (self.0.as_by(), self.1.as_by(), self.2.as_by())
-    }
-}
-impl<A, B, C> Sealed for (A, B, C)
-where
-    A: Pass,
-    B: Pass,
-    C: Pass,
-{
-}
-
-impl<A, B, C, D> Pass for (A, B, C, D)
-where
-    A: Pass,
-    B: Pass,
-    C: Pass,
-    D: Pass,
-{
-    type By<'a> = (PassBy<'a, A>, PassBy<'a, B>, PassBy<'a, C>, PassBy<'a, D>);
-
-    fn as_by(&self) -> Self::By<'_> {
-        (
-            self.0.as_by(),
-            self.1.as_by(),
-            self.2.as_by(),
-            self.3.as_by(),
-        )
-    }
-}
-impl<A, B, C, D> Sealed for (A, B, C, D)
-where
-    A: Pass,
-    B: Pass,
-    C: Pass,
-    D: Pass,
-{
-}
-
-impl<A, B, C, D, E> Pass for (A, B, C, D, E)
-where
-    A: Pass,
-    B: Pass,
-    C: Pass,
-    D: Pass,
-    E: Pass,
-{
-    type By<'a> = (
-        PassBy<'a, A>,
-        PassBy<'a, B>,
-        PassBy<'a, C>,
-        PassBy<'a, D>,
-        PassBy<'a, E>,
-    );
-
-    fn as_by(&self) -> Self::By<'_> {
-        (
-            self.0.as_by(),
-            self.1.as_by(),
-            self.2.as_by(),
-            self.3.as_by(),
-            self.4.as_by(),
-        )
-    }
-}
-impl<A, B, C, D, E> Sealed for (A, B, C, D, E)
-where
-    A: Pass,
-    B: Pass,
-    C: Pass,
-    D: Pass,
-    E: Pass,
-{
-}
-
-impl<A, B, C, D, E, F> Pass for (A, B, C, D, E, F)
-where
-    A: Pass,
-    B: Pass,
-    C: Pass,
-    D: Pass,
-    E: Pass,
-    F: Pass,
-{
-    type By<'a> = (
-        PassBy<'a, A>,
-        PassBy<'a, B>,
-        PassBy<'a, C>,
-        PassBy<'a, D>,
-        PassBy<'a, E>,
-        PassBy<'a, F>,
-    );
-
-    fn as_by(&self) -> Self::By<'_> {
-        (
-            self.0.as_by(),
-            self.1.as_by(),
-            self.2.as_by(),
-            self.3.as_by(),
-            self.4.as_by(),
-            self.5.as_by(),
-        )
-    }
-}
-impl<A, B, C, D, E, F> Sealed for (A, B, C, D, E, F)
-where
-    A: Pass,
-    B: Pass,
-    C: Pass,
-    D: Pass,
-    E: Pass,
-    F: Pass,
-{
-}
-
-impl<A, B, C, D, E, F, G> Pass for (A, B, C, D, E, F, G)
-where
-    A: Pass,
-    B: Pass,
-    C: Pass,
-    D: Pass,
-    E: Pass,
-    F: Pass,
-    G: Pass,
-{
-    type By<'a> = (
-        PassBy<'a, A>,
-        PassBy<'a, B>,
-        PassBy<'a, C>,
-        PassBy<'a, D>,
-        PassBy<'a, E>,
-        PassBy<'a, F>,
-        PassBy<'a, G>,
-    );
-
-    fn as_by(&self) -> Self::By<'_> {
-        (
-            self.0.as_by(),
-            self.1.as_by(),
-            self.2.as_by(),
-            self.3.as_by(),
-            self.4.as_by(),
-            self.5.as_by(),
-            self.6.as_by(),
-        )
-    }
-}
-impl<A, B, C, D, E, F, G> Sealed for (A, B, C, D, E, F, G)
-where
-    A: Pass,
-    B: Pass,
-    C: Pass,
-    D: Pass,
-    E: Pass,
-    F: Pass,
-    G: Pass,
-{
-}
-
-impl<A, B, C, D, E, F, G, H> Pass for (A, B, C, D, E, F, G, H)
-where
-    A: Pass,
-    B: Pass,
-    C: Pass,
-    D: Pass,
-    E: Pass,
-    F: Pass,
-    G: Pass,
-    H: Pass,
-{
-    type By<'a> = (
-        PassBy<'a, A>,
-        PassBy<'a, B>,
-        PassBy<'a, C>,
-        PassBy<'a, D>,
-        PassBy<'a, E>,
-        PassBy<'a, F>,
-        PassBy<'a, G>,
-        PassBy<'a, H>,
-    );
-
-    fn as_by(&self) -> Self::By<'_> {
-        (
-            self.0.as_by(),
-            self.1.as_by(),
-            self.2.as_by(),
-            self.3.as_by(),
-            self.4.as_by(),
-            self.5.as_by(),
-            self.6.as_by(),
-            self.7.as_by(),
-        )
-    }
-}
-impl<A, B, C, D, E, F, G, H> Sealed for (A, B, C, D, E, F, G, H)
-where
-    A: Pass,
-    B: Pass,
-    C: Pass,
-    D: Pass,
-    E: Pass,
-    F: Pass,
-    G: Pass,
-    H: Pass,
-{
-}
+// Implement Pass for tuples up to size 16
+impl_pass_for_tuples!(
+    (A 0, B 1),
+    (A 0, B 1, C 2),
+    (A 0, B 1, C 2, D 3),
+    (A 0, B 1, C 2, D 3, E 4),
+    (A 0, B 1, C 2, D 3, E 4, F 5),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14),
+    (A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15),
+);

--- a/pictorus-traits/src/tuple_array_interop.rs
+++ b/pictorus-traits/src/tuple_array_interop.rs
@@ -3,71 +3,63 @@
 use crate::{Pass, Scalar};
 
 pub trait TupleEquivalent<T: Scalar, const N: usize>: Sized {
-    type TupleEquivalent: Sized + Default + Pass;
+    type TupleEquivalent: Sized + Pass;
 
     fn into_tuple(self) -> Self::TupleEquivalent;
 }
 
-impl<T: Scalar> TupleEquivalent<T, 1> for [T; 1] {
-    type TupleEquivalent = T;
+/// Generates impls for Array to Tuple conversions for sizes 1 to 12.
+/// Example expansion:
+/// ```rust ignore
+/// impl<T: Scalar> TupleEquivalent<T, 1> for [T; 1] {
+///     type TupleEquivalent = T;
+///
+///     fn into_tuple(self) -> Self::TupleEquivalent {
+///         self[0]
+///     }
+/// }
+///
+/// impl<T: Scalar> TupleEquivalent<T, 2> for [T; 2] {
+///     type TupleEquivalent = (T, T);
+///
+///     fn into_tuple(self) -> Self::TupleEquivalent {
+///         self.into()
+///     }
+/// }
+/// ```
+macro_rules! impl_tuple_array_interop {
+    (1) => {
+        impl<T: Scalar> TupleEquivalent<T, 1> for [T; 1] {
+            type TupleEquivalent = T;
 
-    fn into_tuple(self) -> Self::TupleEquivalent {
-        self[0]
-    }
+            fn into_tuple(self) -> Self::TupleEquivalent {
+                self[0]
+            }
+        }
+    };
+
+    ($n:expr, $($t:ident),+) => {
+        impl<T: Scalar> TupleEquivalent<T, $n> for [T; $n] {
+            type TupleEquivalent = ($($t,)+);
+
+            fn into_tuple(self) -> Self::TupleEquivalent {
+                self.into()
+            }
+        }
+    };
 }
 
-impl<T: Scalar> TupleEquivalent<T, 2> for [T; 2] {
-    type TupleEquivalent = (T, T);
-
-    fn into_tuple(self) -> Self::TupleEquivalent {
-        self.into()
-    }
-}
-
-impl<T: Scalar> TupleEquivalent<T, 3> for [T; 3] {
-    type TupleEquivalent = (T, T, T);
-
-    fn into_tuple(self) -> Self::TupleEquivalent {
-        self.into()
-    }
-}
-
-impl<T: Scalar> TupleEquivalent<T, 4> for [T; 4] {
-    type TupleEquivalent = (T, T, T, T);
-
-    fn into_tuple(self) -> Self::TupleEquivalent {
-        self.into()
-    }
-}
-
-impl<T: Scalar> TupleEquivalent<T, 5> for [T; 5] {
-    type TupleEquivalent = (T, T, T, T, T);
-
-    fn into_tuple(self) -> Self::TupleEquivalent {
-        self.into()
-    }
-}
-
-impl<T: Scalar> TupleEquivalent<T, 6> for [T; 6] {
-    type TupleEquivalent = (T, T, T, T, T, T);
-
-    fn into_tuple(self) -> Self::TupleEquivalent {
-        self.into()
-    }
-}
-
-impl<T: Scalar> TupleEquivalent<T, 7> for [T; 7] {
-    type TupleEquivalent = (T, T, T, T, T, T, T);
-
-    fn into_tuple(self) -> Self::TupleEquivalent {
-        self.into()
-    }
-}
-
-impl<T: Scalar> TupleEquivalent<T, 8> for [T; 8] {
-    type TupleEquivalent = (T, T, T, T, T, T, T, T);
-
-    fn into_tuple(self) -> Self::TupleEquivalent {
-        self.into()
-    }
-}
+// Currently implement up to 12-tuples/arrays since we are using
+// Default and From: https://doc.rust-lang.org/std/primitive.tuple.html
+impl_tuple_array_interop!(1);
+impl_tuple_array_interop!(2, T, T);
+impl_tuple_array_interop!(3, T, T, T);
+impl_tuple_array_interop!(4, T, T, T, T);
+impl_tuple_array_interop!(5, T, T, T, T, T);
+impl_tuple_array_interop!(6, T, T, T, T, T, T);
+impl_tuple_array_interop!(7, T, T, T, T, T, T, T);
+impl_tuple_array_interop!(8, T, T, T, T, T, T, T, T);
+impl_tuple_array_interop!(9, T, T, T, T, T, T, T, T, T);
+impl_tuple_array_interop!(10, T, T, T, T, T, T, T, T, T, T);
+impl_tuple_array_interop!(11, T, T, T, T, T, T, T, T, T, T, T);
+impl_tuple_array_interop!(12, T, T, T, T, T, T, T, T, T, T, T, T);


### PR DESCRIPTION
Closes #31 

- Adds macro impl_pass_for_tuples which allows easier addition of pass traits beyond 8
- Adds impl_tuple_array_interop to do a similar task for the TupleEquivalent, within Rust limitations
- Linter removing a space in message_impls

<img width="1655" height="1280" alt="Screenshot 2025-10-07 at 11 09 56 AM" src="https://github.com/user-attachments/assets/f86314fe-15bd-4f96-ade5-6d5225dc0637" />
