### PR TITLE
Remove ComponentOutputBlock

### DIFF
--- a/pictorus-blocks/src/core_blocks/mod.rs
+++ b/pictorus-blocks/src/core_blocks/mod.rs
@@ -172,9 +172,6 @@ pub use passthrough_block::Parameters as GpioInputBlockParams;
 #[doc(hidden)]
 pub use passthrough_block::Parameters as SpiTransmitBlockParams;
 
-/// Used to signify an output port of a component.
-#[doc(inline)]
-pub use passthrough_block::PassthroughBlock as ComponentOutputBlock;
 /// Used to signify an input port of a component.
 #[doc(inline)]
 pub use passthrough_block::PassthroughBlock as ComponentInputBlock;

--- a/pictorus-px4/examples/quad_controller.rs
+++ b/pictorus-px4/examples/quad_controller.rs
@@ -1,3 +1,10 @@
+// TODO: This drifted out of sync before, and especially after, removing ComponentOutputBlock
+// Run: cargo check --example quad_controller -p pictorus-px4
+// Issues:
+//   - `ComponentOutputBlock` import + ~30 usages dangle now that the alias is gone.
+//   - `pictorus_internal` is referenced but isn't in this crate's dev-dependencies.
+//   - Several ToPassType errors
+
 //! Translated from https://www.app.pictor.us/app/68ae03a7aad158fcb5c48245
 #![no_std]
 extern crate alloc;


### PR DESCRIPTION
- Remove ComponentOutputBlock. Component outputs now exist as pub fields on the component's struct of type T instead of ComponentOutputBlock<T>.
- Add TODO on quad_controller, it had drifted out of sync before this PR and drifted++ after.