### PR TITLE
Remove `TimeSource` and simplify `SystemTimeBlock`

### DIFF
--- a/pictorus-blocks/src/std_blocks/mod.rs
+++ b/pictorus-blocks/src/std_blocks/mod.rs
@@ -2,7 +2,7 @@ mod fft_block;
 pub use fft_block::FftBlock as FFTBlock;
 
 mod system_time_block;
-pub use system_time_block::{Sim, SystemTimeBlock};
+pub use system_time_block::SystemTimeBlock;
 
 #[cfg(target_arch = "x86_64")]
 mod fmu_block;

--- a/pictorus-blocks/src/std_blocks/system_time_block.rs
+++ b/pictorus-blocks/src/std_blocks/system_time_block.rs
@@ -4,29 +4,18 @@ use pictorus_traits::GeneratorBlock;
 
 /// This block can be used in `std` environments to get the current system time.
 /// The time output can be in different formats, such as epoch time, second, minute, hour, day of the month, day of the year, month, or year.
-///
-/// Optionally, this accepts a sim input, in that case it must be instantiated with `SystemTimeBlock<Sim>`. In this case, the
-/// `data` field is assumed to be set externally
-pub struct SystemTimeBlock<T: TimeSource = Real> {
+pub struct SystemTimeBlock {
     pub data: OldBlockData,
     output: f64,
     start_time: DateTime<Local>,
-    _phantom: core::marker::PhantomData<T>,
 }
 
-pub trait TimeSource {}
-pub struct Sim;
-impl TimeSource for Sim {}
-pub struct Real;
-impl TimeSource for Real {}
-
-impl<T: TimeSource> Default for SystemTimeBlock<T> {
+impl Default for SystemTimeBlock {
     fn default() -> Self {
         Self {
             data: OldBlockData::from_scalar(0.0),
             output: 0.0,
             start_time: Local::now(),
-            _phantom: core::marker::PhantomData,
         }
     }
 }
@@ -44,7 +33,7 @@ fn get_output_value(time: DateTime<Local>, method: SystemTimeEnum) -> f64 {
     }
 }
 
-impl GeneratorBlock for SystemTimeBlock<Real> {
+impl GeneratorBlock for SystemTimeBlock {
     type Output = f64;
     type Parameters = Parameters;
 
@@ -63,23 +52,7 @@ impl GeneratorBlock for SystemTimeBlock<Real> {
     }
 }
 
-impl GeneratorBlock for SystemTimeBlock<Sim> {
-    type Output = f64;
-    type Parameters = Parameters;
-
-    fn generate(
-        &mut self,
-        _parameters: &Self::Parameters,
-        _context: &dyn pictorus_traits::Context,
-    ) -> pictorus_traits::PassBy<'_, Self::Output> {
-        // Assume that self.data was set externally and just use that
-        self.output = self.data.scalar();
-        self.output
-    }
-}
-
 /// The type of output wanted from the SystemTimeBlock.
-/// Has no affect when used with a sim input
 #[derive(strum::EnumString, Clone, Copy, Debug)]
 pub enum SystemTimeEnum {
     Epoch,
@@ -150,20 +123,5 @@ mod tests {
         let output = block.generate(&params, &context);
         assert_eq!(output, start_time.timestamp() as f64 + 42.0);
         assert_eq!(block.data.scalar(), start_time.timestamp() as f64 + 42.0);
-    }
-
-    #[test]
-    fn test_system_time_block_sim() {
-        let mut block: SystemTimeBlock<Sim> = Default::default();
-        block.data.set_scalar(1337.0);
-        let params = Parameters::new("Epoch");
-        let context = StubContext::new(
-            Duration::from_secs(42),
-            Some(Duration::from_millis(100)),
-            Duration::from_millis(100),
-        );
-        let output = block.generate(&params, &context);
-        assert_eq!(output, 1337.0);
-        assert_eq!(block.data.scalar(), 1337.0);
     }
 }


### PR DESCRIPTION
This is part of the change to clean up sim components on our way to remove BlockData. `SystemTimeBlock` was treated a bit differently than other components during simulation, in that its struct had a generic type associated with it. These changes are to bring all the sim components in line. 

<img width="642" height="214" alt="Screenshot 2026-05-05 at 3 02 58 PM" src="https://github.com/user-attachments/assets/f88448ac-844d-43e2-9ef2-5a990502a93c" />

The code for simulating time for a simple sim component (above) is now just a pass through:
```
// <...imports...>

pub struct Component1Component {
    last_time_s: f64,
    pub time_input: ComponentInputBlock<f64>,
    pub time_output: ComponentOutputBlock<f64>,
}

impl Component1Component {
    pub fn new(_context: &Context) -> Self {
        // Time Input
        let time_input = ComponentInputBlock::default();

        // Time Output
        let time_output = ComponentOutputBlock::default();

        Component1Component {
            last_time_s: -1.0,
            time_input,
            time_output,
        }
    }

    pub fn run(&mut self, context: &mut Context, time_input: f64) {
        let app_time_s = context.app_time_s();
        let runtime_ctx = context.get_runtime_context();

        if self.last_time_s == -1.0 {
            self.last_time_s = app_time_s;
        }
        let timestep_s: f64 = app_time_s - self.last_time_s;

        log::debug!(
            "-- State::Component1Component iteration. Time: {}s (dt: {}s) ",
            app_time_s,
            timestep_s
        );

        // Time Input
        let time_input_0 = self.time_input.process(
            &context.application_parameters.time_input_a203d,
            &runtime_ctx,
            time_input,
        );

        let system_time1_0 = time_input_0;

        // Time Output
        let _ = self.time_output.process(
            &context.application_parameters.time_output_a203f,
            &runtime_ctx,
            system_time1_0,
        );

        self.last_time_s = app_time_s;
    }

    pub fn post_run(&mut self) {}
}
```

If Sim Input is not wired, then a `SystemTimeBlock` is inserted, without the `TimeSource` generic as that is no longer needed.
```
// <...imports...>

pub struct Component1Component {
    last_time_s: f64,
    pub system_time1: SystemTimeBlock,
    pub time_output: ComponentOutputBlock<f64>,
}

impl Component1Component {
    pub fn new(_context: &Context) -> Self {
        // SystemTime1
        let system_time1 = SystemTimeBlock::default();

        // Time Output
        let time_output = ComponentOutputBlock::default();

        Component1Component {
            last_time_s: -1.0,
            system_time1,
            time_output,
        }
    }

    pub fn run(&mut self, context: &mut Context) {
        let app_time_s = context.app_time_s();
        let runtime_ctx = context.get_runtime_context();

        if self.last_time_s == -1.0 {
            self.last_time_s = app_time_s;
        }
        let timestep_s: f64 = app_time_s - self.last_time_s;

        log::debug!(
            "-- State::Component1Component iteration. Time: {}s (dt: {}s) ",
            app_time_s,
            timestep_s
        );

        // SystemTime1
        let system_time1_0 = self.system_time1.generate(
            &context.application_parameters.system_time1_a203c,
            &runtime_ctx,
        );

        // Time Output
        let _ = self.time_output.process(
            &context.application_parameters.time_output_a203f,
            &runtime_ctx,
            system_time1_0,
        );

        self.last_time_s = app_time_s;
    }

    pub fn post_run(&mut self) {}
}
```

Changes:
- Remove TimeSource trait and Real and Sim impl
- Remove TimeSource generic from SystemTimeBlock
- Unify SystemTimeBlock<Real> / <Sim> into just a single `SystemTimeBlock`