### PR TITLE
Change `BlockDef` signature 

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,7 @@ unmaintained = 'all'
 ignore = [
     { id = "RUSTSEC-2024-0436", reason = "Waiting for alternative to paste to be stabilized" },
     { id = "RUSTSEC-2023-0089", reason = "Postcard uses heapless 0.7.0 which uses deprecated atomic-polyfill"},
+    { id = "RUSTSEC-2026-0110", reason = "bare-metal v0.2.5 is a dep of cortex-m v0.7.7 (embassy-stm32, ra4m2-hal, stm32-metapac); upstream cortex-m must migrate to critical-section" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/pictorus-internal/src/utils.rs
+++ b/pictorus-internal/src/utils.rs
@@ -113,6 +113,7 @@ cfg_if::cfg_if! {
         use std::format;
         use std::io::Write;
         use std::prelude::rust_2021::*;
+        use std::panic;
 
         use log::{info, warn, LevelFilter};
         use chrono::Local;

--- a/pictorus-linux/src/pwm_protocol/soft_pwm.rs
+++ b/pictorus-linux/src/pwm_protocol/soft_pwm.rs
@@ -46,7 +46,8 @@ impl SoftPwm {
             // will silently fail if we're not running as root.
             #[cfg(target_env = "gnu")]
             let params = sched_param {
-                // SAFETY: this is a safe function
+                // SAFETY: sched_get_priority_max takes a scheduling policy constant
+                // (SCHED_RR is valid) and has no pointer arguments, so the FFI call is sound.
                 sched_priority: unsafe { libc::sched_get_priority_max(SCHED_RR) },
             };
 
@@ -57,7 +58,8 @@ impl SoftPwm {
             let params = {
                 // SAFETY: sched_param is plain data and is valid when zero-initialized.
                 let mut params: sched_param = unsafe { std::mem::zeroed() };
-                // SAFETY: sched_get_priority_max is a safe function.
+                // SAFETY: sched_get_priority_max takes a scheduling policy constant
+                // (SCHED_RR is valid) and has no pointer arguments, so the FFI call is sound.
                 params.sched_priority = unsafe { libc::sched_get_priority_max(SCHED_RR) };
                 params
             };

--- a/pictorus-linux/src/pwm_protocol/soft_pwm.rs
+++ b/pictorus-linux/src/pwm_protocol/soft_pwm.rs
@@ -50,10 +50,16 @@ impl SoftPwm {
                 sched_priority: unsafe { libc::sched_get_priority_max(SCHED_RR) },
             };
 
+            // sched_param's non-priority fields differ across musl versions (older musl
+            // exposes deprecated SS scheduling fields, newer musl replaces them with
+            // private padding), so initialize via zeroed() instead of naming them.
             #[cfg(target_env = "musl")]
-            let params = sched_param {
-                // SAFETY: this is a safe function
-                sched_priority: unsafe { libc::sched_get_priority_max(SCHED_RR) },
+            let params = {
+                // SAFETY: sched_param is plain data and is valid when zero-initialized.
+                let mut params: sched_param = unsafe { std::mem::zeroed() };
+                // SAFETY: sched_get_priority_max is a safe function.
+                params.sched_priority = unsafe { libc::sched_get_priority_max(SCHED_RR) };
+                params
             };
 
             #[cfg(target_os = "linux")]

--- a/pictorus-linux/src/pwm_protocol/soft_pwm.rs
+++ b/pictorus-linux/src/pwm_protocol/soft_pwm.rs
@@ -54,16 +54,6 @@ impl SoftPwm {
             let params = sched_param {
                 // SAFETY: this is a safe function
                 sched_priority: unsafe { libc::sched_get_priority_max(SCHED_RR) },
-                sched_ss_low_priority: 0,
-                sched_ss_repl_period: timespec {
-                    tv_sec: 0,
-                    tv_nsec: 0,
-                },
-                sched_ss_init_budget: timespec {
-                    tv_sec: 0,
-                    tv_nsec: 0,
-                },
-                sched_ss_max_repl: 0,
             };
 
             #[cfg(target_os = "linux")]

--- a/pictorus-traits/src/custom_blocks.rs
+++ b/pictorus-traits/src/custom_blocks.rs
@@ -198,8 +198,7 @@ where
     }
 }
 
-impl<const NROWS: usize, const NCOLS: usize, T: Scalar> BlockDataWrite 
-    for Matrix<NROWS, NCOLS, T>
+impl<const NROWS: usize, const NCOLS: usize, T: Scalar> BlockDataWrite for Matrix<NROWS, NCOLS, T>
 where
     for<'a> &'a mut T: BlockDataWrite,
 {

--- a/pictorus-traits/src/custom_blocks.rs
+++ b/pictorus-traits/src/custom_blocks.rs
@@ -88,6 +88,12 @@ pub trait BlockDef {
     fn cleanup(&mut self) {}
 }
 
+// Returns a 'static [f64] of length 1 backing the bool's f64 representation.
+fn bool_as_matrix_data(b: bool) -> &'static [f64] {
+    static LUT: [f64; 2] = [0.0, 1.0];
+    core::slice::from_ref(&LUT[b as usize])
+}
+
 impl BlockDataRead for &bool {
     fn get_scalar(&self) -> f64 {
         if **self {
@@ -98,7 +104,7 @@ impl BlockDataRead for &bool {
     }
 
     fn get_matrix(&self) -> (usize, usize, &[f64]) {
-        unimplemented!("Cannot get matrix of scalar bool value")
+        (1, 1, bool_as_matrix_data(**self))
     }
 }
 
@@ -112,7 +118,7 @@ impl BlockDataRead for bool {
     }
 
     fn get_matrix(&self) -> (usize, usize, &[f64]) {
-        unimplemented!("Cannot get matrix of scalar bool value")
+        (1, 1, bool_as_matrix_data(*self))
     }
 }
 
@@ -124,7 +130,10 @@ macro_rules! scalar_block_data_read_impl {
                         (**self).into()
                     }
                     fn get_matrix(&self) -> (usize, usize, &[f64]) {
-                        unimplemented!("Can not get matrix of scalar {} value", stringify!($t))
+                        unimplemented!(
+                            "get_matrix on scalar {} is not supported; only f64 and bool scalars convert to 1x1 matrices",
+                            stringify!($t)
+                        )
                     }
                 }
 
@@ -133,14 +142,37 @@ macro_rules! scalar_block_data_read_impl {
                         (*self).into()
                     }
                     fn get_matrix(&self) -> (usize, usize, &[f64]) {
-                        unimplemented!("Can not get matrix of scalar {} value", stringify!($t))
+                        unimplemented!(
+                            "get_matrix on scalar {} is not supported; only f64 and bool scalars convert to 1x1 matrices",
+                            stringify!($t)
+                        )
                     }
                 }
             )+
         };
     }
 
-scalar_block_data_read_impl!(u8, i8, u16, i16, u32, i32, f32, f64);
+scalar_block_data_read_impl!(u8, i8, u16, i16, u32, i32, f32);
+
+impl BlockDataRead for &f64 {
+    fn get_scalar(&self) -> f64 {
+        **self
+    }
+
+    fn get_matrix(&self) -> (usize, usize, &[f64]) {
+        (1, 1, core::slice::from_ref(*self))
+    }
+}
+
+impl BlockDataRead for f64 {
+    fn get_scalar(&self) -> f64 {
+        *self
+    }
+
+    fn get_matrix(&self) -> (usize, usize, &[f64]) {
+        (1, 1, core::slice::from_ref(self))
+    }
+}
 
 // We can't easily implement this for non f64 types because we need to have an array of f64
 // with a long enough lifetime to be passed to the caller. We would need to use some sort of
@@ -359,5 +391,62 @@ mod tests {
         assert_eq!(nrows, 2);
         assert_eq!(ncols, 2);
         assert_eq!(data, &[1.0, 3.0, 2.0, 4.0]);
+    }
+
+    #[test]
+    fn test_block_data_read_scalar_f64_get_matrix_through_dyn() {
+        let x: f64 = 3.5;
+        let reader: &dyn BlockDataRead = &x;
+        let (nrows, ncols, data) = reader.get_matrix();
+        assert_eq!(nrows, 1);
+        assert_eq!(ncols, 1);
+        assert_eq!(data, &[3.5]);
+    }
+
+    #[test]
+    fn test_block_data_read_scalar_f64_ref_get_matrix_through_dyn() {
+        let value: f64 = 9.25;
+        let x: &f64 = &value;
+        let reader: &dyn BlockDataRead = &x;
+        let (nrows, ncols, data) = reader.get_matrix();
+        assert_eq!(nrows, 1);
+        assert_eq!(ncols, 1);
+        assert_eq!(data, &[9.25]);
+    }
+
+    #[test]
+    fn test_block_data_read_scalar_bool_get_matrix_through_dyn() {
+        let t = true;
+        let reader: &dyn BlockDataRead = &t;
+        let (nrows, ncols, data) = reader.get_matrix();
+        assert_eq!(nrows, 1);
+        assert_eq!(ncols, 1);
+        assert_eq!(data, &[1.0]);
+
+        let f = false;
+        let reader: &dyn BlockDataRead = &f;
+        let (nrows, ncols, data) = reader.get_matrix();
+        assert_eq!(nrows, 1);
+        assert_eq!(ncols, 1);
+        assert_eq!(data, &[0.0]);
+    }
+
+    #[test]
+    fn test_block_data_read_scalar_bool_ref_get_matrix_through_dyn() {
+        let value = true;
+        let x: &bool = &value;
+        let reader: &dyn BlockDataRead = &x;
+        let (nrows, ncols, data) = reader.get_matrix();
+        assert_eq!(nrows, 1);
+        assert_eq!(ncols, 1);
+        assert_eq!(data, &[1.0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "get_matrix on scalar u8 is not supported")]
+    fn test_block_data_read_scalar_u8_get_matrix_still_panics() {
+        let x: u8 = 5;
+        let reader: &dyn BlockDataRead = &x;
+        let _ = reader.get_matrix();
     }
 }

--- a/pictorus-traits/src/custom_blocks.rs
+++ b/pictorus-traits/src/custom_blocks.rs
@@ -102,6 +102,20 @@ impl BlockDataRead for &bool {
     }
 }
 
+impl BlockDataRead for bool {
+    fn get_scalar(&self) -> f64 {
+        if *self {
+            1.0
+        } else {
+            0.0
+        }
+    }
+
+    fn get_matrix(&self) -> (usize, usize, &[f64]) {
+        unimplemented!("Cannot get matrix of scalar bool value")
+    }
+}
+
 macro_rules! scalar_block_data_read_impl {
         ($($t:ty),+) => {
             $(
@@ -142,9 +156,30 @@ impl<const NROWS: usize, const NCOLS: usize> BlockDataRead for &Matrix<NROWS, NC
     }
 }
 
+impl<const NROWS: usize, const NCOLS: usize> BlockDataRead for Matrix<NROWS, NCOLS, f64> {
+    fn get_scalar(&self) -> f64 {
+        unimplemented!("Can not get scalar of matrix value")
+    }
+
+    fn get_matrix(&self) -> (usize, usize, &[f64]) {
+        let data = self.data.as_flattened();
+        (NROWS, NCOLS, data)
+    }
+}
+
 impl BlockDataWrite for &mut bool {
     fn set_scalar_value(&mut self, value: f64) {
         **self = value != 0.0;
+    }
+
+    fn set_matrix_value(&mut self, _nrows: usize, _ncols: usize, _data: &[f64]) {
+        unimplemented!("Can not set matrix of scalar bool value")
+    }
+}
+
+impl BlockDataWrite for bool {
+    fn set_scalar_value(&mut self, value: f64) {
+        *self = value != 0.0;
     }
 
     fn set_matrix_value(&mut self, _nrows: usize, _ncols: usize, _data: &[f64]) {
@@ -258,5 +293,71 @@ mod tests {
 
         let param = BlockParam::String("not a matrix");
         assert_eq!(param.as_matrix(), None);
+    }
+
+    #[test]
+    fn test_block_data_write_scalar_f64_through_dyn() {
+        let mut x: f64 = 0.0;
+        let writer: &mut dyn BlockDataWrite = &mut x;
+        writer.set_scalar_value(42.5);
+        assert_eq!(x, 42.5);
+    }
+
+    #[test]
+    fn test_block_data_write_scalar_u8_through_dyn() {
+        let mut x: u8 = 0;
+        let writer: &mut dyn BlockDataWrite = &mut x;
+        writer.set_scalar_value(7.0);
+        assert_eq!(x, 7);
+    }
+
+    #[test]
+    fn test_block_data_write_scalar_bool_through_dyn() {
+        let mut x: bool = false;
+        {
+            let writer: &mut dyn BlockDataWrite = &mut x;
+            writer.set_scalar_value(1.0);
+        }
+        assert!(x);
+        {
+            let writer: &mut dyn BlockDataWrite = &mut x;
+            writer.set_scalar_value(0.0);
+        }
+        assert!(!x);
+    }
+
+    #[test]
+    fn test_block_data_write_matrix_through_dyn() {
+        let mut m: Matrix<2, 2, f64> = Matrix::zeroed();
+        let writer: &mut dyn BlockDataWrite = &mut m;
+        // Column-major: column 0 = [1.0, 3.0], column 1 = [2.0, 4.0]
+        writer.set_matrix_value(2, 2, &[1.0, 3.0, 2.0, 4.0]);
+        assert_eq!(m.data, [[1.0, 3.0], [2.0, 4.0]]);
+    }
+
+    #[test]
+    fn test_block_data_read_scalar_f64_through_dyn() {
+        let x: f64 = 3.5;
+        let reader: &dyn BlockDataRead = &x;
+        assert_eq!(reader.get_scalar(), 3.5);
+    }
+
+    #[test]
+    fn test_block_data_read_scalar_bool_through_dyn() {
+        let x = true;
+        let reader: &dyn BlockDataRead = &x;
+        assert_eq!(reader.get_scalar(), 1.0);
+    }
+
+    #[test]
+    fn test_block_data_read_matrix_through_dyn() {
+        let m: Matrix<2, 2, f64> = Matrix {
+            data: [[1.0, 3.0], [2.0, 4.0]],
+        };
+        let reader: &dyn BlockDataRead = &m;
+        let (nrows, ncols, data) = reader.get_matrix();
+        assert_eq!(nrows, 2);
+        assert_eq!(ncols, 2);
+        assert_eq!(data, &[1.0, 3.0, 2.0, 4.0]);
     }
 }

--- a/pictorus-traits/src/custom_blocks.rs
+++ b/pictorus-traits/src/custom_blocks.rs
@@ -79,7 +79,7 @@ pub trait BlockDef {
     /// and a list of outputs corresponding to data that will be passed to downstream blocks.
     ///
     /// Each iteration of this block should modify the output data in place to reflect the current state
-    fn run(&mut self, inputs: &[impl BlockDataRead], outputs: &mut [impl BlockDataWrite]);
+    fn run(&mut self, inputs: &[&dyn BlockDataRead], outputs: &mut [&mut dyn BlockDataWrite]);
 
     /// Optional cleanup of any resources used by this block
     ///
@@ -114,7 +114,7 @@ macro_rules! scalar_block_data_read_impl {
                     }
                 }
 
-                 impl BlockDataRead for $t {
+                impl BlockDataRead for $t {
                     fn get_scalar(&self) -> f64 {
                         (*self).into()
                     }
@@ -164,6 +164,15 @@ macro_rules! scalar_block_data_write_impl {
                         unimplemented!("Can not set matrix for scalar {}", stringify!($t))
                     }
                 }
+
+                impl BlockDataWrite for $t {
+                    fn set_scalar_value(&mut self, value: f64) {
+                        *self = value as $t;
+                    }
+                    fn set_matrix_value(&mut self, _nrows: usize, _ncols: usize, _data: &[f64]) {
+                        unimplemented!("Can not set matrix for scalar {}", stringify!($t))
+                    }
+                }
             )+
         };
     }
@@ -171,6 +180,26 @@ scalar_block_data_write_impl!(u8, i8, u16, i16, u32, i32, f32, f64);
 
 impl<const NROWS: usize, const NCOLS: usize, T: Scalar> BlockDataWrite
     for &mut Matrix<NROWS, NCOLS, T>
+where
+    for<'a> &'a mut T: BlockDataWrite,
+{
+    fn set_scalar_value(&mut self, _value: f64) {
+        unimplemented!("Can not set scalar of matrix value")
+    }
+
+    fn set_matrix_value(&mut self, nrows: usize, ncols: usize, data: &[f64]) {
+        assert_eq!(nrows, NROWS);
+        assert_eq!(ncols, NCOLS);
+        self.data
+            .as_flattened_mut()
+            .iter_mut()
+            .zip(data.iter())
+            .for_each(|(mut a, b)| a.set_scalar_value(*b));
+    }
+}
+
+impl<const NROWS: usize, const NCOLS: usize, T: Scalar> BlockDataWrite 
+    for Matrix<NROWS, NCOLS, T>
 where
     for<'a> &'a mut T: BlockDataWrite,
 {

--- a/pictorus-traits/src/custom_blocks.rs
+++ b/pictorus-traits/src/custom_blocks.rs
@@ -90,8 +90,13 @@ pub trait BlockDef {
 
 // Returns a 'static [f64] of length 1 backing the bool's f64 representation.
 fn bool_as_matrix_data(b: bool) -> &'static [f64] {
-    static LUT: [f64; 2] = [0.0, 1.0];
-    core::slice::from_ref(&LUT[b as usize])
+    static TRUE_VAL: f64 = 1.0;
+    static FALSE_VAL: f64 = 0.0;
+    if b {
+        core::slice::from_ref(&TRUE_VAL)
+    } else {
+        core::slice::from_ref(&FALSE_VAL)
+    }
 }
 
 impl BlockDataRead for &bool {


### PR DESCRIPTION
Changes:
- Updated `BlockDef` run signature to take: 
    -  immutable reference to an array of references that are of type BlockDataRead 
    - A mutable reference to an array of mutable references that are of type  BlockDataWrite
- Implement BlockDataWrite for: 
    - f64 (currently impl for &f64)
    - Matrix (currently impl for &Matrix)