### PR TITLE
Add .buffer() trait function to allow a way to get access to a blocks last run value.

### DIFF
--- a/pictorus-blocks/src/core_blocks/abs_block.rs
+++ b/pictorus-blocks/src/core_blocks/abs_block.rs
@@ -20,7 +20,7 @@ impl Parameter {
 /// Computes the absolute value of a scalar, vector, or matrix.
 pub struct AbsBlock<T: Pass + Default> {
     pub data: OldBlockData,
-    buffer: Option<T>,
+    buffer: T,
 }
 
 impl<T> Default for AbsBlock<T>
@@ -31,7 +31,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
-            buffer: None,
+            buffer: T::default(),
         }
     }
 }
@@ -54,8 +54,13 @@ macro_rules! impl_abs_block {
                 inputs: pictorus_traits::PassBy<'_, Self::Inputs>,
             ) -> pictorus_traits::PassBy<'b, Self::Output> {
                 let output = Float::abs(inputs);
+                self.buffer = output;
                 self.data = OldBlockData::from_scalar(output.into());
                 output
+            }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
             }
         }
 
@@ -76,10 +81,13 @@ macro_rules! impl_abs_block {
                 input: PassBy<Self::Inputs>,
             ) -> PassBy<'_, Self::Output> {
                 let abs = input.as_view().abs();
-                let o = Matrix::<ROWS, COLS, $type>::from_view(&abs.as_view());
-                let output = self.buffer.insert(o);
-                self.data = OldBlockData::from_pass(output);
-                output
+                self.buffer = Matrix::<ROWS, COLS, $type>::from_view(&abs.as_view());
+                self.data = OldBlockData::from_pass(&self.buffer);
+                &self.buffer
+            }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
             }
         }
     };
@@ -99,6 +107,15 @@ mod tests {
         ($name:ident, $type:ty) => {
             paste! {
                 #[test]
+                fn [<test_abs_block_default_buffer_ $name>]() {
+                    let block = AbsBlock::<$type>::default();
+                    assert_eq!(block.buffer(), <$type>::default());
+
+                    let block = AbsBlock::<Matrix<2, 2, $type>>::default();
+                    assert_eq!(block.buffer(), &Matrix::<2, 2, $type>::zeroed());
+                }
+
+                #[test]
                 fn [<test_abs_block_scalar_ $name>]()
                 {
                     let mut block = AbsBlock::<$type>::default();
@@ -107,6 +124,7 @@ mod tests {
                     let output = block.process(&Parameter::new(), &context, <$type>::one());
                     assert_eq!(output, <$type>::one());
                     assert_eq!(block.data, OldBlockData::from_scalar(<$type>::one().into()));
+                    assert_eq!(block.buffer(), output);
 
                     let output = block.process(&Parameter::new(), &context, -<$type>::one());
                     assert_eq!(output, <$type>::one());

--- a/pictorus-blocks/src/core_blocks/adc_block.rs
+++ b/pictorus-blocks/src/core_blocks/adc_block.rs
@@ -64,6 +64,10 @@ where
         self.data = OldBlockData::from_scalar(self.buffer.into());
         self.buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer
+    }
 }
 
 #[cfg(test)]
@@ -72,12 +76,19 @@ mod test {
     use crate::testing::StubContext;
 
     #[test]
+    fn test_adc_block_default_buffer_no_panic() {
+        let block = AdcBlock::<u16, f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_adc_block_f64() {
         let c = StubContext::default();
         let mut block = AdcBlock::<u16, f64>::default();
         let input = 42u16;
         let output = block.process(&Parameters::new(), &c, input);
         assert_eq!(output, 42.0);
+        assert_eq!(block.buffer(), output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/aggregate_block.rs
+++ b/pictorus-blocks/src/core_blocks/aggregate_block.rs
@@ -5,7 +5,7 @@ use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
 /// Block for performing an aggregation operation (i.e. sum, min, max) on input data.
 pub struct AggregateBlock<T: Apply> {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
 }
 
 impl<T: Apply> Default for AggregateBlock<T>
@@ -16,7 +16,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
-            buffer: None,
+            buffer: <T::Output>::default(),
         }
     }
 }
@@ -40,13 +40,17 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 pub trait Apply: Pass {
     type Output: Scalar;
 
     fn apply<'s>(
-        store: &mut Option<Self::Output>,
+        store: &mut Self::Output,
         input: PassBy<Self>,
         method: AggregateMethod,
     ) -> PassBy<'s, Self::Output>;
@@ -63,11 +67,11 @@ macro_rules! scalar_impls {
             type Output = $type;
 
             fn apply<'s>(
-                store: &mut Option<Self::Output>,
+                store: &mut Self::Output,
                 input: PassBy<Self>,
                 _method: AggregateMethod,
             ) -> PassBy<'s, Self::Output> {
-                *store = Some(input);
+                *store = input;
                 input
             }
         }
@@ -81,7 +85,7 @@ macro_rules! float_matrix_impl {
             type Output = $type;
 
             fn apply<'s>(
-                store: &mut Option<Self::Output>,
+                store: &mut Self::Output,
                 input: PassBy<Self>,
                 method: AggregateMethod,
             ) -> PassBy<'s, Self::Output> {
@@ -105,7 +109,7 @@ macro_rules! float_matrix_impl {
                     AggregateMethod::Min => view.min(),
                     AggregateMethod::Max => view.max(),
                 };
-                *store = Some(output);
+                *store = output;
                 output
             }
         }
@@ -149,6 +153,12 @@ mod tests {
     use approx::assert_relative_eq;
 
     #[test]
+    fn test_aggregate_default_buffer_no_panic() {
+        let block = AggregateBlock::<Matrix<4, 7, f64>>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_aggregate_sum_f32() {
         let mut block = AggregateBlock::<Matrix<4, 7, f32>>::default();
         let context = StubContext::default();
@@ -161,6 +171,7 @@ mod tests {
         let output = block.process(&params, &context, &input);
         assert_relative_eq!(output, 28.0);
         assert_relative_eq!(block.data.scalar(), 28.0);
+        assert_relative_eq!(block.buffer(), output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/app_time_block.rs
+++ b/pictorus-blocks/src/core_blocks/app_time_block.rs
@@ -1,6 +1,6 @@
 use crate::traits::Float;
 use pictorus_block_data::BlockData;
-use pictorus_traits::{GeneratorBlock, Scalar};
+use pictorus_traits::{GeneratorBlock, PassBy, Scalar};
 
 #[derive(Debug, Clone, Default)]
 pub struct Parameters {}
@@ -15,6 +15,7 @@ impl Parameters {
 #[derive(Debug, Clone)]
 pub struct AppTimeBlock<T: Scalar + Float> {
     phantom: core::marker::PhantomData<T>,
+    buffer: T,
     pub data: BlockData,
 }
 
@@ -25,6 +26,7 @@ where
     fn default() -> Self {
         Self {
             phantom: core::marker::PhantomData,
+            buffer: T::zero(),
             data: BlockData::from_scalar(f64::from(T::zero())),
         }
     }
@@ -44,8 +46,13 @@ where
         context: &dyn pictorus_traits::Context,
     ) -> pictorus_traits::PassBy<'_, Self::Output> {
         let time = T::from_duration(context.time());
+        self.buffer = time;
         self.data = BlockData::from_scalar(time.into());
         time
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer
     }
 }
 
@@ -54,6 +61,12 @@ mod tests {
     use crate::testing::StubRuntime;
     use crate::AppTimeBlock;
     use pictorus_traits::GeneratorBlock;
+
+    #[test]
+    fn test_app_time_default_buffer_no_panic() {
+        let block = AppTimeBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
 
     #[test]
     fn test_app_time_block() {
@@ -66,6 +79,7 @@ mod tests {
             let context = runtime.context();
             let output = block.generate(&parameters, &context);
             assert_eq!(output, block.data.scalar());
+            assert_eq!(block.buffer(), output);
             runtime.tick();
         }
     }

--- a/pictorus-blocks/src/core_blocks/arg_min_max_block.rs
+++ b/pictorus-blocks/src/core_blocks/arg_min_max_block.rs
@@ -15,7 +15,7 @@ use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
 /// ----------------------
 pub struct ArgMinMaxBlock<T: Apply> {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
 }
 
 impl<T: Apply> Default for ArgMinMaxBlock<T>
@@ -26,7 +26,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
-            buffer: None,
+            buffer: <T::Output>::default(),
         }
     }
 }
@@ -50,13 +50,17 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 pub trait Apply: Pass {
     type Output: Scalar;
 
     fn apply<'s>(
-        store: &mut Option<Self::Output>,
+        store: &mut Self::Output,
         input: PassBy<Self>,
         method: ArgMethod,
     ) -> PassBy<'s, Self::Output>;
@@ -76,12 +80,13 @@ impl<T: ArgMinMaxScalar> Apply for T {
     type Output = T;
 
     fn apply<'s>(
-        store: &mut Option<Self::Output>,
+        store: &mut Self::Output,
         _input: PassBy<Self>,
         _method: ArgMethod,
     ) -> PassBy<'s, Self::Output> {
         // If a scalar is passed in then the only possible index is zero
-        *store.insert(T::zero())
+        *store = T::zero();
+        *store
     }
 }
 
@@ -89,7 +94,7 @@ impl<const NROWS: usize, const NCOLS: usize, T: ArgMinMaxScalar> Apply for Matri
     type Output = T;
 
     fn apply<'s>(
-        store: &mut Option<Self::Output>,
+        store: &mut Self::Output,
         input: PassBy<Self>,
         method: ArgMethod,
     ) -> PassBy<'s, Self::Output> {
@@ -115,7 +120,8 @@ impl<const NROWS: usize, const NCOLS: usize, T: ArgMinMaxScalar> Apply for Matri
                     .0
             }
         };
-        *store.insert(T::from_usize(index).expect("Couldn't convert usize to T"))
+        *store = T::from_usize(index).expect("Couldn't convert usize to T");
+        *store
     }
 }
 
@@ -142,6 +148,14 @@ mod tests {
     use crate::testing::StubContext;
 
     #[test]
+    fn test_default_buffer_no_panic() {
+        let block = ArgMinMaxBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+        let block = ArgMinMaxBlock::<Matrix<2, 3, f64>>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_scalar_input() {
         let mut block = ArgMinMaxBlock::<f64>::default();
         let context = StubContext::default();
@@ -150,6 +164,7 @@ mod tests {
         let output = block.process(&params, &context, input);
         assert_eq!(output, 0.0);
         assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/bias_block.rs
+++ b/pictorus-blocks/src/core_blocks/bias_block.rs
@@ -8,7 +8,7 @@ where
     T: Apply<B>,
 {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
 }
 
 impl<B, T> Default for BiasBlock<B, T>
@@ -20,7 +20,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
-            buffer: None,
+            buffer: <T::Output>::default(),
         }
     }
 }
@@ -45,13 +45,17 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 pub trait Apply<B: Scalar>: Pass {
     type Output: Pass + Default;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         offset: B,
     ) -> PassBy<'s, Self::Output>;
@@ -64,13 +68,13 @@ where
     type Output = Promotion<B, f64>;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         offset: B,
     ) -> PassBy<'s, Self::Output> {
         let output =
             <B as Promote<f64>>::promote_left(offset) + <B as Promote<f64>>::promote_right(input);
-        *store = Some(output);
+        *store = output;
         output
     }
 }
@@ -82,13 +86,13 @@ where
     type Output = Promotion<B, f32>;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         offset: B,
     ) -> PassBy<'s, Self::Output> {
         let output =
             <B as Promote<f32>>::promote_left(offset) + <B as Promote<f32>>::promote_right(input);
-        *store = Some(output);
+        *store = output;
         output
     }
 }
@@ -101,18 +105,17 @@ where
     type Output = Matrix<NROWS, NCOLS, Promotion<B, T>>;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         offset: B,
     ) -> PassBy<'s, Self::Output> {
-        let output = store.insert(Matrix::zeroed());
         for i in 0..NROWS {
             for j in 0..NCOLS {
-                output.data[j][i] = <B as Promote<T>>::promote_left(offset)
+                store.data[j][i] = <B as Promote<T>>::promote_left(offset)
                     + <B as Promote<T>>::promote_right(input.data[j][i]);
             }
         }
-        output
+        store
     }
 }
 
@@ -140,6 +143,15 @@ mod tests {
     use pictorus_block_data::ToPass;
 
     #[test]
+    fn test_bias_default_buffer_no_panic() {
+        let block = BiasBlock::<f64, f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = BiasBlock::<f64, Matrix<2, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
+    }
+
+    #[test]
     fn test_bias_scalar() {
         let mut block = BiasBlock::<f64, f64>::default();
         let parameters = Parameters::new(3.0);
@@ -148,6 +160,7 @@ mod tests {
         let output = block.process(&parameters, &context, 2.0);
         assert_eq!(output, 5.0);
         assert_eq!(block.data.scalar(), 5.0);
+        assert_eq!(block.buffer(), output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/bit_shift_block.rs
+++ b/pictorus-blocks/src/core_blocks/bit_shift_block.rs
@@ -10,7 +10,7 @@ where
     T: Apply,
 {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
 }
 
 impl<T> Default for BitShiftBlock<T>
@@ -21,7 +21,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
-            buffer: None,
+            buffer: T::Output::default(),
         }
     }
 }
@@ -67,13 +67,17 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 pub trait Apply: Pass {
     type Output: Pass + Default;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         params: &Parameters,
     ) -> PassBy<'s, Self::Output>;
@@ -85,7 +89,7 @@ macro_rules! impl_bit_shift_apply {
             type Output = $type;
 
             fn apply<'s>(
-                store: &'s mut Option<Self::Output>,
+                store: &'s mut Self::Output,
                 input: PassBy<Self>,
                 params: &Parameters,
             ) -> PassBy<'s, Self::Output> {
@@ -94,7 +98,7 @@ macro_rules! impl_bit_shift_apply {
                     ShiftDirection::Left => input << params.bits,
                     ShiftDirection::Right => input >> params.bits,
                 } as $type;
-                *store = Some(output);
+                *store = output;
                 output
             }
         }
@@ -103,11 +107,10 @@ macro_rules! impl_bit_shift_apply {
             type Output = Matrix<NROWS, NCOLS, $type>;
 
             fn apply<'s>(
-                store: &'s mut Option<Self::Output>,
+                store: &'s mut Self::Output,
                 input: PassBy<Self>,
                 params: &Parameters,
             ) -> PassBy<'s, Self::Output> {
-                let output = store.insert(Matrix::zeroed());
                 for i in 0..NROWS {
                     for j in 0..NCOLS {
                         let input_val = input.data[j][i] as $cast_type;
@@ -115,10 +118,10 @@ macro_rules! impl_bit_shift_apply {
                             ShiftDirection::Left => input_val << params.bits,
                             ShiftDirection::Right => input_val >> params.bits,
                         } as $type;
-                        output.data[j][i] = res;
+                        store.data[j][i] = res;
                     }
                 }
-                output
+                store
             }
         }
     };
@@ -140,6 +143,14 @@ mod tests {
         ($type:ty) => {
             paste! {
                 #[test]
+                fn [<test_default_buffer_no_panic_ $type>]() {
+                    let block = BitShiftBlock::<$type>::default();
+                    assert_eq!(block.buffer(), <$type>::default());
+                    let block = BitShiftBlock::<Matrix<2, 2, $type>>::default();
+                    assert_eq!(block.buffer(), &Matrix::<2, 2, $type>::zeroed());
+                }
+
+                #[test]
                 fn [<test_left_shift_scalar_ $type>]() {
                     let mut block = BitShiftBlock::<$type>::default();
                     let context = StubContext::default();
@@ -147,6 +158,7 @@ mod tests {
                     let output = block.process(&params, &context, [<1 $type>]);
                     assert_eq!(output, [<4 $type>]);
                     assert_eq!(block.data.scalar(), 4.0);
+                    assert_eq!(block.buffer(), output);
                 }
 
                 #[test]

--- a/pictorus-blocks/src/core_blocks/bitwise_operator_block.rs
+++ b/pictorus-blocks/src/core_blocks/bitwise_operator_block.rs
@@ -13,7 +13,7 @@ where
     T: Apply,
     OldBlockData: FromPass<<T as Apply>::Output>,
 {
-    store: Option<T::Output>,
+    store: T::Output,
     pub data: OldBlockData,
 }
 
@@ -24,7 +24,7 @@ where
 {
     fn default() -> Self {
         Self {
-            store: None,
+            store: T::Output::default(),
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
         }
     }
@@ -48,6 +48,10 @@ where
         let result = T::apply(inputs, *parameters, &mut self.store);
         self.data = OldBlockData::from_pass(result);
         result
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.store.as_by()
     }
 }
 
@@ -144,7 +148,7 @@ pub trait Apply: Pass {
     fn apply<'a>(
         input: PassBy<Self>,
         operation: Operation,
-        dest: &'a mut Option<Self::Output>,
+        dest: &'a mut Self::Output,
     ) -> PassBy<'a, Self::Output>;
 }
 
@@ -159,13 +163,13 @@ where
     fn apply<'a>(
         input: PassBy<Self>,
         operation: Operation,
-        dest: &'a mut Option<Self::Output>,
+        dest: &'a mut Self::Output,
     ) -> PassBy<'a, Self::Output> {
-        let mut output = A::Output::default();
-        A::copy_into(input.0, &mut output);
-        A::Output::operate_assign(&mut output, input.1, operation);
+        *dest = A::Output::default();
+        A::copy_into(input.0, dest);
+        A::Output::operate_assign(dest, input.1, operation);
 
-        dest.insert(output).as_by()
+        dest.as_by()
     }
 }
 
@@ -181,13 +185,13 @@ where
     fn apply<'a>(
         input: PassBy<Self>,
         operation: Operation,
-        dest: &'a mut Option<Self::Output>,
+        dest: &'a mut Self::Output,
     ) -> PassBy<'a, Self::Output> {
-        let mut output = A::Output::default();
-        A::copy_into(input.0, &mut output);
-        <A::Output as BitOperations<B>>::operate_assign(&mut output, input.1, operation);
-        <A::Output as BitOperations<C>>::operate_assign(&mut output, input.2, operation);
-        dest.insert(output).as_by()
+        *dest = A::Output::default();
+        A::copy_into(input.0, dest);
+        <A::Output as BitOperations<B>>::operate_assign(dest, input.1, operation);
+        <A::Output as BitOperations<C>>::operate_assign(dest, input.2, operation);
+        dest.as_by()
     }
 }
 
@@ -204,14 +208,14 @@ where
     fn apply<'a>(
         input: PassBy<Self>,
         operation: Operation,
-        dest: &'a mut Option<Self::Output>,
+        dest: &'a mut Self::Output,
     ) -> PassBy<'a, Self::Output> {
-        let mut output = A::Output::default();
-        A::copy_into(input.0, &mut output);
-        <A::Output as BitOperations<B>>::operate_assign(&mut output, input.1, operation);
-        <A::Output as BitOperations<C>>::operate_assign(&mut output, input.2, operation);
-        <A::Output as BitOperations<D>>::operate_assign(&mut output, input.3, operation);
-        dest.insert(output).as_by()
+        *dest = A::Output::default();
+        A::copy_into(input.0, dest);
+        <A::Output as BitOperations<B>>::operate_assign(dest, input.1, operation);
+        <A::Output as BitOperations<C>>::operate_assign(dest, input.2, operation);
+        <A::Output as BitOperations<D>>::operate_assign(dest, input.3, operation);
+        dest.as_by()
     }
 }
 
@@ -229,15 +233,15 @@ where
     fn apply<'a>(
         input: PassBy<Self>,
         operation: Operation,
-        dest: &'a mut Option<Self::Output>,
+        dest: &'a mut Self::Output,
     ) -> PassBy<'a, Self::Output> {
-        let mut output = A::Output::default();
-        A::copy_into(input.0, &mut output);
-        <A::Output as BitOperations<B>>::operate_assign(&mut output, input.1, operation);
-        <A::Output as BitOperations<C>>::operate_assign(&mut output, input.2, operation);
-        <A::Output as BitOperations<D>>::operate_assign(&mut output, input.3, operation);
-        <A::Output as BitOperations<E>>::operate_assign(&mut output, input.4, operation);
-        dest.insert(output).as_by()
+        *dest = A::Output::default();
+        A::copy_into(input.0, dest);
+        <A::Output as BitOperations<B>>::operate_assign(dest, input.1, operation);
+        <A::Output as BitOperations<C>>::operate_assign(dest, input.2, operation);
+        <A::Output as BitOperations<D>>::operate_assign(dest, input.3, operation);
+        <A::Output as BitOperations<E>>::operate_assign(dest, input.4, operation);
+        dest.as_by()
     }
 }
 
@@ -260,16 +264,16 @@ where
     fn apply<'a>(
         input: PassBy<Self>,
         operation: Operation,
-        dest: &'a mut Option<Self::Output>,
+        dest: &'a mut Self::Output,
     ) -> PassBy<'a, Self::Output> {
-        let mut output = A::Output::default();
-        A::copy_into(input.0, &mut output);
-        <A::Output as BitOperations<B>>::operate_assign(&mut output, input.1, operation);
-        <A::Output as BitOperations<C>>::operate_assign(&mut output, input.2, operation);
-        <A::Output as BitOperations<D>>::operate_assign(&mut output, input.3, operation);
-        <A::Output as BitOperations<E>>::operate_assign(&mut output, input.4, operation);
-        <A::Output as BitOperations<F>>::operate_assign(&mut output, input.5, operation);
-        dest.insert(output).as_by()
+        *dest = A::Output::default();
+        A::copy_into(input.0, dest);
+        <A::Output as BitOperations<B>>::operate_assign(dest, input.1, operation);
+        <A::Output as BitOperations<C>>::operate_assign(dest, input.2, operation);
+        <A::Output as BitOperations<D>>::operate_assign(dest, input.3, operation);
+        <A::Output as BitOperations<E>>::operate_assign(dest, input.4, operation);
+        <A::Output as BitOperations<F>>::operate_assign(dest, input.5, operation);
+        dest.as_by()
     }
 }
 
@@ -294,17 +298,17 @@ where
     fn apply<'a>(
         input: PassBy<Self>,
         operation: Operation,
-        dest: &'a mut Option<Self::Output>,
+        dest: &'a mut Self::Output,
     ) -> PassBy<'a, Self::Output> {
-        let mut output = A::Output::default();
-        A::copy_into(input.0, &mut output);
-        <A::Output as BitOperations<B>>::operate_assign(&mut output, input.1, operation);
-        <A::Output as BitOperations<C>>::operate_assign(&mut output, input.2, operation);
-        <A::Output as BitOperations<D>>::operate_assign(&mut output, input.3, operation);
-        <A::Output as BitOperations<E>>::operate_assign(&mut output, input.4, operation);
-        <A::Output as BitOperations<F>>::operate_assign(&mut output, input.5, operation);
-        <A::Output as BitOperations<G>>::operate_assign(&mut output, input.6, operation);
-        dest.insert(output).as_by()
+        *dest = A::Output::default();
+        A::copy_into(input.0, dest);
+        <A::Output as BitOperations<B>>::operate_assign(dest, input.1, operation);
+        <A::Output as BitOperations<C>>::operate_assign(dest, input.2, operation);
+        <A::Output as BitOperations<D>>::operate_assign(dest, input.3, operation);
+        <A::Output as BitOperations<E>>::operate_assign(dest, input.4, operation);
+        <A::Output as BitOperations<F>>::operate_assign(dest, input.5, operation);
+        <A::Output as BitOperations<G>>::operate_assign(dest, input.6, operation);
+        dest.as_by()
     }
 }
 
@@ -331,18 +335,18 @@ where
     fn apply<'a>(
         input: PassBy<Self>,
         operation: Operation,
-        dest: &'a mut Option<Self::Output>,
+        dest: &'a mut Self::Output,
     ) -> PassBy<'a, Self::Output> {
-        let mut output = A::Output::default();
-        A::copy_into(input.0, &mut output);
-        <A::Output as BitOperations<B>>::operate_assign(&mut output, input.1, operation);
-        <A::Output as BitOperations<C>>::operate_assign(&mut output, input.2, operation);
-        <A::Output as BitOperations<D>>::operate_assign(&mut output, input.3, operation);
-        <A::Output as BitOperations<E>>::operate_assign(&mut output, input.4, operation);
-        <A::Output as BitOperations<F>>::operate_assign(&mut output, input.5, operation);
-        <A::Output as BitOperations<G>>::operate_assign(&mut output, input.6, operation);
-        <A::Output as BitOperations<H>>::operate_assign(&mut output, input.7, operation);
-        dest.insert(output).as_by()
+        *dest = A::Output::default();
+        A::copy_into(input.0, dest);
+        <A::Output as BitOperations<B>>::operate_assign(dest, input.1, operation);
+        <A::Output as BitOperations<C>>::operate_assign(dest, input.2, operation);
+        <A::Output as BitOperations<D>>::operate_assign(dest, input.3, operation);
+        <A::Output as BitOperations<E>>::operate_assign(dest, input.4, operation);
+        <A::Output as BitOperations<F>>::operate_assign(dest, input.5, operation);
+        <A::Output as BitOperations<G>>::operate_assign(dest, input.6, operation);
+        <A::Output as BitOperations<H>>::operate_assign(dest, input.7, operation);
+        dest.as_by()
     }
 }
 
@@ -356,12 +360,19 @@ mod test {
         ($type:ty) => {
             paste! {
                 #[test]
+                fn [<test_default_buffer_no_panic_ $type>]() {
+                    let block = BitwiseOperatorBlock::<($type, $type)>::default();
+                    assert_eq!(block.buffer(), <$type>::default());
+                }
+
+                #[test]
                 fn [<test_and_scalar_ $type>]() {
                     let mut block = BitwiseOperatorBlock::<($type, $type, $type, $type, $type, $type, $type, $type)>::default();
                     let context = StubContext::default();
                     let params = Operation::And;
                     let output = block.process(&params, &context, ([<255 $type>], [<27 $type>], [<8 $type>], [<27 $type>], [<27 $type>], [<27 $type>], [<27 $type>], [<27 $type>]));
                     assert_eq!(output, [<8 $type>]);
+                    assert_eq!(block.buffer(), output);
                 }
 
                 #[test]

--- a/pictorus-blocks/src/core_blocks/bytes_join_block.rs
+++ b/pictorus-blocks/src/core_blocks/bytes_join_block.rs
@@ -52,6 +52,10 @@ impl<T: Apply> ProcessBlock for BytesJoinBlock<T> {
         self.data.set_bytes(&self.buffer);
         &self.buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        &self.buffer
+    }
 }
 
 pub trait Apply: Pass {
@@ -185,6 +189,12 @@ mod tests {
     use pictorus_traits::Matrix;
 
     #[test]
+    fn test_bytes_join_default_buffer_no_panic() {
+        let block = BytesJoinBlock::<(f64, f64)>::default();
+        assert_eq!(block.buffer(), b"");
+    }
+
+    #[test]
     fn test_bytes_join_block() {
         let ctxt = StubContext::default();
         let params = Parameters::new("/ ");
@@ -213,6 +223,7 @@ mod tests {
         let expected_string = "1.0/ [[1.0,2.0,3.0],[4.0,5.0,6.0]]/ hello there".to_string();
         assert_eq!(res, expected_string.as_bytes());
         assert_eq!(block.data.raw_string(), expected_string);
+        assert_eq!(block.buffer(), expected_string.as_bytes());
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/bytes_literal_block.rs
+++ b/pictorus-blocks/src/core_blocks/bytes_literal_block.rs
@@ -39,6 +39,10 @@ impl<const CHARS: usize> GeneratorBlock for BytesLiteralBlock<CHARS> {
         self.buffer = parameters.value;
         &self.buffer
     }
+
+    fn buffer(&self) -> pictorus_traits::PassBy<'_, Self::Output> {
+        &self.buffer
+    }
 }
 
 #[cfg(test)]
@@ -46,6 +50,12 @@ mod tests {
     use super::*;
 
     use crate::testing::StubContext;
+
+    #[test]
+    fn test_bytes_literal_default_buffer_no_panic() {
+        let block = BytesLiteralBlock::<11>::default();
+        assert_eq!(block.buffer(), &[0u8; 11]);
+    }
 
     #[test]
     fn test_constant_block() {
@@ -56,8 +66,9 @@ mod tests {
         let parameters = Parameters::new(bytes_literal_ic);
         let context = StubContext::default();
 
-        let output = block.generate(&parameters, &context);
+        let output = block.generate(&parameters, &context).to_vec();
         assert_eq!(output, "Hello World".as_bytes());
         assert_eq!(block.data, BlockData::from_bytes("Hello World".as_bytes()));
+        assert_eq!(block.buffer(), output.as_slice());
     }
 }

--- a/pictorus-blocks/src/core_blocks/bytes_pack_block.rs
+++ b/pictorus-blocks/src/core_blocks/bytes_pack_block.rs
@@ -37,6 +37,10 @@ impl<T: Apply> ProcessBlock for BytesPackBlock<T> {
         self.data = OldBlockData::from_bytes(&self.buffer);
         self.buffer.as_slice()
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_slice()
+    }
 }
 
 /// Each input must be assigned a data spec that describes how to pack the input into bytes.
@@ -205,6 +209,12 @@ mod tests {
     use byteorder::WriteBytesExt;
 
     #[test]
+    fn test_bytes_pack_default_buffer_no_panic() {
+        let block = BytesPackBlock::<f64>::default();
+        assert_eq!(block.buffer(), b"");
+    }
+
+    #[test]
     fn test_bytes_pack_block_1_input() {
         let context = StubContext::default();
         let params = Parameters::new(&["I8:BigEndian"]);
@@ -220,6 +230,7 @@ mod tests {
         let output = block.process(&params, &context, inputs);
         assert_eq!(output, expected.as_slice());
         assert_eq!(block.data, OldBlockData::from_bytes(&expected));
+        assert_eq!(block.buffer(), expected.as_slice());
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/bytes_split_block.rs
+++ b/pictorus-blocks/src/core_blocks/bytes_split_block.rs
@@ -19,7 +19,7 @@ use pictorus_traits::{ByteSliceSignal, Pass, PassBy, ProcessBlock};
 /// the block will output false for the "is_valid" output.
 pub struct BytesSplitBlock<T: Apply> {
     pub data: Vec<OldBlockData>,
-    buffer: Option<T::Storage>,
+    buffer: T::Storage,
     last_valid_time: Option<Duration>,
 }
 
@@ -64,7 +64,7 @@ impl<T: Apply> Default for BytesSplitBlock<T> {
     fn default() -> Self {
         Self {
             data: T::default_block_data(),
-            buffer: None,
+            buffer: T::default_storage_value(),
             last_valid_time: None,
         }
     }
@@ -101,8 +101,12 @@ impl<T: Apply> ProcessBlock for BytesSplitBlock<T> {
         if parse_success {
             self.last_valid_time = Some(context.time());
         }
-        self.data = T::build_block_data(self.buffer.as_ref().unwrap());
-        <T as Apply>::storage_as_by(self.buffer.as_ref().unwrap())
+        self.data = T::build_block_data(&self.buffer);
+        <T as Apply>::storage_as_by(&self.buffer)
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        <T as Apply>::storage_as_by(&self.buffer)
     }
 }
 
@@ -158,7 +162,7 @@ pub trait Apply: Pass {
     /// Handles parsing input into the storage type, also manages the is_valid output. Outputs `true` if it was able to parse the input
     /// and `false` if it was not able to parse the input. This is used to update the `last_valid_time` field of the block.
     fn apply(
-        dest: &mut Option<Self::Storage>,
+        dest: &mut Self::Storage,
         input_bytes: &[u8],
         params: &Parameters,
         delim_idxs: &[usize],
@@ -172,7 +176,9 @@ pub trait Apply: Pass {
 
     fn default_block_data() -> Vec<OldBlockData>;
 
-    fn is_valid(storage: &Option<Self::Storage>) -> bool;
+    fn default_storage_value() -> Self::Storage;
+
+    fn is_valid(storage: &Self::Storage) -> bool;
 }
 
 impl<A: FromBytes> Apply for A
@@ -183,14 +189,13 @@ where
     type Output = (A, bool);
 
     fn apply(
-        dest: &mut Option<Self::Storage>,
+        dest: &mut Self::Storage,
         input_bytes: &[u8],
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
         update_age: Duration,
     ) -> bool {
-        let dest = dest.get_or_insert((A::default_storage(), false));
         let parsed_data = parse_bytes::<A>(
             input_bytes,
             delim_idxs,
@@ -218,12 +223,16 @@ where
         ))]
     }
 
+    fn default_storage_value() -> Self::Storage {
+        (A::default_storage(), false)
+    }
+
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (A::from_storage(&storage.0), storage.1)
     }
 
-    fn is_valid(storage: &Option<Self::Storage>) -> bool {
-        storage.as_ref().map(|s| s.1).unwrap_or(false)
+    fn is_valid(storage: &Self::Storage) -> bool {
+        storage.1
     }
 }
 
@@ -236,14 +245,13 @@ where
     type Storage = (A::Storage, B::Storage, bool);
 
     fn apply(
-        dest: &mut Option<Self::Storage>,
+        dest: &mut Self::Storage,
         input_bytes: &[u8],
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
         update_age: Duration,
     ) -> bool {
-        let dest = dest.get_or_insert((A::default_storage(), B::default_storage(), false));
         let parsed_data_a = parse_bytes::<A>(
             input_bytes,
             delim_idxs,
@@ -281,6 +289,10 @@ where
         ]
     }
 
+    fn default_storage_value() -> Self::Storage {
+        (A::default_storage(), B::default_storage(), false)
+    }
+
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (
             A::from_storage(&storage.0),
@@ -288,8 +300,8 @@ where
             storage.2,
         )
     }
-    fn is_valid(storage: &Option<Self::Storage>) -> bool {
-        storage.as_ref().map(|s| s.2).unwrap_or(false)
+    fn is_valid(storage: &Self::Storage) -> bool {
+        storage.2
     }
 }
 
@@ -303,19 +315,13 @@ where
     type Storage = (A::Storage, B::Storage, C::Storage, bool);
 
     fn apply(
-        dest: &mut Option<Self::Storage>,
+        dest: &mut Self::Storage,
         input_bytes: &[u8],
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
         update_age: Duration,
     ) -> bool {
-        let dest = dest.get_or_insert((
-            A::default_storage(),
-            B::default_storage(),
-            C::default_storage(),
-            false,
-        ));
         let parsed_data_a = parse_bytes::<A>(
             input_bytes,
             delim_idxs,
@@ -363,6 +369,15 @@ where
         ]
     }
 
+    fn default_storage_value() -> Self::Storage {
+        (
+            A::default_storage(),
+            B::default_storage(),
+            C::default_storage(),
+            false,
+        )
+    }
+
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (
             A::from_storage(&storage.0),
@@ -371,8 +386,8 @@ where
             storage.3,
         )
     }
-    fn is_valid(storage: &Option<Self::Storage>) -> bool {
-        storage.as_ref().map(|s| s.3).unwrap_or(false)
+    fn is_valid(storage: &Self::Storage) -> bool {
+        storage.3
     }
 }
 
@@ -387,20 +402,13 @@ where
     type Storage = (A::Storage, B::Storage, C::Storage, D::Storage, bool);
 
     fn apply(
-        dest: &mut Option<Self::Storage>,
+        dest: &mut Self::Storage,
         input_bytes: &[u8],
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
         update_age: Duration,
     ) -> bool {
-        let dest = dest.get_or_insert((
-            A::default_storage(),
-            B::default_storage(),
-            C::default_storage(),
-            D::default_storage(),
-            false,
-        ));
         let parsed_data_a = parse_bytes::<A>(
             input_bytes,
             delim_idxs,
@@ -466,6 +474,16 @@ where
         ]
     }
 
+    fn default_storage_value() -> Self::Storage {
+        (
+            A::default_storage(),
+            B::default_storage(),
+            C::default_storage(),
+            D::default_storage(),
+            false,
+        )
+    }
+
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (
             A::from_storage(&storage.0),
@@ -476,8 +494,8 @@ where
         )
     }
 
-    fn is_valid(storage: &Option<Self::Storage>) -> bool {
-        storage.as_ref().map(|s| s.4).unwrap_or(false)
+    fn is_valid(storage: &Self::Storage) -> bool {
+        storage.4
     }
 }
 
@@ -500,21 +518,13 @@ where
     );
 
     fn apply(
-        dest: &mut Option<Self::Storage>,
+        dest: &mut Self::Storage,
         input_bytes: &[u8],
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
         update_age: Duration,
     ) -> bool {
-        let dest = dest.get_or_insert((
-            A::default_storage(),
-            B::default_storage(),
-            C::default_storage(),
-            D::default_storage(),
-            E::default_storage(),
-            false,
-        ));
         let parsed_data_a = parse_bytes::<A>(
             input_bytes,
             delim_idxs,
@@ -595,6 +605,17 @@ where
         ]
     }
 
+    fn default_storage_value() -> Self::Storage {
+        (
+            A::default_storage(),
+            B::default_storage(),
+            C::default_storage(),
+            D::default_storage(),
+            E::default_storage(),
+            false,
+        )
+    }
+
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (
             A::from_storage(&storage.0),
@@ -606,8 +627,8 @@ where
         )
     }
 
-    fn is_valid(storage: &Option<Self::Storage>) -> bool {
-        storage.as_ref().map(|s| s.5).unwrap_or(false)
+    fn is_valid(storage: &Self::Storage) -> bool {
+        storage.5
     }
 }
 
@@ -633,22 +654,13 @@ where
     );
 
     fn apply(
-        dest: &mut Option<Self::Storage>,
+        dest: &mut Self::Storage,
         input_bytes: &[u8],
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
         update_age: Duration,
     ) -> bool {
-        let dest = dest.get_or_insert((
-            A::default_storage(),
-            B::default_storage(),
-            C::default_storage(),
-            D::default_storage(),
-            E::default_storage(),
-            F::default_storage(),
-            false,
-        ));
         let parsed_data_a = parse_bytes::<A>(
             input_bytes,
             delim_idxs,
@@ -740,6 +752,18 @@ where
         ]
     }
 
+    fn default_storage_value() -> Self::Storage {
+        (
+            A::default_storage(),
+            B::default_storage(),
+            C::default_storage(),
+            D::default_storage(),
+            E::default_storage(),
+            F::default_storage(),
+            false,
+        )
+    }
+
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (
             A::from_storage(&storage.0),
@@ -752,8 +776,8 @@ where
         )
     }
 
-    fn is_valid(storage: &Option<Self::Storage>) -> bool {
-        storage.as_ref().map(|s| s.6).unwrap_or(false)
+    fn is_valid(storage: &Self::Storage) -> bool {
+        storage.6
     }
 }
 
@@ -788,23 +812,13 @@ where
     );
 
     fn apply(
-        dest: &mut Option<Self::Storage>,
+        dest: &mut Self::Storage,
         input_bytes: &[u8],
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
         update_age: Duration,
     ) -> bool {
-        let dest = dest.get_or_insert((
-            A::default_storage(),
-            B::default_storage(),
-            C::default_storage(),
-            D::default_storage(),
-            E::default_storage(),
-            F::default_storage(),
-            G::default_storage(),
-            false,
-        ));
         let parsed_data_a = parse_bytes::<A>(
             input_bytes,
             delim_idxs,
@@ -907,6 +921,19 @@ where
         ]
     }
 
+    fn default_storage_value() -> Self::Storage {
+        (
+            A::default_storage(),
+            B::default_storage(),
+            C::default_storage(),
+            D::default_storage(),
+            E::default_storage(),
+            F::default_storage(),
+            G::default_storage(),
+            false,
+        )
+    }
+
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (
             A::from_storage(&storage.0),
@@ -920,8 +947,8 @@ where
         )
     }
 
-    fn is_valid(storage: &Option<Self::Storage>) -> bool {
-        storage.as_ref().map(|s| s.7).unwrap_or(false)
+    fn is_valid(storage: &Self::Storage) -> bool {
+        storage.7
     }
 }
 

--- a/pictorus-blocks/src/core_blocks/bytes_unpack_block.rs
+++ b/pictorus-blocks/src/core_blocks/bytes_unpack_block.rs
@@ -93,6 +93,10 @@ where
             .collect();
         &self.buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        &self.buffer
+    }
 }
 
 impl<const N: usize> IsValid for BytesUnpackBlock<N> {

--- a/pictorus-blocks/src/core_blocks/can_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/can_receive_block.rs
@@ -114,6 +114,10 @@ where
         .expect("parameters.signal_count is shorter than output tuple type");
         self.output_buffer.as_by()
     }
+
+    fn buffer(&self) -> pictorus_traits::PassBy<'_, Self::Output> {
+        self.output_buffer.as_by()
+    }
 }
 
 impl<const N: usize, S: Float, C, O: Pass + Default + ToTupleOutput<S>> IsValid

--- a/pictorus-blocks/src/core_blocks/can_transmit_block.rs
+++ b/pictorus-blocks/src/core_blocks/can_transmit_block.rs
@@ -83,6 +83,10 @@ where
 
         &self.byte_buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        &self.byte_buffer
+    }
 }
 
 // Trait to merge a tuple into a Vec
@@ -213,8 +217,9 @@ mod tests {
             stub_can_parser_callback,
             StubCanParser::new(),
         );
-        let output = block.process(&parameters, &context, 42.0);
+        let output = block.process(&parameters, &context, 42.0).to_vec();
         assert_eq!(output, vec![42, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(block.buffer(), output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/change_detection_block.rs
+++ b/pictorus-blocks/src/core_blocks/change_detection_block.rs
@@ -18,7 +18,7 @@ use strum::EnumString;
 /// so it will always emit `false`
 pub struct ChangeDetectionBlock<T: Apply> {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
     last_input: Option<T>,
 }
 
@@ -28,9 +28,14 @@ where
     OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
+        log::warn!(
+            "ChangeDetectionBlock constructed via Default; IC not seeded. \
+             Prefer ChangeDetectionBlock::new(&parameters) — otherwise buffer() will return \
+             T::default() until the first process() call."
+        );
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
-            buffer: None,
+            buffer: T::Output::default(),
             last_input: None,
         }
     }
@@ -43,7 +48,7 @@ where
 {
     fn new(parameters: &Self::Parameters) -> Self {
         ChangeDetectionBlock::<T> {
-            buffer: Some(T::Output::default()),
+            buffer: T::Output::default(),
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
             last_input: Some(parameters.ic),
         }
@@ -69,13 +74,17 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 pub trait Apply: Pass + Sized + Copy {
     type Output: Pass + Default;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         params: &Parameters<Self>,
         last_input: &mut Option<Self>,
@@ -86,7 +95,7 @@ impl<C: ChangeDetect> Apply for C {
     type Output = f64;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         params: &Parameters<Self>,
         last_input: &mut Option<Self>,
@@ -95,7 +104,7 @@ impl<C: ChangeDetect> Apply for C {
         let old_last_input = last_input.replace(input);
         let old_last_input = old_last_input.unwrap_or(params.ic);
         let res = Self::change_detect(input, old_last_input, params.change_mode);
-        *store = Some(res);
+        *store = res;
         res.as_by()
     }
 }
@@ -104,7 +113,7 @@ impl<const NROWS: usize, const NCOLS: usize, C: ChangeDetect> Apply for Matrix<N
     type Output = Matrix<NROWS, NCOLS, f64>;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         params: &Parameters<Self>,
         last_input: &mut Option<Self>,
@@ -113,7 +122,7 @@ impl<const NROWS: usize, const NCOLS: usize, C: ChangeDetect> Apply for Matrix<N
         let old_last_input = last_input.replace(*input);
         let old_last_input = old_last_input.unwrap_or(params.ic);
         // Initialize Output to a Zeroed (i.e. all `false`) state.
-        let output = store.insert(Matrix::zeroed());
+        *store = Matrix::zeroed();
         // Make a immutable iterator of each element of `input` and `old_last_input`
 
         let inputs = input
@@ -123,7 +132,7 @@ impl<const NROWS: usize, const NCOLS: usize, C: ChangeDetect> Apply for Matrix<N
             .zip(old_last_input.data.as_flattened().iter());
         // Zip that iterator with a mutable iterator over the output matrix
         // and then perform the operation on each set of three values
-        output
+        store
             .data
             .as_flattened_mut()
             .iter_mut()
@@ -131,7 +140,7 @@ impl<const NROWS: usize, const NCOLS: usize, C: ChangeDetect> Apply for Matrix<N
             .for_each(|(output, (lh, rh))| {
                 *output = C::change_detect(*lh, *rh, params.change_mode)
             });
-        output
+        store
     }
 }
 
@@ -432,6 +441,7 @@ mod tests {
         // No change
         let output = block.process(&params, &context, false);
         assert!(output.is_truthy());
+        assert_eq!(block.buffer(), output);
 
         // Falling for all values
         let output = block.process(&params, &context, false);

--- a/pictorus-blocks/src/core_blocks/change_detection_block.rs
+++ b/pictorus-blocks/src/core_blocks/change_detection_block.rs
@@ -28,16 +28,10 @@ where
     OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
-        log::warn!(
-            "ChangeDetectionBlock constructed via Default; IC not seeded. \
-             Prefer ChangeDetectionBlock::new(&parameters) — otherwise buffer() will return \
-             T::default() until the first process() call."
+        panic!(
+            "ChangeDetectionBlock has initial conditions and must be constructed with \
+             ChangeDetectionBlock::new(&parameters) (HasIc trait), not Default::default()."
         );
-        Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
-            buffer: T::Output::default(),
-            last_input: None,
-        }
     }
 }
 
@@ -206,7 +200,7 @@ mod tests {
                 fn [<test_scalar_rising_ $type>]() {
                     let context = StubContext::default();
                     let params = Parameters::new([<1 $type>], "Rising");
-                    let mut block = ChangeDetectionBlock::<$type>::default();
+                    let mut block = ChangeDetectionBlock::<$type>::new(&params);
 
                     // No change - false
                     let output = block.process(&params, &context, [<1 $type>]);
@@ -225,7 +219,7 @@ mod tests {
                 fn [<test_scalar_falling_ $type>]() {
                     let context = StubContext::default();
                     let params = Parameters::new([<1 $type>], "Falling");
-                    let mut block = ChangeDetectionBlock::<$type>::default();
+                    let mut block = ChangeDetectionBlock::<$type>::new(&params);
 
                     // No change - false
                     let output = block.process(&params, &context, [<1 $type>]);
@@ -245,7 +239,7 @@ mod tests {
                 fn [<test_scalar_any_ $type>]() {
                     let context = StubContext::default();
                     let params = Parameters::new([<1 $type>], "Any");
-                    let mut block = ChangeDetectionBlock::<$type>::default();
+                    let mut block = ChangeDetectionBlock::<$type>::new(&params);
 
                     // No change - false
                     let output = block.process(&params, &context, [<1 $type>]);
@@ -279,7 +273,7 @@ mod tests {
                 fn [<test_matrix_falling_ $type>]() {
                     let context = StubContext::default();
                     let params = Parameters::new(Matrix{data: [[[<42 $type>]; 8]; 11],}, "Falling");
-                    let mut block = ChangeDetectionBlock::<Matrix<8, 11, $type>>::default();
+                    let mut block = ChangeDetectionBlock::<Matrix<8, 11, $type>>::new(&params);
 
                     let input = Matrix {
                         data: [[[<42 $type>]; 8]; 11],
@@ -325,7 +319,7 @@ mod tests {
                 fn [<test_matrix_rising_ $type>]() {
                     let context = StubContext::default();
                     let params = Parameters::new(Matrix{data: [[[<42 $type>]; 8]; 11],}, "Rising");
-                    let mut block = ChangeDetectionBlock::<Matrix<8, 11, $type>>::default();
+                    let mut block = ChangeDetectionBlock::<Matrix<8, 11, $type>>::new(&params);
 
                     let input = Matrix {
                         data: [[[<42 $type>]; 8]; 11],
@@ -371,7 +365,7 @@ mod tests {
                 fn [<test_matrix_any_ $type>]() {
                     let context = StubContext::default();
                     let params = Parameters::new(Matrix{data: [[[<42 $type>]; 8]; 11],}, "Any");
-                    let mut block = ChangeDetectionBlock::<Matrix<8, 11, $type>>::default();
+                    let mut block = ChangeDetectionBlock::<Matrix<8, 11, $type>>::new(&params);
 
                     let input = Matrix {
                         data: [[[<42 $type>]; 8]; 11],
@@ -436,7 +430,7 @@ mod tests {
     fn test_scalar_bool_any() {
         let context = StubContext::default();
         let params = Parameters::new(true, "Any");
-        let mut block = ChangeDetectionBlock::<bool>::default();
+        let mut block = ChangeDetectionBlock::<bool>::new(&params);
 
         // No change
         let output = block.process(&params, &context, false);
@@ -456,7 +450,7 @@ mod tests {
     fn test_scalar_bool_rising() {
         let context = StubContext::default();
         let params = Parameters::new(true, "Rising");
-        let mut block = ChangeDetectionBlock::<bool>::default();
+        let mut block = ChangeDetectionBlock::<bool>::new(&params);
 
         // No change
         let output = block.process(&params, &context, true);
@@ -475,7 +469,7 @@ mod tests {
     fn test_scalar_bool_falling() {
         let context = StubContext::default();
         let params = Parameters::new(true, "Falling");
-        let mut block = ChangeDetectionBlock::<bool>::default();
+        let mut block = ChangeDetectionBlock::<bool>::new(&params);
 
         // No change
         let output = block.process(&params, &context, true);

--- a/pictorus-blocks/src/core_blocks/clamp_block.rs
+++ b/pictorus-blocks/src/core_blocks/clamp_block.rs
@@ -20,7 +20,7 @@ impl<T> Parameters<T> {
 /// the input is less than the min value, it will be set to the min value.
 pub struct ClampBlock<T> {
     pub data: OldBlockData,
-    buffer: Option<T>,
+    buffer: T,
 }
 
 impl<T> Default for ClampBlock<T>
@@ -31,7 +31,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
-            buffer: None,
+            buffer: T::default(),
         }
     }
 }
@@ -52,10 +52,13 @@ macro_rules! impl_clamp_block {
                 _context: &dyn pictorus_traits::Context,
                 input: PassBy<Self::Inputs>,
             ) -> PassBy<'_, Self::Output> {
-                let clamp = input.clamp(parameters.min, parameters.max);
-                let output = self.buffer.insert(clamp);
-                self.data = OldBlockData::from_scalar((*output).into());
-                *output
+                self.buffer = input.clamp(parameters.min, parameters.max);
+                self.data = OldBlockData::from_scalar(self.buffer.into());
+                self.buffer
+            }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
             }
         }
 
@@ -74,14 +77,18 @@ macro_rules! impl_clamp_block {
                 _context: &dyn pictorus_traits::Context,
                 input: PassBy<Self::Inputs>,
             ) -> PassBy<'_, Self::Output> {
-                let output = self.buffer.insert(Matrix::zeroed());
                 for r in 0..ROWS {
                     for c in 0..COLS {
-                        output.data[c][r] = input.data[c][r].clamp(parameters.min, parameters.max);
+                        self.buffer.data[c][r] =
+                            input.data[c][r].clamp(parameters.min, parameters.max);
                     }
                 }
-                self.data = OldBlockData::from_pass(output);
-                output
+                self.data = OldBlockData::from_pass(&self.buffer);
+                &self.buffer
+            }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
             }
         }
     };
@@ -106,6 +113,15 @@ mod test {
     use super::*;
 
     #[test]
+    fn test_clamp_default_buffer_no_panic() {
+        let block = ClampBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = ClampBlock::<Matrix<2, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
+    }
+
+    #[test]
     fn test_clamp_block_original() {
         let c = StubContext::default();
         let lower_limit: f64 = -1.5;
@@ -114,17 +130,18 @@ mod test {
         let mut block = ClampBlock::<Matrix<1, 4, f64>>::default();
         let p = Parameters::new(lower_limit, upper_limit);
 
-        let output = block.process(&p, &c, &input.to_pass());
+        let output = *block.process(&p, &c, &input.to_pass());
         assert_eq!(
             output,
-            &Matrix {
+            Matrix {
                 data: [[-0.5], [-0.5], [-1.2345], [-1.5]]
             }
         );
         assert_eq!(
             block.data,
             OldBlockData::from_matrix(&[&[-0.5, -0.5, -1.2345, -1.5]])
-        )
+        );
+        assert_eq!(block.buffer(), &output);
     }
 
     macro_rules! impl_clamp_block_test_negatives {

--- a/pictorus-blocks/src/core_blocks/compare_to_value_block.rs
+++ b/pictorus-blocks/src/core_blocks/compare_to_value_block.rs
@@ -29,7 +29,7 @@ where
 /// The output is the same size as the input and each element is the result of the comparison.
 pub struct CompareToValueBlock<T: Pass> {
     pub data: OldBlockData,
-    buffer: Option<T>,
+    buffer: T,
 }
 
 impl<T> Default for CompareToValueBlock<T>
@@ -40,7 +40,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
-            buffer: None,
+            buffer: T::default(),
         }
     }
 }
@@ -69,9 +69,13 @@ macro_rules! impl_compare_to_value_block {
                     ComparisonType::GreaterThan => input > parameters.value,
                     ComparisonType::GreaterOrEqual => input >= parameters.value,
                 };
-                let output = self.buffer.insert(val.into());
-                self.data = OldBlockData::from_scalar((*output).into());
-                *output
+                self.buffer = val.into();
+                self.data = OldBlockData::from_scalar(self.buffer.into());
+                self.buffer
+            }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
             }
         }
 
@@ -90,7 +94,6 @@ macro_rules! impl_compare_to_value_block {
                 _context: &dyn pictorus_traits::Context,
                 input: PassBy<Self::Inputs>,
             ) -> PassBy<'_, Self::Output> {
-                let mut b = Matrix::<ROWS, COLS, $type>::zeroed();
                 for r in 0..ROWS {
                     for c in 0..COLS {
                         let val = match parameters.comparison_type {
@@ -101,12 +104,15 @@ macro_rules! impl_compare_to_value_block {
                             ComparisonType::GreaterThan => input.data[c][r] > parameters.value,
                             ComparisonType::GreaterOrEqual => input.data[c][r] >= parameters.value,
                         };
-                        b.data[c][r] = val.into();
+                        self.buffer.data[c][r] = val.into();
                     }
                 }
-                let output = self.buffer.insert(b);
-                self.data = OldBlockData::from_pass(output);
-                output
+                self.data = OldBlockData::from_pass(&self.buffer);
+                &self.buffer
+            }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
             }
         }
     };
@@ -128,6 +134,15 @@ mod tests {
     use num_traits::{One, Zero};
     use paste::paste;
 
+    #[test]
+    fn test_compare_to_value_default_buffer_no_panic() {
+        let block = CompareToValueBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = CompareToValueBlock::<Matrix<2, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
+    }
+
     macro_rules! test_compare_to_value {
         ($name:ident, $type:ty) => {
             paste! {
@@ -144,6 +159,7 @@ mod tests {
                     let output = block.process(&parameters, &context, <$type>::one());
                     assert_eq!(output, <$type>::one());
                     assert_eq!(block.data.scalar(), <$type>::one().into());
+                    assert_eq!(block.buffer(), output);
 
                     parameters.comparison_type = ComparisonType::NotEqual;
                     let output = block.process(&parameters, &context, <$type>::zero());

--- a/pictorus-blocks/src/core_blocks/comparison_block.rs
+++ b/pictorus-blocks/src/core_blocks/comparison_block.rs
@@ -49,7 +49,7 @@ where
     OldBlockData: FromPass<<T as Apply<Parameters>>::Output>,
 {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
 }
 
 impl<T> Default for ComparisonBlock<T>
@@ -60,7 +60,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
-            buffer: None,
+            buffer: T::Output::default(),
         }
     }
 }
@@ -80,10 +80,15 @@ where
         _context: &dyn pictorus_traits::Context,
         inputs: PassBy<Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
-        self.buffer = None;
-        T::apply(inputs, parameters, &mut self.buffer);
-        self.data = OldBlockData::from_pass(self.buffer.as_ref().unwrap().as_by());
-        self.buffer.as_ref().unwrap().as_by()
+        let mut tmp: Option<T::Output> = None;
+        T::apply(inputs, parameters, &mut tmp);
+        self.buffer = tmp.expect("apply must initialize the buffer");
+        self.data = OldBlockData::from_pass(self.buffer.as_by());
+        self.buffer.as_by()
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
     }
 }
 
@@ -191,6 +196,15 @@ mod tests {
     use crate::testing::StubContext;
 
     #[test]
+    fn test_comparison_default_buffer_no_panic() {
+        let block = ComparisonBlock::<(f64, f64)>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = ComparisonBlock::<(Matrix<2, 2, f64>, Matrix<2, 2, f64>)>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
+    }
+
+    #[test]
     fn test_comparison_type() {
         assert_eq!(
             ComparisonType::from_str("Equal").unwrap(),
@@ -224,6 +238,7 @@ mod tests {
         let mut block = ComparisonBlock::<(f64, f64)>::default();
         let output = block.process(&Parameters::new("Equal"), &c, (1., 1.));
         assert_eq!(output, 1.0);
+        assert_eq!(block.buffer(), output);
 
         let output = block.process(&Parameters::new("Equal"), &c, (0., 1.));
         assert_eq!(output, 0.0);

--- a/pictorus-blocks/src/core_blocks/constant_block.rs
+++ b/pictorus-blocks/src/core_blocks/constant_block.rs
@@ -17,7 +17,7 @@ where
     T: Apply,
 {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
 }
 
 impl<T> Default for ConstantBlock<T>
@@ -27,7 +27,7 @@ where
 {
     fn default() -> Self {
         Self {
-            buffer: None,
+            buffer: <T::Output>::default(),
             data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
         }
     }
@@ -50,13 +50,17 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 pub trait Apply: Pass + Sized {
     type Output: Pass + Default;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         parameters: &Parameters<Self>,
     ) -> PassBy<'s, Self::Output>;
 }
@@ -65,10 +69,10 @@ impl Apply for f64 {
     type Output = f64;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         parameters: &Parameters<Self>,
     ) -> PassBy<'s, Self::Output> {
-        *store = Some(parameters.constant);
+        *store = parameters.constant;
         parameters.constant
     }
 }
@@ -80,12 +84,11 @@ where
     type Output = Matrix<NROWS, NCOLS, T>;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         parameters: &Parameters<Self>,
     ) -> PassBy<'s, Self::Output> {
-        let output = store.insert(Matrix::zeroed());
-        *output = parameters.constant;
-        output
+        *store = parameters.constant;
+        store
     }
 }
 
@@ -96,6 +99,15 @@ mod tests {
     use pictorus_block_data::{BlockData, ToPass};
 
     #[test]
+    fn test_constant_default_buffer_no_panic() {
+        let block = ConstantBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = ConstantBlock::<Matrix<2, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
+    }
+
+    #[test]
     fn test_constant_scalar() {
         let mut block = ConstantBlock::<f64>::default();
         let parameters = Parameters::new(3.0);
@@ -104,6 +116,7 @@ mod tests {
         let output = block.generate(&parameters, &context);
         assert_eq!(output, 3.0);
         assert_eq!(block.data, BlockData::from_scalar(3.0));
+        assert_eq!(block.buffer(), output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/counter_block.rs
+++ b/pictorus-blocks/src/core_blocks/counter_block.rs
@@ -52,6 +52,10 @@ where
     ) -> PassBy<'b, Self::Output> {
         T::apply(&mut self.counter, inputs)
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.counter.as_by()
+    }
 }
 
 impl<T: Apply> Default for CounterBlock<T>
@@ -127,6 +131,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_counter_default_buffer_no_panic() {
+        let block = CounterBlock::<(Matrix<1, 1, bool>, Matrix<1, 1, bool>)>::default();
+        assert_eq!(block.buffer(), &Matrix::<1, 1, f64>::zeroed());
+    }
+
+    #[test]
     fn test_counter_block_simple_f64() {
         let p = Parameters::new();
         let mut block = CounterBlock::<(Matrix<1, 1, bool>, Matrix<1, 1, bool>)>::default();
@@ -138,8 +148,9 @@ mod tests {
         let mut reset = Matrix::<1, 1, bool>::zeroed();
         reset.data[0][0] = false;
 
-        let output = block.process(&p, &c, (&increment, &reset));
+        let output = *block.process(&p, &c, (&increment, &reset));
         assert!(output.data[0][0] == 1.0);
+        assert_eq!(block.buffer(), &output);
 
         let output = block.process(&p, &c, (&increment, &reset));
         assert!(output.data[0][0] == 2.0);

--- a/pictorus-blocks/src/core_blocks/cross_product_block.rs
+++ b/pictorus-blocks/src/core_blocks/cross_product_block.rs
@@ -24,7 +24,7 @@ where
     T: Apply + Pass + Default,
 {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
 }
 
 impl<T> Default for CrossProductBlock<T>
@@ -35,7 +35,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
-            buffer: None,
+            buffer: T::Output::default(),
         }
     }
 }
@@ -59,15 +59,17 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 pub trait Apply: Pass + Sized {
     type Output: Pass + Default;
 
-    fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
-        inputs: PassBy<'_, Self>,
-    ) -> PassBy<'s, Self::Output>;
+    fn apply<'s>(store: &'s mut Self::Output, inputs: PassBy<'_, Self>)
+        -> PassBy<'s, Self::Output>;
 }
 
 macro_rules! float_matrix_impl {
@@ -76,12 +78,12 @@ macro_rules! float_matrix_impl {
             type Output = Matrix<1, 3, $type>;
 
             fn apply<'s>(
-                store: &'s mut Option<Self::Output>,
+                store: &'s mut Self::Output,
                 inputs: PassBy<'_, Self>,
             ) -> PassBy<'s, Self::Output> {
                 let cross = inputs.0.as_view().cross(&inputs.1.as_view());
-                let output = store.insert(Matrix::<1, 3, $type>::from_view(&cross.as_view()));
-                output
+                *store = Matrix::<1, 3, $type>::from_view(&cross.as_view());
+                store
             }
         }
 
@@ -89,12 +91,12 @@ macro_rules! float_matrix_impl {
             type Output = Matrix<3, 1, $type>;
 
             fn apply<'s>(
-                store: &'s mut Option<Self::Output>,
+                store: &'s mut Self::Output,
                 inputs: PassBy<'_, Self>,
             ) -> PassBy<'s, Self::Output> {
                 let cross = inputs.0.as_view().cross(&inputs.1.as_view());
-                let output = store.insert(Matrix::<3, 1, $type>::from_view(&cross.as_view()));
-                output
+                *store = Matrix::<3, 1, $type>::from_view(&cross.as_view());
+                store
             }
         }
     };
@@ -111,6 +113,12 @@ mod tests {
     use pictorus_traits::ProcessBlock;
 
     use super::*;
+
+    #[test]
+    fn test_cross_product_default_buffer_no_panic() {
+        let block = CrossProductBlock::<(Matrix<1, 3, f64>, Matrix<1, 3, f64>)>::default();
+        assert_eq!(block.buffer(), &Matrix::<1, 3, f64>::zeroed());
+    }
 
     #[test]
     fn test_vector_cross_f64_blockdata_1x3() {
@@ -156,8 +164,9 @@ mod tests {
         let input2: Matrix<1, 3, f64> = Matrix {
             data: [[0.0], [1.0], [0.0]],
         };
-        let output = cross_block.process(&p, &context, (&input1, &input2));
+        let output = *cross_block.process(&p, &context, (&input1, &input2));
         assert_eq!(output.data, [[0.0], [0.0], [1.0]]);
+        assert_eq!(cross_block.buffer(), &output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/dac_block.rs
+++ b/pictorus-blocks/src/core_blocks/dac_block.rs
@@ -22,7 +22,7 @@ impl Parameters {
 /// Buffer data to be sent to a DAC (Digital-to-Analog Converter).
 pub struct DacBlock<O: Pass> {
     pub data: OldBlockData,
-    buffer: Option<O>,
+    buffer: O,
 }
 
 impl<O> Default for DacBlock<O>
@@ -33,7 +33,7 @@ where
     fn default() -> Self {
         DacBlock {
             data: <OldBlockData as FromPass<O>>::from_pass(<O>::default().as_by()),
-            buffer: None,
+            buffer: O::default(),
         }
     }
 }
@@ -53,9 +53,13 @@ where
         _context: &dyn Context,
         input: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
-        let output = self.buffer.insert(*input);
-        self.data = OldBlockData::from_pass(output);
-        output
+        self.buffer = *input;
+        self.data = OldBlockData::from_pass(&self.buffer);
+        &self.buffer
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
     }
 }
 
@@ -65,11 +69,18 @@ mod tests {
     use crate::testing::StubContext;
 
     #[test]
+    fn test_dac_default_buffer_no_panic() {
+        let block = DacBlock::<Matrix<1, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<1, 2, f64>::zeroed());
+    }
+
+    #[test]
     fn test_dac_block() {
         let mut dac_block = DacBlock::<Matrix<1, 2, f64>>::default();
         let context = StubContext::default();
         let output =
-            dac_block.process(&Parameters::new(), &context, &Matrix { data: [[1.], [2.]] });
+            *dac_block.process(&Parameters::new(), &context, &Matrix { data: [[1.], [2.]] });
         assert_eq!(output.data, [[1.], [2.]]);
+        assert_eq!(dac_block.buffer(), &output);
     }
 }

--- a/pictorus-blocks/src/core_blocks/deadband_block.rs
+++ b/pictorus-blocks/src/core_blocks/deadband_block.rs
@@ -24,7 +24,7 @@ impl<T> Parameters<T> {
 /// If the input is within the deadband, the output is zero. Otherwise, the input value is passed through.
 pub struct DeadbandBlock<T> {
     pub data: OldBlockData,
-    buffer: Option<T>,
+    buffer: T,
 }
 
 impl<T> Default for DeadbandBlock<T>
@@ -35,7 +35,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
-            buffer: None,
+            buffer: T::default(),
         }
     }
 }
@@ -58,9 +58,13 @@ macro_rules! impl_deadband_block {
             ) -> PassBy<'_, Self::Output> {
                 let in_deadband = input < parameters.upper_limit && input > parameters.lower_limit;
                 let res = if in_deadband { 0.0 } else { input };
-                let output = self.buffer.insert(res);
+                self.buffer = res;
                 self.data = OldBlockData::from_scalar(res.into());
-                *output
+                self.buffer
+            }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
             }
         }
 
@@ -79,13 +83,17 @@ macro_rules! impl_deadband_block {
                 _context: &dyn pictorus_traits::Context,
                 input: PassBy<Self::Inputs>,
             ) -> PassBy<'_, Self::Output> {
-                let output = self.buffer.insert(Matrix::zeroed());
+                self.buffer = Matrix::zeroed();
                 input.for_each(|v, c, r| {
                     let in_deadband = v < parameters.upper_limit && v > parameters.lower_limit;
-                    output.data[c][r] = if in_deadband { 0.0 } else { v };
+                    self.buffer.data[c][r] = if in_deadband { 0.0 } else { v };
                 });
-                self.data = OldBlockData::from_pass(output);
-                output
+                self.data = OldBlockData::from_pass(&self.buffer);
+                &self.buffer
+            }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
             }
         }
     };
@@ -100,6 +108,15 @@ mod tests {
     use crate::testing::StubContext;
     use paste::paste;
 
+    #[test]
+    fn test_deadband_default_buffer_no_panic() {
+        let block = DeadbandBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = DeadbandBlock::<Matrix<2, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
+    }
+
     macro_rules! test_deadband_block {
         ($type:ty) => {
             paste! {
@@ -113,6 +130,7 @@ mod tests {
                     let input = -1.0;
                     let output = block.process(&parameters, &ctxt, input);
                     assert_eq!(output, -1.0);
+                    assert_eq!(block.buffer(), output);
 
                     let input = 1.0;
                     let output = block.process(&parameters, &ctxt, input);

--- a/pictorus-blocks/src/core_blocks/delay_block.rs
+++ b/pictorus-blocks/src/core_blocks/delay_block.rs
@@ -1,5 +1,5 @@
 use pictorus_block_data::{BlockData as OldBlockData, FromPass};
-use pictorus_traits::{HasIc, Pass, ProcessBlock};
+use pictorus_traits::{HasIc, Pass, PassBy, ProcessBlock};
 
 use crate::traits::CopyInto;
 
@@ -34,6 +34,11 @@ where
     pictorus_block_data::BlockData: FromPass<T>,
 {
     fn default() -> Self {
+        log::warn!(
+            "DelayBlock constructed via Default; IC not seeded. \
+             Prefer DelayBlock::new(&parameters) — otherwise buffer() will return \
+             T::default() until the first process() call."
+        );
         Self {
             samples: [T::default(); N],
             initial_accumulation: true,
@@ -94,6 +99,10 @@ where
         self.data = OldBlockData::from_pass(self.output.as_by());
         self.output.as_by()
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.output.as_by()
+    }
 }
 
 pub struct Parameters<T: Pass + Default + Copy> {
@@ -124,6 +133,7 @@ mod tests {
 
         // Initial condition should be output until N samples are received
         assert_eq!(block.process(&parameters, &context, 1.0), 0.0);
+        assert_eq!(block.buffer(), 0.0);
         assert_eq!(block.process(&parameters, &context, 2.0), 0.0);
         assert_eq!(block.process(&parameters, &context, 3.0), 0.0);
         assert_eq!(block.process(&parameters, &context, 4.0), 1.0);

--- a/pictorus-blocks/src/core_blocks/delay_block.rs
+++ b/pictorus-blocks/src/core_blocks/delay_block.rs
@@ -21,11 +21,13 @@ where
 {
     /// Constructs a new DelayBlock with the initial conditions from the parameters so that its output will be in a valid state before its first call to process.
     fn new(parameters: &Self::Parameters) -> Self {
-        let mut output = Self::default();
-        // Only setting the output and data fields here. After process has been called once the fields will be set with the IC on subsequent calls until N samples have been received.
-        T::copy_into(parameters.ic.as_by(), &mut output.output);
-        output.data = OldBlockData::from_pass(parameters.ic.as_by());
-        output
+        Self {
+            samples: [T::default(); N],
+            sample_index: 0,
+            initial_accumulation: true,
+            output: parameters.ic,
+            data: OldBlockData::from_pass(parameters.ic.as_by()),
+        }
     }
 }
 

--- a/pictorus-blocks/src/core_blocks/delay_block.rs
+++ b/pictorus-blocks/src/core_blocks/delay_block.rs
@@ -36,18 +36,10 @@ where
     pictorus_block_data::BlockData: FromPass<T>,
 {
     fn default() -> Self {
-        log::warn!(
-            "DelayBlock constructed via Default; IC not seeded. \
-             Prefer DelayBlock::new(&parameters) — otherwise buffer() will return \
-             T::default() until the first process() call."
+        panic!(
+            "DelayBlock has initial conditions and must be constructed with \
+             DelayBlock::new(&parameters) (HasIc trait), not Default::default()."
         );
-        Self {
-            samples: [T::default(); N],
-            initial_accumulation: true,
-            output: T::default(),
-            sample_index: 0,
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
-        }
     }
 }
 
@@ -126,11 +118,11 @@ mod tests {
 
     #[test]
     fn test_delay_block_scalar() {
-        let mut block = DelayBlock::<f64, 3>::default();
         let parameters = Parameters {
             ic: 0.0,
             is_delayed: false,
         };
+        let mut block = DelayBlock::<f64, 3>::new(&parameters);
         let context = StubContext::default();
 
         // Initial condition should be output until N samples are received
@@ -159,11 +151,11 @@ mod tests {
 
     #[test]
     fn test_delay_block_with_delayed_input() {
-        let mut block = DelayBlock::<f64, 3>::default();
         let parameters = Parameters {
             ic: 0.0,
             is_delayed: true,
         };
+        let mut block = DelayBlock::<f64, 3>::new(&parameters);
         let context = StubContext::default();
 
         // Initial condition should be output until N samples are received
@@ -177,13 +169,13 @@ mod tests {
 
     #[test]
     fn test_delay_block_matrix() {
-        let mut block = DelayBlock::<Matrix<2, 2, f64>, 3>::default();
         let parameters = Parameters {
             ic: Matrix {
                 data: [[0.0, 0.0], [0.0, 0.0]],
             },
             is_delayed: false,
         };
+        let mut block = DelayBlock::<Matrix<2, 2, f64>, 3>::new(&parameters);
         let context = StubContext::default();
 
         // Initial condition should be output until N samples are received
@@ -263,11 +255,11 @@ mod tests {
 
     #[test]
     fn test_delay_block_scalar_ics() {
-        let mut block = DelayBlock::<f64, 6>::default();
         let parameters = Parameters {
             ic: 42.0,
             is_delayed: false,
         };
+        let mut block = DelayBlock::<f64, 6>::new(&parameters);
         let context = StubContext::default();
 
         // Initial condition should be output until N samples are received

--- a/pictorus-blocks/src/core_blocks/delay_control_block.rs
+++ b/pictorus-blocks/src/core_blocks/delay_control_block.rs
@@ -12,7 +12,7 @@ use pictorus_traits::{Context, Matrix, Pass, PassBy, ProcessBlock};
 ///  - Throttle: Immediately emit true on first true input, but then wait delay_time before passing through a true input again.
 pub struct DelayControlBlock<T: Apply> {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
     /// This is the state of the block used for the debounce and throttle functionality
     state: T::State,
 }
@@ -24,7 +24,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
-            buffer: None,
+            buffer: T::Output::default(),
             state: T::init_state(),
         }
     }
@@ -44,10 +44,19 @@ where
         context: &dyn Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
-        let buffer = self.buffer.get_or_insert(T::Output::default());
-        let output = T::apply(buffer, inputs, &mut self.state, parameters, context);
+        let output = T::apply(
+            &mut self.buffer,
+            inputs,
+            &mut self.state,
+            parameters,
+            context,
+        );
         self.data = <OldBlockData as FromPass<T::Output>>::from_pass(output);
         output
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
     }
 }
 
@@ -220,6 +229,15 @@ mod tests {
     use crate::testing::StubRuntime;
 
     #[test]
+    fn test_delay_control_default_buffer_no_panic() {
+        let block = DelayControlBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = DelayControlBlock::<Matrix<2, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
+    }
+
+    #[test]
     fn test_scalar_throttle() {
         let mut runtime = StubRuntime::default(); // Time is 0 timestep is 100ms
         let mut block = DelayControlBlock::<f64>::default();
@@ -228,6 +246,7 @@ mod tests {
         let output = block.process(&parameters, &runtime.context(), 0.0);
         assert!(!output.is_truthy());
         assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), output);
 
         runtime.tick(); // Time is 100ms
         let output = block.process(&parameters, &runtime.context(), 0.5);

--- a/pictorus-blocks/src/core_blocks/derivative_block.rs
+++ b/pictorus-blocks/src/core_blocks/derivative_block.rs
@@ -21,18 +21,10 @@ where
     pictorus_block_data::BlockData: FromPass<T>,
 {
     fn default() -> Self {
-        log::warn!(
-            "DerivativeBlock constructed via Default; IC not seeded. \
-             Prefer DerivativeBlock::new(&parameters) — otherwise buffer() will return \
-             T::default() until the first process() call."
+        panic!(
+            "DerivativeBlock has initial conditions and must be constructed with \
+             DerivativeBlock::new(&parameters) (HasIc trait), not Default::default()."
         );
-        Self {
-            samples: [T::default(); N],
-            sample_index: 0,
-            initial_accumulation: true,
-            output: T::default(),
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
-        }
     }
 }
 
@@ -167,10 +159,10 @@ mod tests {
 
     #[test]
     fn test_scalar() {
-        let mut block = DerivativeBlock::<f64, 2>::default();
         let mut runtime = StubRuntime::default();
         runtime.context.fundamental_timestep = Duration::from_secs(1);
         let parameters = Parameters::new(0.0);
+        let mut block = DerivativeBlock::<f64, 2>::new(&parameters);
 
         let input = 1.0;
         let output = block.process(&parameters, &runtime.context(), input);
@@ -194,10 +186,10 @@ mod tests {
 
     #[test]
     fn test_matrix() {
-        let mut block = DerivativeBlock::<Matrix<2, 2, f32>, 2>::default();
         let mut runtime = StubRuntime::default();
         runtime.context.fundamental_timestep = Duration::from_secs(1);
         let parameters = Parameters::new(Matrix::zeroed());
+        let mut block = DerivativeBlock::<Matrix<2, 2, f32>, 2>::new(&parameters);
 
         let input = Matrix {
             data: [[1.0, 2.0], [3.0, 4.0]],

--- a/pictorus-blocks/src/core_blocks/derivative_block.rs
+++ b/pictorus-blocks/src/core_blocks/derivative_block.rs
@@ -21,6 +21,11 @@ where
     pictorus_block_data::BlockData: FromPass<T>,
 {
     fn default() -> Self {
+        log::warn!(
+            "DerivativeBlock constructed via Default; IC not seeded. \
+             Prefer DerivativeBlock::new(&parameters) — otherwise buffer() will return \
+             T::default() until the first process() call."
+        );
         Self {
             samples: [T::default(); N],
             sample_index: 0,
@@ -65,6 +70,10 @@ macro_rules! impl_process {
                 self.data = <OldBlockData as FromPass<$type>>::from_pass(self.output);
                 self.output.as_by()
             }
+
+            fn buffer(&self) -> pictorus_traits::PassBy<'_, Self::Output> {
+                self.output.as_by()
+            }
         }
 
         impl<const N: usize> HasIc for DerivativeBlock<$type, N>
@@ -79,7 +88,6 @@ macro_rules! impl_process {
                 }
             }
         }
-
 
         impl<const N: usize, const NCOLS: usize, const NROWS: usize> ProcessBlock for DerivativeBlock< Matrix<NROWS, NCOLS, $type>, N>
         {
@@ -114,6 +122,10 @@ macro_rules! impl_process {
                 self.data = <OldBlockData as FromPass<Matrix<NROWS, NCOLS, $type>>>::from_pass(self.output.as_by());
                 &self.output
             }
+
+            fn buffer(&self) -> pictorus_traits::PassBy<'_, Self::Output> {
+                self.output.as_by()
+            }
         }
 
         impl<const N: usize, const NCOLS: usize, const NROWS: usize> HasIc for DerivativeBlock<Matrix<NROWS, NCOLS, $type>, N>
@@ -128,9 +140,6 @@ macro_rules! impl_process {
                 }
             }
         }
-
-
-
     }
     };
 }

--- a/pictorus-blocks/src/core_blocks/determinant_block.rs
+++ b/pictorus-blocks/src/core_blocks/determinant_block.rs
@@ -60,6 +60,10 @@ macro_rules! impl_determinant_block {
                 self.data = OldBlockData::from_scalar(self.buffer.into());
                 self.buffer
             }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
+            }
         }
 
         impl ProcessBlock for DeterminantBlock<$type, $type>
@@ -80,6 +84,10 @@ macro_rules! impl_determinant_block {
                 self.data = OldBlockData::from_scalar(self.buffer.into());
                 self.buffer
             }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
+            }
         }
     };
 }
@@ -93,6 +101,12 @@ mod tests {
     use crate::testing::StubContext;
     use paste::paste;
     use pictorus_block_data::BlockDataType;
+
+    #[test]
+    fn test_determinant_default_buffer_no_panic() {
+        let block = DeterminantBlock::<f64, Matrix<2, 2, f64>>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
 
     macro_rules! impl_determinant_tests {
         ($type:ty) => {
@@ -111,6 +125,7 @@ mod tests {
                     assert!(output == -2.0);
                     assert!(det_block.data.scalar() == -2.0);
                     assert!(det_block.data.get_type() == BlockDataType::Scalar);
+                    assert_eq!(det_block.buffer(), output);
 
                     let mut det_block_3x3 = DeterminantBlock::<$type, Matrix<3, 3, $type>>::default();
                     let input_3x3 = Matrix {

--- a/pictorus-blocks/src/core_blocks/dot_product_block.rs
+++ b/pictorus-blocks/src/core_blocks/dot_product_block.rs
@@ -7,7 +7,7 @@ use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Calculate the dot product of two same-sized vectors.
 pub struct DotProductBlock<T: Apply> {
-    buffer: Option<T::Output>,
+    buffer: T::Output,
     pub data: OldBlockData,
 }
 
@@ -19,7 +19,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
-            buffer: None,
+            buffer: T::Output::default(),
         }
     }
 }
@@ -43,15 +43,16 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 pub trait Apply: Pass {
     type Output: Pass + Default;
 
-    fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
-        input: PassBy<Self>,
-    ) -> PassBy<'s, Self::Output>;
+    fn apply<'s>(store: &'s mut Self::Output, input: PassBy<Self>) -> PassBy<'s, Self::Output>;
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -70,13 +71,10 @@ where
 {
     type Output = T;
 
-    fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
-        input: PassBy<Self>,
-    ) -> PassBy<'s, Self::Output> {
+    fn apply<'s>(store: &'s mut Self::Output, input: PassBy<Self>) -> PassBy<'s, Self::Output> {
         let (lhs, rhs) = input;
         let output = lhs.as_view().dot(&rhs.as_view());
-        *store = Some(output);
+        *store = output;
         output
     }
 }
@@ -88,6 +86,12 @@ mod tests {
     use crate::traits::MatrixOps;
 
     #[test]
+    fn test_dot_product_default_buffer_no_panic() {
+        let block = DotProductBlock::<(Matrix<2, 1, f64>, Matrix<2, 1, f64>)>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_dot_product_block() {
         let mut block = DotProductBlock::<(Matrix<2, 1, f64>, Matrix<2, 1, f64>)>::default();
         let context = StubContext::default();
@@ -95,6 +99,7 @@ mod tests {
         let input = (&Matrix::from_element(2.0), &Matrix::from_element(6.0));
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, 24.0);
+        assert_eq!(block.buffer(), output);
 
         let mut block = DotProductBlock::<(Matrix<1, 2, u16>, Matrix<1, 2, u16>)>::default();
         let context = StubContext::default();

--- a/pictorus-blocks/src/core_blocks/exponent_block.rs
+++ b/pictorus-blocks/src/core_blocks/exponent_block.rs
@@ -17,7 +17,7 @@ use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 #[derive(Debug)]
 pub struct ExponentBlock<T: Pass + Default> {
     pub data: OldBlockData,
-    output: Option<T>,
+    output: T,
 }
 
 impl<T: Pass + Default> Default for ExponentBlock<T>
@@ -27,7 +27,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
-            output: None,
+            output: T::default(),
         }
     }
 }
@@ -54,17 +54,19 @@ where
                 inputs_local = inputs_local.abs();
             }
         }
-        let output = self
-            .output
-            .insert(inputs_local.powf(parameters.coefficient));
+        self.output = inputs_local.powf(parameters.coefficient);
         if parameters.preserve_sign {
-            let should_flip_sign = (*output < S::zero()) != (inputs < S::zero());
+            let should_flip_sign = (self.output < S::zero()) != (inputs < S::zero());
             if should_flip_sign {
-                *output = output.neg();
+                self.output = self.output.neg();
             };
         }
-        self.data = OldBlockData::from_pass(*output);
-        *output
+        self.data = OldBlockData::from_pass(self.output);
+        self.output
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.output.as_by()
     }
 }
 
@@ -83,27 +85,35 @@ where
         _context: &dyn pictorus_traits::Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
-        let output = self.output.insert(*inputs);
-        output.data.as_flattened_mut().iter_mut().for_each(|x| {
-            let mut x_local = *x;
-            if (x_local < S::zero()) && (parameters.coefficient < S::one()) {
-                if !parameters.preserve_sign {
-                    panic!("Negative input to Exponent with coefficient < 1.0!");
-                } else {
-                    x_local = x_local.abs();
+        self.output = *inputs;
+        self.output
+            .data
+            .as_flattened_mut()
+            .iter_mut()
+            .for_each(|x| {
+                let mut x_local = *x;
+                if (x_local < S::zero()) && (parameters.coefficient < S::one()) {
+                    if !parameters.preserve_sign {
+                        panic!("Negative input to Exponent with coefficient < 1.0!");
+                    } else {
+                        x_local = x_local.abs();
+                    }
                 }
-            }
-            x_local = x_local.powf(parameters.coefficient);
-            if parameters.preserve_sign {
-                let should_flip_sign = (x_local < S::zero()) != (*x < S::zero());
-                if should_flip_sign {
-                    x_local = x_local.neg();
-                };
-            }
-            *x = x_local;
-        });
-        self.data = OldBlockData::from_pass(output);
-        output
+                x_local = x_local.powf(parameters.coefficient);
+                if parameters.preserve_sign {
+                    let should_flip_sign = (x_local < S::zero()) != (*x < S::zero());
+                    if should_flip_sign {
+                        x_local = x_local.neg();
+                    };
+                }
+                *x = x_local;
+            });
+        self.data = OldBlockData::from_pass(&self.output);
+        &self.output
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.output.as_by()
     }
 }
 
@@ -135,6 +145,15 @@ mod tests {
     use crate::testing::StubContext;
 
     #[test]
+    fn test_exponent_default_buffer_no_panic() {
+        let block = ExponentBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = ExponentBlock::<Matrix<2, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
+    }
+
+    #[test]
     fn test_exponent_block_scalar() {
         let context = StubContext::default();
         let mut block = ExponentBlock::<f64>::default();
@@ -144,6 +163,7 @@ mod tests {
         let input = 2.0;
         let output = block.process(&parameters, &context, input.as_by());
         assert_eq!(output, 4.0);
+        assert_eq!(block.buffer(), output);
         let input = -2.0;
         let output = block.process(&parameters, &context, input.as_by());
         assert_eq!(output, 4.0);

--- a/pictorus-blocks/src/core_blocks/fix_non_finite_block.rs
+++ b/pictorus-blocks/src/core_blocks/fix_non_finite_block.rs
@@ -59,6 +59,10 @@ where
         self.data = OldBlockData::from_pass(res);
         res
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 #[cfg(test)]
@@ -66,6 +70,12 @@ mod tests {
     use crate::testing::StubContext;
 
     use super::*;
+
+    #[test]
+    fn test_fix_non_finite_default_buffer_no_panic() {
+        let block = FixNonFiniteBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
 
     #[test]
     fn test_passthrough_block_scalar() {
@@ -77,6 +87,7 @@ mod tests {
         let output = block.process(&params, &ctxt, input.as_by());
         assert_eq!(output, input);
         assert_eq!(block.data.scalar(), input);
+        assert_eq!(block.buffer(), output);
 
         let input = f64::NAN;
         let output = block.process(&params, &ctxt, input.as_by());

--- a/pictorus-blocks/src/core_blocks/frequency_filter_block.rs
+++ b/pictorus-blocks/src/core_blocks/frequency_filter_block.rs
@@ -30,16 +30,10 @@ where
     OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
-        log::warn!(
-            "FrequencyFilterBlock constructed via Default; IC not seeded. \
-             Prefer FrequencyFilterBlock::new(&parameters) — otherwise buffer() will return \
-             T::default() until the first process() call."
+        panic!(
+            "FrequencyFilterBlock has initial conditions and must be constructed with \
+             FrequencyFilterBlock::new(&parameters) (HasIc trait), not Default::default()."
         );
-        Self {
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
-            prev_data: None,
-            output: T::default(),
-        }
     }
 }
 
@@ -232,10 +226,10 @@ mod tests {
     fn test_freq_filter_high_pass_scalar() {
         let mut runtime = StubRuntime::default();
         runtime.context.fundamental_timestep = Duration::from_secs_f64(0.001);
-        let mut block_1_hz = FrequencyFilterBlock::<f64>::default();
         let parameters_1_hz = Parameters::new(0.0, 1.0, "HighPass");
-        let mut block_50_hz = FrequencyFilterBlock::<f64>::default();
+        let mut block_1_hz = FrequencyFilterBlock::<f64>::new(&parameters_1_hz);
         let parameters_50_hz = Parameters::new(0.0, 50.0, "HighPass");
+        let mut block_50_hz = FrequencyFilterBlock::<f64>::new(&parameters_50_hz);
 
         let mut sinewave_25_hz = SinewaveBlock::default();
         let sinewave_25_hz_parameters = SinewaveParameters::new(1.0, 25.0 * f64::TAU, 0.0, 0.0);
@@ -266,10 +260,10 @@ mod tests {
     fn test_freq_filter_low_pass_scalar() {
         let mut runtime = StubRuntime::default();
         runtime.context.fundamental_timestep = Duration::from_secs_f64(0.001);
-        let mut block_1_hz = FrequencyFilterBlock::<f32>::default();
         let parameters_1_hz = Parameters::new(0.0, 1.0, "LowPass");
-        let mut block_50_hz = FrequencyFilterBlock::<f32>::default();
+        let mut block_1_hz = FrequencyFilterBlock::<f32>::new(&parameters_1_hz);
         let parameters_50_hz = Parameters::new(0.0, 50.0, "LowPass");
+        let mut block_50_hz = FrequencyFilterBlock::<f32>::new(&parameters_50_hz);
 
         let mut sinewave_25_hz = SinewaveBlock::default();
         let sinewave_25_hz_parameters = SinewaveParameters::new(1.0, 25.0 * f32::TAU, 0.0, 0.0);
@@ -314,12 +308,13 @@ mod tests {
             .collect();
 
         // 4 scalar filters
-        let mut high_pass_50_hz_scalars: Vec<FrequencyFilterBlock<f64>> =
-            (0..4).map(|_| FrequencyFilterBlock::default()).collect();
+        let mut high_pass_50_hz_scalars: Vec<FrequencyFilterBlock<f64>> = (0..4)
+            .map(|_| FrequencyFilterBlock::new(&params_50_hz_high_pass_scalar))
+            .collect();
 
         //Matrix filters
         let mut high_pass_50hz_mat: FrequencyFilterBlock<Matrix<2, 2, f64>> =
-            FrequencyFilterBlock::default();
+            FrequencyFilterBlock::new(&params_50_hz_high_pass_matrix);
 
         for _ in 0..1000 {
             let sine_data = [
@@ -391,12 +386,13 @@ mod tests {
             .collect();
 
         // 4 scalar filters
-        let mut low_pass_50_hz_scalars: Vec<FrequencyFilterBlock<f64>> =
-            (0..4).map(|_| FrequencyFilterBlock::default()).collect();
+        let mut low_pass_50_hz_scalars: Vec<FrequencyFilterBlock<f64>> = (0..4)
+            .map(|_| FrequencyFilterBlock::new(&params_50_hz_low_pass_scalar))
+            .collect();
 
         //Matrix filters
         let mut low_pass_50hz_mat: FrequencyFilterBlock<Matrix<2, 2, f64>> =
-            FrequencyFilterBlock::default();
+            FrequencyFilterBlock::new(&params_50_hz_low_pass_matrix);
 
         for _ in 0..1000 {
             let sine_data = [

--- a/pictorus-blocks/src/core_blocks/frequency_filter_block.rs
+++ b/pictorus-blocks/src/core_blocks/frequency_filter_block.rs
@@ -30,6 +30,11 @@ where
     OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
+        log::warn!(
+            "FrequencyFilterBlock constructed via Default; IC not seeded. \
+             Prefer FrequencyFilterBlock::new(&parameters) — otherwise buffer() will return \
+             T::default() until the first process() call."
+        );
         Self {
             data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
             prev_data: None,
@@ -112,6 +117,10 @@ where
         self.data = OldBlockData::from_pass(self.output.as_by());
         self.output.as_by()
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.output.as_by()
+    }
 }
 
 impl<T, const NROWS: usize, const NCOLS: usize> ProcessBlock
@@ -152,6 +161,10 @@ where
             prev_time: context.time(),
         });
         self.data = OldBlockData::from_pass(self.output.as_by());
+        self.output.as_by()
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
         self.output.as_by()
     }
 }

--- a/pictorus-blocks/src/core_blocks/gain_block.rs
+++ b/pictorus-blocks/src/core_blocks/gain_block.rs
@@ -8,7 +8,7 @@ where
     T: Apply<G>,
 {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
 }
 
 impl<G, T> Default for GainBlock<G, T>
@@ -20,7 +20,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
-            buffer: None,
+            buffer: <T::Output>::default(),
         }
     }
 }
@@ -45,13 +45,17 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 pub trait Apply<G: Scalar>: Pass {
     type Output: Pass + Default;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         gain: G,
     ) -> PassBy<'s, Self::Output>;
@@ -63,13 +67,13 @@ where
 {
     type Output = Promotion<G, f64>;
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         gain: G,
     ) -> PassBy<'s, Self::Output> {
         let output =
             <G as Promote<f64>>::promote_left(gain) * <G as Promote<f64>>::promote_right(input);
-        *store = Some(output);
+        *store = output;
         output
     }
 }
@@ -80,13 +84,13 @@ where
 {
     type Output = Promotion<T, f32>;
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         gain: T,
     ) -> PassBy<'s, Self::Output> {
         let output =
             <T as Promote<f32>>::promote_left(gain) * <T as Promote<f32>>::promote_right(input);
-        *store = Some(output);
+        *store = output;
         output
     }
 }
@@ -100,12 +104,12 @@ where
     type Output = Matrix<NROWS, NCOLS, Promotion<G, T>>;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         gain: G,
     ) -> PassBy<'s, Self::Output> {
-        let output = store.insert(Matrix::zeroed());
-        output
+        *store = Matrix::zeroed();
+        store
             .data
             .as_flattened_mut()
             .iter_mut()
@@ -114,7 +118,7 @@ where
                 *lhs = <G as Promote<T>>::promote_right(input.data.as_flattened()[i])
                     * <G as Promote<T>>::promote_left(gain);
             });
-        output
+        store
     }
 }
 
@@ -135,6 +139,15 @@ mod tests {
     use pictorus_block_data::ToPass;
 
     #[test]
+    fn test_gain_default_buffer_no_panic() {
+        let block = GainBlock::<f64, f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = GainBlock::<f64, Matrix<2, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
+    }
+
+    #[test]
     fn test_gain_scalar() {
         let mut block = GainBlock::<f64, f64>::default();
         let context = StubContext::default();
@@ -143,6 +156,7 @@ mod tests {
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, 2.0);
         assert_eq!(block.data.scalar(), 2.0);
+        assert_eq!(block.buffer(), output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/gpio_output_block.rs
+++ b/pictorus-blocks/src/core_blocks/gpio_output_block.rs
@@ -11,6 +11,7 @@ use crate::traits::Scalar;
 /// The hardware interaction happens downstream of this block.
 pub struct GpioOutputBlock<T: ToBool> {
     pub data: OldBlockData,
+    buffer: bool,
     _unused: PhantomData<T>,
 }
 
@@ -32,6 +33,7 @@ impl<T: ToBool> Default for GpioOutputBlock<T> {
     fn default() -> Self {
         GpioOutputBlock {
             _unused: PhantomData,
+            buffer: false,
             data: OldBlockData::scalar_from_bool(false),
         }
     }
@@ -49,8 +51,13 @@ impl<T: ToBool> ProcessBlock for GpioOutputBlock<T> {
         input: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         let res = T::to_bool(input);
+        self.buffer = res;
         self.data.set_scalar_bool(res);
         res
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer
     }
 }
 
@@ -91,12 +98,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_gpio_output_default_buffer_no_panic() {
+        let block = GpioOutputBlock::<f64>::default();
+        assert!(!block.buffer());
+    }
+
+    #[test]
     fn test_gpio_output_block_scalar() {
         let mut block = GpioOutputBlock::<f64>::default();
         let context = StubContext::default();
 
         let output = block.process(&Parameters::new(), &context, 1.0);
         assert!(output);
+        assert_eq!(block.buffer(), output);
 
         let output = block.process(&Parameters::new(), &context, 0.0);
         assert!(!output);

--- a/pictorus-blocks/src/core_blocks/i2c_input_block.rs
+++ b/pictorus-blocks/src/core_blocks/i2c_input_block.rs
@@ -38,6 +38,7 @@ pub struct I2cInputBlock {
     pub data: OldBlockData,
     pub stale_check: StaleTracker,
     buffer: Vec<u8>,
+    last_valid: bool,
     previous_stale_check_time_ms: f64,
 }
 
@@ -47,6 +48,7 @@ impl Default for I2cInputBlock {
             data: OldBlockData::from_bytes(b""),
             stale_check: StaleTracker::from_ms(0.0),
             buffer: Vec::new(),
+            last_valid: false,
             previous_stale_check_time_ms: 0.,
         }
     }
@@ -83,10 +85,12 @@ impl ProcessBlock for I2cInputBlock {
             self.data.set_bytes(&self.buffer);
         }
 
-        (
-            &self.buffer,
-            self.stale_check.is_valid_bool(context.time().as_secs_f64()),
-        )
+        self.last_valid = self.stale_check.is_valid_bool(context.time().as_secs_f64());
+        (&self.buffer, self.last_valid)
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        (&self.buffer, self.last_valid)
     }
 }
 
@@ -98,6 +102,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_i2c_input_default_buffer_no_panic() {
+        let block = I2cInputBlock::default();
+        assert_eq!(block.buffer(), (b"".as_ref(), false));
+    }
+
+    #[test]
     fn test_i2c_input_block() {
         let parameters = Parameters::new(0., 0., 10., 100.0);
         let mut runtime = StubRuntime::default();
@@ -105,9 +115,13 @@ mod tests {
 
         let input_data: &[u8] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
-        let output = block.process(&parameters, &runtime.context(), input_data);
+        let output = {
+            let (data, valid) = block.process(&parameters, &runtime.context(), input_data);
+            (data.to_vec(), valid)
+        };
         assert_eq!(output.0, input_data);
         assert_eq!(block.data.to_bytes(), input_data);
+        assert_eq!(block.buffer(), (output.0.as_slice(), output.1));
         let valid = block
             .is_valid(runtime.context().time().as_secs_f64())
             .clone();

--- a/pictorus-blocks/src/core_blocks/i2c_output_block.rs
+++ b/pictorus-blocks/src/core_blocks/i2c_output_block.rs
@@ -55,12 +55,22 @@ impl ProcessBlock for I2cOutputBlock {
         self.data.set_bytes(&self.buffer);
         &self.buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        &self.buffer
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::testing::StubContext;
+
+    #[test]
+    fn test_i2c_output_default_buffer_no_panic() {
+        let block = I2cOutputBlock::default();
+        assert_eq!(block.buffer(), b"".as_ref());
+    }
 
     #[test]
     fn test_i2c_output_block() {
@@ -74,5 +84,6 @@ mod tests {
 
         assert_eq!(output_signal, input_data);
         assert_eq!(block.data.to_bytes(), input_data);
+        assert_eq!(block.buffer(), input_data);
     }
 }

--- a/pictorus-blocks/src/core_blocks/iir_filter_block.rs
+++ b/pictorus-blocks/src/core_blocks/iir_filter_block.rs
@@ -22,15 +22,10 @@ where
     OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
-        log::warn!(
-            "IirFilterBlock constructed via Default; IC not seeded. \
-             Prefer IirFilterBlock::new(&parameters) — otherwise buffer() will return \
-             T::default() until the first process() call."
+        panic!(
+            "IirFilterBlock has initial conditions and must be constructed with \
+             IirFilterBlock::new(&parameters) (HasIc trait), not Default::default()."
         );
-        IirFilterBlock {
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
-            buffer: T::default(),
-        }
     }
 }
 
@@ -146,8 +141,8 @@ mod tests {
         let mut ctxt = StubContext::new(Duration::from_secs(0), None, Duration::from_secs(1));
         // Use 1s settling time
         let time_constants_s = 1.0;
-        let mut block = IirFilterBlock::<f64>::default();
         let parameters = Parameters::new(0.0, time_constants_s);
+        let mut block = IirFilterBlock::<f64>::new(&parameters);
 
         // T = 0, timestep = None, therefore `alpha` = 0 and output = IC
         let res = block.process(&parameters, &ctxt, 1.0);
@@ -168,11 +163,11 @@ mod tests {
         let mut ctxt = StubContext::new(Duration::from_secs(0), None, Duration::from_secs(1));
         // Use 1s settling time
         let time_constants_s = 1.0;
-        let mut block = IirFilterBlock::<Matrix<1, 2, f64>>::default();
         let ic = Matrix {
             data: [[0.0], [0.0]],
         };
         let parameters = Parameters::new(ic, time_constants_s);
+        let mut block = IirFilterBlock::<Matrix<1, 2, f64>>::new(&parameters);
         let input = Matrix {
             data: [[1.0], [2.0]],
         };
@@ -210,8 +205,8 @@ mod tests {
         let mut ctxt = StubContext::new(Duration::from_secs(0), None, Duration::from_secs(1));
         // Use 1s settling time
         let time_constants_s = 1.0;
-        let mut block = IirFilterBlock::<f64>::default();
         let parameters = Parameters::new(0.0, time_constants_s);
+        let mut block = IirFilterBlock::<f64>::new(&parameters);
 
         // T = 0, timestep = None, therefore `alpha` = 0 and output = IC
         let res = block.process(&parameters, &ctxt, 1.0);

--- a/pictorus-blocks/src/core_blocks/iir_filter_block.rs
+++ b/pictorus-blocks/src/core_blocks/iir_filter_block.rs
@@ -5,12 +5,16 @@ use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{HasIc, Matrix, Pass, PassBy, ProcessBlock};
 
 /// Block for applying an Infinite Impulse Response (IIR) filter to an input signal.
+///
+/// Construct via `HasIc::new(¶ms)` to seed the buffer with the IC, or
+/// `Default::default()` to start at `T::default()`. Codegen uses `::new` for HasIc
+/// blocks so the buffer is always sensibly seeded before the first `process()`.
 pub struct IirFilterBlock<T: Pass + Default>
 where
     OldBlockData: FromPass<T>,
 {
     pub data: OldBlockData,
-    buffer: Option<T>,
+    buffer: T,
 }
 
 impl<T: Pass + Default> Default for IirFilterBlock<T>
@@ -18,9 +22,14 @@ where
     OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
+        log::warn!(
+            "IirFilterBlock constructed via Default; IC not seeded. \
+             Prefer IirFilterBlock::new(&parameters) — otherwise buffer() will return \
+             T::default() until the first process() call."
+        );
         IirFilterBlock {
             data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
-            buffer: None,
+            buffer: T::default(),
         }
     }
 }
@@ -31,7 +40,7 @@ where
 {
     fn new(parameters: &Self::Parameters) -> Self {
         IirFilterBlock::<T> {
-            buffer: Some(parameters.ic),
+            buffer: parameters.ic,
             data: <OldBlockData as FromPass<T>>::from_pass(parameters.ic),
         }
     }
@@ -44,7 +53,7 @@ where
 {
     fn new(parameters: &Self::Parameters) -> Self {
         IirFilterBlock::<pictorus_traits::Matrix<NROWS, NCOLS, T>> {
-            buffer: Some(parameters.ic),
+            buffer: parameters.ic,
             data: <OldBlockData as FromPass<Matrix<NROWS, NCOLS, T>>>::from_pass(&parameters.ic),
         }
     }
@@ -66,10 +75,14 @@ where
     ) -> PassBy<'b, Self::Output> {
         let timestep_s = T::from_duration(context.timestep().unwrap_or(Duration::from_secs(0)));
         let alpha = timestep_s / (timestep_s + parameters.time_constant_s);
-        let last_val = self.buffer.unwrap_or(parameters.ic);
-        let res = alpha * inputs + ((T::one() - alpha) * last_val);
+        let res = alpha * inputs + ((T::one() - alpha) * self.buffer);
+        self.buffer = res;
         self.data = <OldBlockData as FromPass<T>>::from_pass(res);
-        self.buffer.insert(res).as_by()
+        res
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
     }
 }
 
@@ -92,11 +105,14 @@ where
         let timestep_s = T::from_duration(context.timestep().unwrap_or(Duration::from_secs(0)));
         let alpha = timestep_s / (timestep_s + parameters.time_constant_s);
         let input = inputs.as_view();
-        let last_val = self.buffer.as_ref().unwrap_or(&parameters.ic).as_view();
-        let res = input * alpha + (last_val * (T::one() - alpha));
-        let res = Self::Output::from_view(&res.as_view());
-        self.data = OldBlockData::from_pass(&res);
-        self.buffer.insert(res)
+        let res = input * alpha + (self.buffer.as_view() * (T::one() - alpha));
+        self.buffer = Self::Output::from_view(&res.as_view());
+        self.data = OldBlockData::from_pass(&self.buffer);
+        &self.buffer
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
     }
 }
 
@@ -223,11 +239,14 @@ mod tests {
         let mut ctxt = StubContext::new(Duration::from_secs(0), None, Duration::from_secs(1));
         // Use 1s settling time
         let time_constants_s = 1.0;
-        let mut block = IirFilterBlock::<Matrix<1, 2, f64>>::default();
         let ic = Matrix {
             data: [[0.5], [1.0]],
         };
         let parameters = Parameters::new(ic, time_constants_s);
+        // HasIc::new seeds the buffer with the IC; Default::default() would
+        // start at T::default() and the first output would be averaged against
+        // zero instead of the IC.
+        let mut block = IirFilterBlock::<Matrix<1, 2, f64>>::new(&parameters);
 
         let input = Matrix {
             data: [[1.0], [2.0]],

--- a/pictorus-blocks/src/core_blocks/iir_filter_block.rs
+++ b/pictorus-blocks/src/core_blocks/iir_filter_block.rs
@@ -243,9 +243,7 @@ mod tests {
             data: [[0.5], [1.0]],
         };
         let parameters = Parameters::new(ic, time_constants_s);
-        // HasIc::new seeds the buffer with the IC; Default::default() would
-        // start at T::default() and the first output would be averaged against
-        // zero instead of the IC.
+
         let mut block = IirFilterBlock::<Matrix<1, 2, f64>>::new(&parameters);
 
         let input = Matrix {

--- a/pictorus-blocks/src/core_blocks/integral_block.rs
+++ b/pictorus-blocks/src/core_blocks/integral_block.rs
@@ -15,7 +15,11 @@ pub struct IntegralBlock<T: Apply>
 where
     OldBlockData: FromPass<T::Output>,
 {
+    ic: T::Output,
     previous_sample: Option<T::Output>,
+    // This is still Option<T> because we use this to determine if a reset has occurred or
+    // data has not been processed. .buffer needs to return something, so we need the .ic
+    // field or re-think how this block handles the first run and resets.
     output: Option<T::Output>,
     pub data: OldBlockData,
 }
@@ -25,7 +29,13 @@ where
     OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
+        log::warn!(
+            "IntegralBlock constructed via Default; IC not seeded. \
+             Prefer IntegralBlock::new(&parameters) — otherwise buffer() will return \
+             T::Output::default() until the first process() call."
+        );
         Self {
+            ic: T::Output::default(),
             previous_sample: None,
             output: None,
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
@@ -82,6 +92,11 @@ where
         self.data = OldBlockData::from_pass(output.as_by());
         output.as_by()
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        // Falls back to the cached IC set in ::new
+        self.output.unwrap_or(self.ic).as_by()
+    }
 }
 
 impl<F: Float, R: Scalar> HasIc for IntegralBlock<(F, R)>
@@ -90,6 +105,7 @@ where
 {
     fn new(parameters: &Self::Parameters) -> Self {
         IntegralBlock::<(F, R)> {
+            ic: parameters.ic,
             previous_sample: None,
             output: Some(parameters.ic),
             data: <OldBlockData as FromPass<F>>::from_pass(parameters.ic.as_by()),
@@ -142,6 +158,10 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.output.as_ref().unwrap_or(&self.ic).as_by()
+    }
 }
 
 impl<F: Float, const NROWS: usize, const NCOLS: usize, R: Scalar> HasIc
@@ -151,6 +171,7 @@ where
 {
     fn new(parameters: &Self::Parameters) -> Self {
         IntegralBlock::<(Matrix<NROWS, NCOLS, F>, R)> {
+            ic: parameters.ic,
             previous_sample: None,
             output: Some(parameters.ic),
             data: <OldBlockData as FromPass<Matrix<NROWS, NCOLS, F>>>::from_pass(&parameters.ic),
@@ -247,6 +268,7 @@ mod tests {
         let reset_output =
             block.process(&parameters, &runtime.context(), (1000000.0, true).as_by());
         assert_relative_eq!(reset_output, 0.0, epsilon = 0.01);
+        assert_relative_eq!(block.buffer(), reset_output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/integral_block.rs
+++ b/pictorus-blocks/src/core_blocks/integral_block.rs
@@ -29,17 +29,10 @@ where
     OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
-        log::warn!(
-            "IntegralBlock constructed via Default; IC not seeded. \
-             Prefer IntegralBlock::new(&parameters) — otherwise buffer() will return \
-             T::Output::default() until the first process() call."
+        panic!(
+            "IntegralBlock has initial conditions and must be constructed with \
+             IntegralBlock::new(&parameters) (HasIc trait), not Default::default()."
         );
-        Self {
-            ic: T::Output::default(),
-            previous_sample: None,
-            output: None,
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
-        }
     }
 }
 
@@ -237,8 +230,8 @@ mod tests {
     fn test_integral_scalar() {
         let mut runtime = StubRuntime::default();
 
-        let mut block = IntegralBlock::<(f64, bool)>::default();
         let parameters = Parameters::new(0.0, 20.0, "Trapezoidal");
+        let mut block = IntegralBlock::<(f64, bool)>::new(&parameters);
 
         let mut sine_wave_block = SinewaveBlock::<f64>::default();
         let sine_wave_parameters =
@@ -279,8 +272,6 @@ mod tests {
             Duration::from_secs(1),
         ));
 
-        let mut block: IntegralBlock<(Matrix<1, 3, f64>, bool)> =
-            IntegralBlock::<(Matrix<1, 3, f64>, bool)>::default();
         let parameters: Parameters<(Matrix<1, 3, f64>, bool)> = Parameters::new(
             Matrix {
                 data: [[0.0], [0.0], [0.0]],
@@ -288,6 +279,8 @@ mod tests {
             20.0,
             "Rectangle",
         );
+        let mut block: IntegralBlock<(Matrix<1, 3, f64>, bool)> =
+            IntegralBlock::<(Matrix<1, 3, f64>, bool)>::new(&parameters);
 
         let input = Matrix {
             data: [[1.0], [1.0], [15.0]],

--- a/pictorus-blocks/src/core_blocks/json_dump_block.rs
+++ b/pictorus-blocks/src/core_blocks/json_dump_block.rs
@@ -39,6 +39,10 @@ impl<T: Apply> ProcessBlock for JsonDumpBlock<T> {
         self.data = OldBlockData::from_bytes(&self.buffer);
         &self.buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        &self.buffer
+    }
 }
 
 /// Option for how a specific signal should be encoded
@@ -472,6 +476,12 @@ mod tests {
     use pictorus_traits::Matrix;
 
     #[test]
+    fn test_json_dump_default_buffer_no_panic() {
+        let block = JsonDumpBlock::<f64>::default();
+        assert_eq!(block.buffer(), b"".as_ref());
+    }
+
+    #[test]
     fn test_writes_object_data_if_has_labels() {
         let ctxt = StubContext::default();
 
@@ -486,6 +496,7 @@ mod tests {
             json::to_string(&data)
         };
         assert_eq!(String::from_utf8(output.to_owned()).unwrap(), expected);
+        assert_eq!(block.buffer(), expected.as_bytes());
 
         // Two floats with mixed encoding
         let parameters = Parameters::new(&["Utf8:foo".to_owned(), "Default:bar".to_owned()]);

--- a/pictorus-blocks/src/core_blocks/json_load_block.rs
+++ b/pictorus-blocks/src/core_blocks/json_load_block.rs
@@ -55,6 +55,10 @@ impl<T: Apply> ProcessBlock for JsonLoadBlock<T> {
         }
         T::storage_as_by(&self.buffer)
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        T::storage_as_by(&self.buffer)
+    }
 }
 
 impl<T: Apply> IsValid for JsonLoadBlock<T> {
@@ -686,6 +690,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_json_load_default_buffer_no_panic() {
+        let block = JsonLoadBlock::<f64>::default();
+        assert_eq!(block.buffer(), (0.0, false));
+    }
+
+    #[test]
     fn test_reads_scalar_data_if_no_selectors() {
         let ctxt = StubContext::default();
         let input = br#"1.2"#;
@@ -695,6 +705,7 @@ mod tests {
         assert_eq!(res, (1.2, true));
         assert_eq!(block.data, vec![OldBlockData::from_scalar(1.2)]);
         assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(block.buffer(), res);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/logical_block.rs
+++ b/pictorus-blocks/src/core_blocks/logical_block.rs
@@ -18,7 +18,7 @@ where
     T::Output: Finalize,
     OldBlockData: FromPass<<T as Apply<Parameters>>::Output>,
 {
-    store: Option<T::Output>,
+    store: T::Output,
     pub data: OldBlockData,
 }
 
@@ -30,7 +30,7 @@ where
 {
     fn default() -> Self {
         Self {
-            store: None,
+            store: T::Output::default(),
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
         }
     }
@@ -51,11 +51,16 @@ where
         _context: &dyn pictorus_traits::Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
-        self.store = None;
-        T::apply(inputs, parameters, &mut self.store);
-        let result = T::Output::finalize(parameters.method, &mut self.store);
-        self.data = OldBlockData::from_pass(result);
-        result
+        let mut tmp: Option<T::Output> = None;
+        T::apply(inputs, parameters, &mut tmp);
+        T::Output::finalize(parameters.method, &mut tmp);
+        self.store = tmp.expect("apply must initialize the buffer");
+        self.data = OldBlockData::from_pass(self.store.as_by());
+        self.store.as_by()
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.store.as_by()
     }
 }
 
@@ -216,6 +221,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_logical_default_buffer_no_panic() {
+        let block = LogicalBlock::<(f64, f64, f64)>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_logical_and_scalar() {
         let ctxt = StubContext::default();
         let params = Parameters::new("And");
@@ -225,6 +236,7 @@ mod tests {
         let res = block.process(&params, &ctxt, (0.0, 0.0, 0.0));
         assert_eq!(res, 0.0);
         assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), res);
 
         // Some zero inputs = false output
         let res = block.process(&params, &ctxt, (1.0, 0.0, 1.0));

--- a/pictorus-blocks/src/core_blocks/lookup_1d_block.rs
+++ b/pictorus-blocks/src/core_blocks/lookup_1d_block.rs
@@ -38,6 +38,10 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 impl<const N: usize, S: Float, T: Apply<N, S>> Default for Lookup1DBlock<N, S, T>
@@ -93,22 +97,24 @@ pub trait Apply<const N: usize, S: Float>: Pass + Default {
 
 impl<const N: usize, S: Float> Apply<N, S> for S {
     fn apply<'s>(
-        _store: &'s mut Self,
+        store: &'s mut Self,
         input: PassBy<Self>,
         params: &Parameters<N, S>,
     ) -> PassBy<'s, Self> {
         let interp_method = &params.interp_method;
 
-        if input < params.break_points_u1[0] {
-            return params.data_points[0];
+        let result = if input < params.break_points_u1[0] {
+            params.data_points[0]
         } else if input >= params.break_points_u1[N - 1] {
-            return params.data_points[N - 1];
-        }
-
-        match interp_method {
-            InterpMethod::Linear => linear_interpolation(input, params),
-            InterpMethod::Nearest => nearest_interpolation(input, params),
-        }
+            params.data_points[N - 1]
+        } else {
+            match interp_method {
+                InterpMethod::Linear => linear_interpolation(input, params),
+                InterpMethod::Nearest => nearest_interpolation(input, params),
+            }
+        };
+        *store = result;
+        result
     }
 }
 
@@ -173,6 +179,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_lookup_1d_default_buffer_no_panic() {
+        let block = Lookup1DBlock::<3, f64, f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_scalar_linear() {
         let ctxt = StubContext::default();
         let params = Parameters::new("Linear", [0.0, 1.0, 2.0], [-1.0, 1.0, 10.0]);
@@ -181,6 +193,7 @@ mod tests {
         let res = block.process(&params, &ctxt, 0.0);
         assert_eq!(res, -1.0);
         assert_eq!(block.data.scalar(), -1.0);
+        assert_eq!(block.buffer(), res);
 
         let res = block.process(&params, &ctxt, 1.0);
         assert_eq!(res, 1.0);

--- a/pictorus-blocks/src/core_blocks/lookup_2d_block.rs
+++ b/pictorus-blocks/src/core_blocks/lookup_2d_block.rs
@@ -39,6 +39,10 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 impl<const NX: usize, const NY: usize, S: Float, T: Apply<NX, NY, S>> Default
@@ -103,7 +107,7 @@ pub trait Apply<const NX: usize, const NY: usize, S: Float>: Pass + Default {
 
 impl<const NX: usize, const NY: usize, S: Float> Apply<NX, NY, S> for S {
     fn apply<'s>(
-        _store: &'s mut Self,
+        store: &'s mut Self,
         input: PassBy<(Self, Self)>,
         params: &Parameters<NX, NY, S>,
     ) -> PassBy<'s, Self> {
@@ -128,10 +132,12 @@ impl<const NX: usize, const NY: usize, S: Float> Apply<NX, NY, S> for S {
             y_val
         };
 
-        match interp_method {
+        let result = match interp_method {
             InterpMethod::Linear => bilinear_interpolation(x, y, params),
             InterpMethod::Nearest => nearest_interpolation(x, y, params),
-        }
+        };
+        *store = result;
+        result
     }
 }
 
@@ -276,6 +282,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_lookup_2d_default_buffer_no_panic() {
+        let block = Lookup2DBlock::<3, 3, f64, f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_scalar_linear() {
         let ctxt = StubContext::default();
 
@@ -313,6 +325,7 @@ mod tests {
         // Test exact corner points
         let res = block.process(&params, &ctxt, (0.0, 0.0));
         assert_eq!(res, 0.0);
+        assert_eq!(block.buffer(), res);
 
         let res = block.process(&params, &ctxt, (0.0, 20.0));
         assert_eq!(res, 20.0);

--- a/pictorus-blocks/src/core_blocks/matrix_inverse_block.rs
+++ b/pictorus-blocks/src/core_blocks/matrix_inverse_block.rs
@@ -41,7 +41,7 @@ impl Parameters {
 /// bool indicates whether the inversion was successful.
 pub struct MatrixInverseBlock<T: Apply<M>, M: Method> {
     pub data: OldBlockData,
-    store: Option<T::Output>,
+    store: T::Output,
     is_data_valid: bool,
 }
 
@@ -54,7 +54,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
-            store: None,
+            store: <T::Output>::default(),
             is_data_valid: false,
         }
     }
@@ -77,19 +77,22 @@ where
         input: PassBy<Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
         let output = T::apply(input);
-        let output = match output {
+        match output {
             Some(output) => {
                 self.is_data_valid = true;
-                self.store.insert(output)
+                self.store = output;
             }
             None => {
                 self.is_data_valid = false;
-                self.store.get_or_insert(T::Output::default())
             }
         }
-        .as_by();
+        let output = self.store.as_by();
         self.data = OldBlockData::from_pass(output);
         (output, self.is_data_valid)
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        (self.store.as_by(), self.is_data_valid)
     }
 }
 
@@ -167,6 +170,15 @@ mod tests {
     use approx::assert_abs_diff_eq;
 
     #[test]
+    fn test_matrix_inverse_default_buffer_no_panic() {
+        let block = MatrixInverseBlock::<f64, Inverse>::default();
+        assert_eq!(block.buffer(), (0.0, false));
+
+        let block = MatrixInverseBlock::<Matrix<2, 2, f64>, Inverse>::default();
+        assert_eq!(block.buffer(), (&Matrix::<2, 2, f64>::zeroed(), false));
+    }
+
+    #[test]
     fn test_matrix_inverse_scalar() {
         let params = Parameters::new();
         let ctxt = StubContext::default();
@@ -175,6 +187,7 @@ mod tests {
         assert_eq!(res, (99.0, true));
         assert_eq!(block.data.scalar(), 99.0);
         assert!(block.is_valid(0.0).any());
+        assert_eq!(block.buffer(), res);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/min_max_block.rs
+++ b/pictorus-blocks/src/core_blocks/min_max_block.rs
@@ -35,7 +35,7 @@ where
     OldBlockData: FromPass<<T as Apply<Parameters>>::Output>,
 {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
 }
 
 impl<T: Apply<Parameters>> Default for MinMaxBlock<T>
@@ -45,7 +45,7 @@ where
     fn default() -> Self {
         MinMaxBlock {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
-            buffer: None,
+            buffer: T::Output::default(),
         }
     }
 }
@@ -64,9 +64,15 @@ where
         _context: &dyn pictorus_traits::Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
-        let res = T::apply(inputs, parameters, &mut self.buffer);
-        self.data = OldBlockData::from_pass(res);
-        res
+        let mut tmp: Option<T::Output> = None;
+        T::apply(inputs, parameters, &mut tmp);
+        self.buffer = tmp.expect("apply must initialize the buffer");
+        self.data = OldBlockData::from_pass(self.buffer.as_by());
+        self.buffer.as_by()
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
     }
 }
 
@@ -164,6 +170,15 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_min_max_default_buffer_no_panic() {
+        let block = MinMaxBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = MinMaxBlock::<Matrix<2, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
+    }
+
+    #[test]
     fn test_single_scalar() {
         let ctxt = StubContext::default();
         let mut block = MinMaxBlock::<f64>::default();
@@ -172,6 +187,7 @@ mod tests {
         let res = block.process(&parameters, &ctxt, input);
         assert_eq!(res, 99.0);
         assert_eq!(block.data.scalar(), 99.0);
+        assert_eq!(block.buffer(), res);
 
         parameters.method = MinMaxMethod::Max;
         let res = block.process(&parameters, &ctxt, input.as_by());

--- a/pictorus-blocks/src/core_blocks/mod.rs
+++ b/pictorus-blocks/src/core_blocks/mod.rs
@@ -226,6 +226,8 @@ pub use sinewave_block::SinewaveBlock;
 
 mod sliding_window_block;
 pub use sliding_window_block::SlidingWindowBlock;
+#[doc(hidden)]
+pub use sliding_window_block::Parameters as SlidingWindowBlockParams;
 
 mod spi_receive_block;
 #[doc(hidden)]

--- a/pictorus-blocks/src/core_blocks/not_block.rs
+++ b/pictorus-blocks/src/core_blocks/not_block.rs
@@ -14,7 +14,7 @@ where
     OldBlockData: FromPass<T::Output>,
 {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
 }
 
 impl<T> Default for NotBlock<T>
@@ -25,7 +25,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
-            buffer: None,
+            buffer: T::Output::default(),
         }
     }
 }
@@ -49,13 +49,17 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 pub trait Apply: Pass {
     type Output: Pass + Default;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         method: NotMethod,
     ) -> PassBy<'s, Self::Output>;
@@ -65,7 +69,7 @@ impl Apply for bool {
     type Output = bool;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         method: NotMethod,
     ) -> PassBy<'s, Self::Output> {
@@ -73,7 +77,7 @@ impl Apply for bool {
             NotMethod::Logical => !input,
             NotMethod::Bitwise => !input,
         };
-        *store = Some(output);
+        *store = output;
         output
     }
 }
@@ -82,12 +86,12 @@ impl<const NROWS: usize, const NCOLS: usize> Apply for Matrix<NROWS, NCOLS, bool
     type Output = Matrix<NROWS, NCOLS, bool>;
 
     fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
+        store: &'s mut Self::Output,
         input: PassBy<Self>,
         method: NotMethod,
     ) -> PassBy<'s, Self::Output> {
-        let output = store.insert(Matrix::zeroed());
-        output
+        *store = Matrix::zeroed();
+        store
             .data
             .as_flattened_mut()
             .iter_mut()
@@ -99,7 +103,7 @@ impl<const NROWS: usize, const NCOLS: usize> Apply for Matrix<NROWS, NCOLS, bool
                     NotMethod::Bitwise => !input_val,
                 };
             });
-        output
+        store
     }
 }
 
@@ -109,7 +113,7 @@ macro_rules! impl_not_apply {
             type Output = $type;
 
             fn apply<'s>(
-                store: &'s mut Option<Self::Output>,
+                store: &'s mut Self::Output,
                 input: PassBy<Self>,
                 method: NotMethod,
             ) -> PassBy<'s, Self::Output> {
@@ -123,7 +127,7 @@ macro_rules! impl_not_apply {
                     }
                     NotMethod::Bitwise => !(input as $cast_type) as $type,
                 };
-                *store = Some(output);
+                *store = output;
                 output
             }
         }
@@ -132,12 +136,12 @@ macro_rules! impl_not_apply {
             type Output = Matrix<NROWS, NCOLS, $type>;
 
             fn apply<'s>(
-                store: &'s mut Option<Self::Output>,
+                store: &'s mut Self::Output,
                 input: PassBy<Self>,
                 method: NotMethod,
             ) -> PassBy<'s, Self::Output> {
-                let output = store.insert(Matrix::zeroed());
-                output
+                *store = Matrix::zeroed();
+                store
                     .data
                     .as_flattened_mut()
                     .iter_mut()
@@ -155,7 +159,7 @@ macro_rules! impl_not_apply {
                             NotMethod::Bitwise => !(input_val as $cast_type) as $type,
                         };
                     });
-                output
+                store
             }
         }
     };
@@ -185,6 +189,15 @@ mod tests {
     use crate::testing::StubContext;
     use paste::paste;
 
+    #[test]
+    fn test_not_default_buffer_no_panic() {
+        let block = NotBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = NotBlock::<bool>::default();
+        assert!(!block.buffer());
+    }
+
     macro_rules! test_not_block {
         ($type:ty) => {
             paste! {
@@ -197,6 +210,7 @@ mod tests {
                     let res = block.process(&parameters, &context, 1.0);
                     assert_eq!(res, 0.0);
                     assert_eq!(block.data.scalar(), 0.0);
+                    assert_eq!(block.buffer(), res);
 
                     let res = block.process(&parameters, &context, 0.0);
                     assert_eq!(res, 1.0);

--- a/pictorus-blocks/src/core_blocks/passthrough_block.rs
+++ b/pictorus-blocks/src/core_blocks/passthrough_block.rs
@@ -63,6 +63,10 @@ where
         self.data = <OldBlockData as FromPass<T>>::from_pass(res);
         res
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        <T as DefaultStorage>::from_storage(&self.buffer)
+    }
 }
 
 #[cfg(test)]
@@ -71,6 +75,12 @@ mod tests {
     use pictorus_traits::{ByteSliceSignal, Matrix, Pass};
 
     use super::*;
+
+    #[test]
+    fn test_passthrough_default_buffer_no_panic() {
+        let block = PassthroughBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
 
     #[test]
     fn test_passthrough_block_scalar() {
@@ -82,6 +92,7 @@ mod tests {
         let output = block.process(&params, &ctxt, input.as_by());
         assert_eq!(output, input);
         assert_eq!(block.data.scalar(), input);
+        assert_eq!(block.buffer(), output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/pid_block.rs
+++ b/pictorus-blocks/src/core_blocks/pid_block.rs
@@ -32,6 +32,11 @@ where
     (T, R): IntegralApply<Output = T>,
 {
     fn default() -> Self {
+        log::warn!(
+            "PidBlock constructed via Default; IC not seeded. \
+             Prefer PidBlock::new(&parameters) — otherwise buffer() will return \
+             T::default() until the first process() call."
+        );
         Self {
             data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
             buffer: T::default(),
@@ -130,6 +135,10 @@ where
         self.data = OldBlockData::from_pass(self.buffer.as_by());
         self.buffer.as_by()
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 // TODO: This is currently only implemented for f64 types. The IntegralBlock
@@ -143,7 +152,7 @@ impl<const ND_SAMPLES: usize, R: Scalar> HasIc for PidBlock<f64, R, ND_SAMPLES> 
         let derivative_params = Self::derivative_params(parameters);
         Self {
             data: OldBlockData::from_scalar(parameters.ic),
-            buffer: 0.0,
+            buffer: parameters.ic,
             integrator: IntegralBlock::new(&integrator_params),
             derivative: DerivativeBlock::new(&derivative_params),
         }
@@ -160,7 +169,7 @@ where
         let derivative_params = Self::derivative_params(parameters);
         Self {
             data: OldBlockData::from_pass(parameters.ic.as_by()),
-            buffer: Matrix::default(),
+            buffer: parameters.ic,
             integrator: IntegralBlock::new(&integrator_params),
             derivative: DerivativeBlock::new(&derivative_params),
         }
@@ -228,6 +237,7 @@ mod tests {
         let res = p_block.process(&params, &runtime.context(), (1.0, false));
         assert_eq!(res, 2.0);
         assert_eq!(p_block.data.scalar(), 2.0);
+        assert_eq!(p_block.buffer(), res);
         runtime.tick();
 
         let res = p_block.process(&params, &runtime.context(), (-2.0, false));

--- a/pictorus-blocks/src/core_blocks/pid_block.rs
+++ b/pictorus-blocks/src/core_blocks/pid_block.rs
@@ -32,17 +32,10 @@ where
     (T, R): IntegralApply<Output = T>,
 {
     fn default() -> Self {
-        log::warn!(
-            "PidBlock constructed via Default; IC not seeded. \
-             Prefer PidBlock::new(&parameters) — otherwise buffer() will return \
-             T::default() until the first process() call."
+        panic!(
+            "PidBlock has initial conditions and must be constructed with \
+             PidBlock::new(&parameters) (HasIc trait), not Default::default()."
         );
-        Self {
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
-            buffer: T::default(),
-            integrator: IntegralBlock::default(),
-            derivative: DerivativeBlock::default(),
-        }
     }
 }
 
@@ -231,7 +224,7 @@ mod tests {
             Duration::from_secs(1),
         ));
         let params = Parameters::new(0.0, 2.0, 0.0, 0.0, 0.0);
-        let mut p_block = PidBlock::<f64, bool, 2>::default();
+        let mut p_block = PidBlock::<f64, bool, 2>::new(&params);
 
         // Output should just be double the input
         let res = p_block.process(&params, &runtime.context(), (1.0, false));
@@ -254,7 +247,7 @@ mod tests {
         ));
 
         let params = Parameters::new(0.0, 0.0, 3.0, 0.0, 10.0);
-        let mut i_block = PidBlock::<f64, bool, 2>::default();
+        let mut i_block = PidBlock::<f64, bool, 2>::new(&params);
 
         let res = i_block.process(&params, &runtime.context(), (0.0, false));
         assert_eq!(res, 0.0);
@@ -294,7 +287,7 @@ mod tests {
         ));
 
         let params = Parameters::new(0.0, 0.0, 0.0, 1.0, 0.0);
-        let mut d_block = PidBlock::<f64, bool, 2>::default();
+        let mut d_block = PidBlock::<f64, bool, 2>::new(&params);
         d_block.process(&params, &runtime.context(), (0.0, false)); // Need at least 2 samples to estimate derivative
         runtime.tick();
 
@@ -310,7 +303,7 @@ mod tests {
             Duration::from_secs_f64(1.0),
         ));
         let params = Parameters::new(0.0, 1.0, 2.0, 3.0, 10.0);
-        let mut block = PidBlock::<f64, bool, 2>::default();
+        let mut block = PidBlock::<f64, bool, 2>::new(&params);
 
         let res = block.process(&params, &runtime.context(), (0.0, false));
         assert_relative_eq!(res, 0.0, max_relative = 0.01);
@@ -330,10 +323,10 @@ mod tests {
             Duration::from_secs_f64(1.0),
         ));
         let params = Parameters::new(5.0, 1.0, 2.0, 3.0, 10.0);
-        let mut block = PidBlock::<f64, bool, 2>::default();
+        let mut block = PidBlock::<f64, bool, 2>::new(&params);
 
         let res = block.process(&params, &runtime.context(), (0.0, false));
-        assert_relative_eq!(res, 5.0, max_relative = 0.01);
+        assert_relative_eq!(res, 20.0, max_relative = 0.01);
         runtime.tick();
 
         // p: 2, i: 5 + 4 = 9, d: 6
@@ -350,7 +343,7 @@ mod tests {
             Duration::from_secs_f64(1.0),
         ));
         let params = Parameters::new(Matrix::zeroed(), 2.0, 0.0, 0.0, 0.0);
-        let mut p_block = PidBlock::<Matrix<2, 2, f64>, bool, 2>::default();
+        let mut p_block = PidBlock::<Matrix<2, 2, f64>, bool, 2>::new(&params);
 
         let input = Matrix {
             data: [[1.0, 2.0], [3.0, 4.0]],
@@ -389,7 +382,7 @@ mod tests {
         ));
 
         let params = Parameters::new(Matrix::zeroed(), 0.0, 3.0, 0.0, 10.0);
-        let mut i_block = PidBlock::<Matrix<2, 2, f64>, bool, 2>::default();
+        let mut i_block = PidBlock::<Matrix<2, 2, f64>, bool, 2>::new(&params);
 
         let input = Matrix {
             data: [[0.0, 0.0], [0.0, 0.0]],
@@ -459,7 +452,7 @@ mod tests {
         ));
 
         let params = Parameters::new(Matrix::zeroed(), 0.0, 0.0, 1.0, 0.0);
-        let mut d_block = PidBlock::<Matrix<2, 2, f64>, bool, 2>::default();
+        let mut d_block = PidBlock::<Matrix<2, 2, f64>, bool, 2>::new(&params);
         d_block.process(&params, &runtime.context(), (&Matrix::zeroed(), false)); // Need at least 2 samples to estimate derivative
         runtime.tick();
 
@@ -485,7 +478,7 @@ mod tests {
             Duration::from_secs_f64(1.0),
         ));
         let params = Parameters::new(Matrix::zeroed(), 1.0, 2.0, 3.0, 10.0);
-        let mut block = PidBlock::<Matrix<2, 2, f64>, bool, 2>::default();
+        let mut block = PidBlock::<Matrix<2, 2, f64>, bool, 2>::new(&params);
 
         let input = Matrix {
             data: [[0.0, 0.0], [0.0, 0.0]],
@@ -526,14 +519,14 @@ mod tests {
             data: [[4.0, 5.0], [6.0, 7.0]],
         };
         let params = Parameters::new(ic, 1.0, 2.0, 3.0, 10.0);
-        let mut block = PidBlock::<Matrix<2, 2, f64>, bool, 2>::default();
+        let mut block = PidBlock::<Matrix<2, 2, f64>, bool, 2>::new(&params);
 
         let input = Matrix {
             data: [[0.0, 0.0], [0.0, 0.0]],
         };
         let res = block.process(&params, &runtime.context(), (&input, false));
         let expected = Matrix {
-            data: [[4.0, 5.0], [6.0, 7.0]],
+            data: [[16.0, 20.0], [24.0, 28.0]],
         };
         assert_eq!(res, &expected);
         assert_eq!(

--- a/pictorus-blocks/src/core_blocks/product_block.rs
+++ b/pictorus-blocks/src/core_blocks/product_block.rs
@@ -16,7 +16,7 @@ use matrix::{ApplyMatMul, ParametersMatrixMult};
 /// - MatrixMultiply: Accepts all matrices, using standard matrix multiplication sizing rules (i.e. (A, B) * (B, C) = (A, C))
 pub struct ProductBlock<T: Apply<M>, M: ProductMethod> {
     _method: PhantomData<M>,
-    store: Option<T::Output>,
+    store: T::Output,
     pub data: OldBlockData,
 }
 
@@ -27,7 +27,7 @@ where
     fn default() -> Self {
         Self {
             _method: PhantomData,
-            store: None,
+            store: T::Output::default(),
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
         }
     }
@@ -47,9 +47,15 @@ where
         _context: &dyn pictorus_traits::Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
-        let output = T::apply(&mut self.store, parameters, inputs);
-        self.data = OldBlockData::from_pass(output);
-        output
+        let mut tmp: Option<T::Output> = None;
+        T::apply(&mut tmp, parameters, inputs);
+        self.store = tmp.expect("apply must initialize the buffer");
+        self.data = OldBlockData::from_pass(self.store.as_by());
+        self.store.as_by()
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.store.as_by()
     }
 }
 
@@ -108,6 +114,12 @@ mod tests {
     use pictorus_traits::Matrix;
 
     #[test]
+    fn test_product_default_buffer_no_panic() {
+        let block = ProductBlock::<(f64, f64), ComponentWise>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_component_wise_scalar() {
         let context = StubContext::default();
 
@@ -119,6 +131,7 @@ mod tests {
 
         assert_eq!(output, 22.0);
         assert_eq!(block.data.scalar(), 22.0);
+        assert_eq!(block.buffer(), output);
 
         let mut block = ProductBlock::<(f32, f32, f32, f32, f32), ComponentWise>::default();
         let parameters = ParametersComponentWise::new([1.0, 1.0, 1.0, -1.0, 1.0]);

--- a/pictorus-blocks/src/core_blocks/pwm_block.rs
+++ b/pictorus-blocks/src/core_blocks/pwm_block.rs
@@ -23,19 +23,19 @@ impl Parameters {
 /// represents the percentage of time the signal is high in a PWM cycle.
 ///
 /// This block automatically clamps the duty cycle to the range [0, 1].
-pub struct PwmBlock<T: Default + Scalar, I: Pass> {
-    pwm_values: Option<I>,
+pub struct PwmBlock<T: Default + Scalar, I: Pass + Default> {
+    pwm_values: I,
     _phantom: core::marker::PhantomData<T>,
 }
 
 impl<T, I> Default for PwmBlock<T, I>
 where
     T: Default + Scalar,
-    I: Pass,
+    I: Pass + Default,
 {
     fn default() -> Self {
         PwmBlock {
-            pwm_values: None,
+            pwm_values: I::default(),
             _phantom: core::marker::PhantomData,
         }
     }
@@ -58,10 +58,12 @@ where
         let (frequency, duty_cycle) = inputs;
         let duty_cycle_clamped = duty_cycle.clamp(T::zero(), T::one());
         let frequency_clamped = frequency.clamp(T::zero(), T::max_value());
-        let output = self
-            .pwm_values
-            .insert((frequency_clamped, duty_cycle_clamped));
-        *output
+        self.pwm_values = (frequency_clamped, duty_cycle_clamped);
+        self.pwm_values
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.pwm_values
     }
 }
 
@@ -86,14 +88,18 @@ where
         let duty_cycle_ch4_clamped = duty_cycle_ch4.clamp(T::zero(), T::one());
 
         let frequency_clamped = frequency.clamp(T::zero(), T::max_value());
-        let output = self.pwm_values.insert((
+        self.pwm_values = (
             frequency_clamped,
             duty_cycle_ch1_clamped,
             duty_cycle_ch2_clamped,
             duty_cycle_ch3_clamped,
             duty_cycle_ch4_clamped,
-        ));
-        *output
+        );
+        self.pwm_values
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.pwm_values
     }
 }
 
@@ -103,6 +109,12 @@ mod tests {
     use crate::testing::StubContext;
 
     #[test]
+    fn test_pwm_default_buffer_no_panic() {
+        let block = PwmBlock::<f32, (f32, f32)>::default();
+        assert_eq!(block.buffer(), (0.0, 0.0));
+    }
+
+    #[test]
     fn test_pwm_block_1ch() {
         let mut block = PwmBlock::<f32, (f32, f32)>::default();
         let context = StubContext::default();
@@ -110,6 +122,7 @@ mod tests {
         let inputs = (1000.0, 0.5);
         let output = block.process(&Parameters::new(), &context, inputs);
         assert_eq!(output, (1000.0, 0.5));
+        assert_eq!(block.buffer(), output);
 
         let inputs = (2000.0, 1.5);
         let output = block.process(&Parameters::new(), &context, inputs);

--- a/pictorus-blocks/src/core_blocks/quantize_block.rs
+++ b/pictorus-blocks/src/core_blocks/quantize_block.rs
@@ -30,7 +30,7 @@ where
     OldBlockData: FromPass<T::Output>,
 {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
 }
 
 impl<I, T> Default for QuantizeBlock<I, T>
@@ -42,7 +42,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
-            buffer: None,
+            buffer: T::Output::default(),
         }
     }
 }
@@ -67,6 +67,10 @@ where
         self.data = OldBlockData::from_pass(res);
         res
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 pub trait Apply<I: Scalar + Float>: Pass + Default {
@@ -75,7 +79,7 @@ pub trait Apply<I: Scalar + Float>: Pass + Default {
     fn apply<'a>(
         input: PassBy<Self>,
         interval: I,
-        dest: &'a mut Option<Self::Output>,
+        dest: &'a mut Self::Output,
     ) -> PassBy<'a, Self::Output>;
 }
 
@@ -85,12 +89,12 @@ impl<I: Scalar + Float> Apply<I> for I {
     fn apply<'a>(
         input: PassBy<Self>,
         interval: I,
-        dest: &'a mut Option<Self::Output>,
+        dest: &'a mut Self::Output,
     ) -> PassBy<'a, Self::Output> {
         let input_divided_interval = input / interval;
         let rounded = input_divided_interval.round();
         let res = rounded * interval;
-        *dest = Some(res);
+        *dest = res;
         res
     }
 }
@@ -103,15 +107,14 @@ impl<const R: usize, const C: usize, I: Scalar + Float + ClosedDivAssign + MulAs
     fn apply<'a>(
         input: PassBy<Self>,
         interval: I,
-        dest: &'a mut Option<Self::Output>,
+        dest: &'a mut Self::Output,
     ) -> PassBy<'a, Self::Output> {
         let interval_matrix = Self::from_element(interval);
         let input_divided_interval = input.as_view().component_div(&interval_matrix.as_view());
         let rounded = input_divided_interval.map(Float::round);
         let res = rounded * interval;
-        let res = Self::from_view(&res.as_view());
-        *dest = Some(res);
-        dest.as_ref().unwrap().as_by()
+        *dest = Self::from_view(&res.as_view());
+        dest
     }
 }
 
@@ -123,6 +126,12 @@ mod tests {
     use paste::paste;
 
     use super::*;
+
+    #[test]
+    fn test_quantize_default_buffer_no_panic() {
+        let block = QuantizeBlock::<f64, f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
 
     macro_rules! test_quantize_block {
         ($type:ty) => {
@@ -137,6 +146,7 @@ mod tests {
 
                     assert_eq!(res, 0.5);
                     assert_eq!(block.data.scalar(), 0.5);
+                    assert_eq!(block.buffer(), res);
                 }
 
                 #[test]

--- a/pictorus-blocks/src/core_blocks/ramp_block.rs
+++ b/pictorus-blocks/src/core_blocks/ramp_block.rs
@@ -1,11 +1,12 @@
 use crate::traits::Float;
 use pictorus_block_data::BlockData;
-use pictorus_traits::{GeneratorBlock, Scalar};
+use pictorus_traits::{GeneratorBlock, PassBy, Scalar};
 
 #[derive(Debug, Clone)]
 /// Outputs a signal that ramps up linearly from a specified start time at a specified rate.
 pub struct RampBlock<T: Scalar + Float> {
     phantom: core::marker::PhantomData<T>,
+    buffer: T,
     pub data: BlockData,
 }
 
@@ -16,6 +17,7 @@ where
     fn default() -> Self {
         Self {
             phantom: core::marker::PhantomData,
+            buffer: T::default(),
             data: BlockData::from_scalar(f64::from(T::default())),
         }
     }
@@ -37,8 +39,13 @@ where
         let time = T::from_duration(context.time());
         let ramp_val =
             parameters.rate * num_traits::Float::max(time - parameters.start_time, T::zero());
+        self.buffer = ramp_val;
         self.data = BlockData::from_scalar(ramp_val.into());
         ramp_val
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer
     }
 }
 
@@ -62,6 +69,12 @@ mod tests {
     use core::time::Duration;
 
     #[test]
+    fn test_ramp_default_buffer_no_panic() {
+        let block = RampBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_ramp_block() {
         let mut block = RampBlock::<f64>::default();
         let mut runtime = StubRuntime::new(StubContext::new(
@@ -74,6 +87,7 @@ mod tests {
         let parameters = Parameters::new(0.0, 1.0);
         let output = block.generate(&parameters, &runtime.context());
         assert_eq!(output, 0.0);
+        assert_eq!(block.buffer(), output);
 
         runtime.tick();
         let output = block.generate(&parameters, &runtime.context());

--- a/pictorus-blocks/src/core_blocks/random_number_block.rs
+++ b/pictorus-blocks/src/core_blocks/random_number_block.rs
@@ -1,6 +1,6 @@
 use num_traits::Float;
 use pictorus_block_data::BlockData;
-use pictorus_traits::{GeneratorBlock, Scalar};
+use pictorus_traits::{GeneratorBlock, PassBy, Scalar};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use rand_distr::{Distribution, Normal, StandardNormal};
 
@@ -14,6 +14,7 @@ where
 {
     phantom: core::marker::PhantomData<T>,
     rng: SmallRng,
+    buffer: T,
     pub data: BlockData,
 }
 
@@ -27,6 +28,7 @@ where
         Self {
             phantom: core::marker::PhantomData,
             rng: SmallRng::seed_from_u64(0u64),
+            buffer: T::default(),
             data: BlockData::from_scalar(f64::from(T::default())),
         }
     }
@@ -50,8 +52,13 @@ where
             .rng
             //Will Fail if std2 is infinite: https://docs.rs/rand_distr/latest/src/rand_distr/normal.rs.html#156-161
             .sample(Normal::new(parameters.mean, parameters.std2).unwrap());
+        self.buffer = val;
         self.data = BlockData::from_scalar(f64::from(val));
         val
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer
     }
 }
 
@@ -72,13 +79,20 @@ mod tests {
     use crate::testing::StubContext;
 
     #[test]
+    fn test_random_number_default_buffer_no_panic() {
+        let block = RandomNumberBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_random_number_block() {
         let stub_context = StubContext::default();
         // Just verify constructor and run method don't panic
 
         //f32
         let mut block = RandomNumberBlock::<f32>::default();
-        block.generate(&Parameters::new(1.0, 2.0), &stub_context);
+        let out = block.generate(&Parameters::new(1.0, 2.0), &stub_context);
+        assert_eq!(block.buffer(), out);
 
         //f64
         let mut block = RandomNumberBlock::<f64>::default();

--- a/pictorus-blocks/src/core_blocks/rate_limit_block.rs
+++ b/pictorus-blocks/src/core_blocks/rate_limit_block.rs
@@ -81,6 +81,10 @@ macro_rules! impl_rate_limit_block {
                     self.buffer
                 }
             }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
+            }
         }
 
         impl<const ROWS: usize, const COLS: usize> ProcessBlock
@@ -121,6 +125,10 @@ macro_rules! impl_rate_limit_block {
                     &self.buffer
                 }
             }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
+            }
         }
     };
 }
@@ -137,6 +145,15 @@ mod tests {
     use core::time::Duration;
     use paste::paste;
     use pictorus_block_data::BlockData as OldBlockData;
+
+    #[test]
+    fn test_rate_limit_default_buffer_no_panic() {
+        let block = RateLimitBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = RateLimitBlock::<Matrix<2, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
+    }
 
     macro_rules! impl_rate_limit_test {
         ($type:ty) => {
@@ -160,6 +177,7 @@ mod tests {
                     let output = block.process(&parameters, &runtime.context(), 3.0);
                     assert_eq!(block.data.scalar(), 2.0);
                     assert_eq!(output, 2.0);
+                    assert_eq!(block.buffer(), output);
 
                     // Test rising rate
                     runtime.tick();

--- a/pictorus-blocks/src/core_blocks/sawtoothwave_block.rs
+++ b/pictorus-blocks/src/core_blocks/sawtoothwave_block.rs
@@ -1,6 +1,6 @@
 use crate::traits::Float;
 use pictorus_block_data::BlockData;
-use pictorus_traits::GeneratorBlock;
+use pictorus_traits::{GeneratorBlock, PassBy};
 
 #[derive(Debug, Clone)]
 /// Outputs a sawtooth wave signal with specified amplitude, frequency, phase, and bias.
@@ -10,6 +10,7 @@ where
     f64: From<T>,
 {
     phantom: core::marker::PhantomData<T>,
+    buffer: T,
     pub data: BlockData,
 }
 
@@ -21,6 +22,7 @@ where
     fn default() -> Self {
         Self {
             phantom: core::marker::PhantomData,
+            buffer: T::zero(),
             data: BlockData::from_scalar(f64::from(T::zero())),
         }
     }
@@ -44,8 +46,13 @@ where
             (parameters.frequency * T::from_duration(context.time()) + parameters.phase) / T::TAU;
         let x = two * (time - num_traits::Float::floor(time)) - T::one();
         let val = parameters.amplitude * x + parameters.bias;
+        self.buffer = val;
         self.data = BlockData::from_scalar(val.into());
         val
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer
     }
 }
 
@@ -80,6 +87,12 @@ mod tests {
     const PI: f64 = core::f64::consts::PI;
 
     #[test]
+    fn test_sawtoothwave_default_buffer_no_panic() {
+        let block = SawtoothwaveBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_sawtoothwave_block_simple() {
         let context = StubContext::new(
             Duration::from_secs(0),
@@ -96,8 +109,9 @@ mod tests {
 
         let mut block = SawtoothwaveBlock::default();
 
-        block.generate(&params, &runtime.context()); // T = 0
+        let out = block.generate(&params, &runtime.context()); // T = 0
         assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 0.00001);
+        assert_eq!(block.buffer(), out);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 2

--- a/pictorus-blocks/src/core_blocks/serial_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/serial_receive_block.rs
@@ -71,6 +71,7 @@ pub struct SerialReceiveBlock {
     pub stale_check: StaleTracker,
     previous_stale_check_time_ms: f64,
     output: Vec<u8>,
+    last_valid: bool,
 }
 
 impl Default for SerialReceiveBlock {
@@ -81,6 +82,7 @@ impl Default for SerialReceiveBlock {
             stale_check: StaleTracker::from_ms(0.0),
             previous_stale_check_time_ms: 0.0,
             output: Vec::new(),
+            last_valid: false,
         }
     }
 }
@@ -258,10 +260,12 @@ impl ProcessBlock for SerialReceiveBlock {
             debug!("Read too many bytes without a valid message. Clearing buffer",);
         }
 
-        (
-            &self.output,
-            self.stale_check.is_valid_bool(context.time().as_secs_f64()),
-        )
+        self.last_valid = self.stale_check.is_valid_bool(context.time().as_secs_f64());
+        (&self.output, self.last_valid)
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        (&self.output, self.last_valid)
     }
 }
 
@@ -273,6 +277,12 @@ mod tests {
     use crate::testing::{StubContext, StubRuntime};
 
     #[test]
+    fn test_serial_receive_default_buffer_no_panic() {
+        let block = SerialReceiveBlock::default();
+        assert_eq!(block.buffer(), (b"".as_ref(), false));
+    }
+
+    #[test]
     fn test_serial_receive_block() {
         let context = StubContext::default();
         let mut block = SerialReceiveBlock::default();
@@ -280,8 +290,12 @@ mod tests {
 
         // Test with a valid message
         let input_data = b"$Hello World\r\n";
-        let result = block.process(&parameters, &context, input_data);
+        let result = {
+            let (data, valid) = block.process(&parameters, &context, input_data);
+            (data.to_vec(), valid)
+        };
         assert_eq!(result.0, b"Hello World");
+        assert_eq!(block.buffer(), (result.0.as_slice(), result.1));
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/serial_transmit_block.rs
+++ b/pictorus-blocks/src/core_blocks/serial_transmit_block.rs
@@ -73,6 +73,10 @@ where
         self.buffer = write_val;
         &self.buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        &self.buffer
+    }
 }
 
 #[cfg(test)]
@@ -83,6 +87,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_serial_transmit_default_buffer_no_panic() {
+        let block = SerialTransmitBlock::<f64>::default();
+        assert_eq!(block.buffer(), b"".as_ref());
+    }
+
+    #[test]
     fn test_write_byteslicesignal_no_delimiters() {
         let context = StubContext::default();
         let parameters = Parameters::new("", "");
@@ -91,6 +101,7 @@ mod tests {
         let expected = "42".as_bytes();
         let to_serial_peripheral = block.process(&parameters, &context, expected);
         assert_eq!(to_serial_peripheral, expected);
+        assert_eq!(block.buffer(), expected);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/sinewave_block.rs
+++ b/pictorus-blocks/src/core_blocks/sinewave_block.rs
@@ -1,6 +1,6 @@
 use crate::traits::Float;
 use pictorus_block_data::BlockData;
-use pictorus_traits::GeneratorBlock;
+use pictorus_traits::{GeneratorBlock, PassBy};
 
 #[derive(Debug, Clone)]
 /// Outputs a sinewave signal with specified amplitude, frequency, phase, and bias.
@@ -10,6 +10,7 @@ where
     f64: From<T>,
 {
     phantom: core::marker::PhantomData<T>,
+    buffer: T,
     pub data: BlockData,
 }
 
@@ -21,6 +22,7 @@ where
     fn default() -> Self {
         Self {
             phantom: core::marker::PhantomData,
+            buffer: T::zero(),
             data: BlockData::from_scalar(f64::from(T::zero())),
         }
     }
@@ -43,8 +45,13 @@ where
         let sin_val = parameters.amplitude
             * num_traits::Float::sin(parameters.frequency * time + parameters.phase)
             + parameters.bias;
+        self.buffer = sin_val;
         self.data = BlockData::from_scalar(sin_val.into());
         sin_val
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer
     }
 }
 
@@ -76,6 +83,12 @@ mod tests {
     use num_traits::Float;
 
     #[test]
+    fn test_sinewave_default_buffer_no_panic() {
+        let block = SinewaveBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_sine_wave() {
         let mut block = SinewaveBlock::<f64>::default();
         let parameters = Parameters {
@@ -89,6 +102,7 @@ mod tests {
 
         assert_eq!(block.generate(&parameters, &context), Float::sin(0.5));
         assert_eq!(block.data.scalar(), Float::sin(0.5));
+        assert_eq!(block.buffer(), Float::sin(0.5));
         context.time = Duration::from_secs(1);
 
         assert_eq!(block.generate(&parameters, &context), Float::sin(1.5));

--- a/pictorus-blocks/src/core_blocks/sliding_window_block.rs
+++ b/pictorus-blocks/src/core_blocks/sliding_window_block.rs
@@ -45,6 +45,11 @@ where
     OldBlockData: FromPass<O>,
 {
     fn default() -> Self {
+        log::warn!(
+            "SlidingWindowBlock constructed via Default; IC not seeded. \
+             Prefer SlidingWindowBlock::new(&parameters) — otherwise buffer() will return \
+             T::default() until the first process() call."
+        );
         SlidingWindowBlock {
             data: <OldBlockData as FromPass<O>>::from_pass(O::default().as_by()),
             memory: Deque::new(),
@@ -110,6 +115,10 @@ where
         }
 
         &self.buffer
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
     }
 }
 
@@ -183,6 +192,10 @@ where
 
         &self.buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 #[cfg(test)]
@@ -201,9 +214,10 @@ mod tests {
             data: [[-1.0], [-1.0], [-1.0]],
         };
 
-        let output = block.process(&Parameters::new(initial_condition), &c, 1.0);
+        let output = *block.process(&Parameters::new(initial_condition), &c, 1.0);
         assert_eq!(output.data.as_flattened(), [-1.0, -1.0, 1.0]);
         assert_eq!(block.data, OldBlockData::from_matrix(&[&[-1.0, -1.0, 1.0]]));
+        assert_eq!(block.buffer(), &output);
 
         let ic2 = Matrix {
             data: [[0.0], [0.0], [0.0]],

--- a/pictorus-blocks/src/core_blocks/sliding_window_block.rs
+++ b/pictorus-blocks/src/core_blocks/sliding_window_block.rs
@@ -25,12 +25,23 @@ impl<I> Parameters<I> {
 ///
 /// OCOLS must equal ICOLS * N
 /// ```
-/// use pictorus_traits::Matrix;
-/// use pictorus_blocks::SlidingWindowBlock;
-/// // Example usage for a sliding window of 3 samples:
-/// let swb_single = SlidingWindowBlock::<3, f64, Matrix<1, 3, f64>>::default();
-/// let swb_vector = SlidingWindowBlock::<3, Matrix<1, 3, f64>, Matrix<1, 9, f64>>::default();
-/// let swb_matrix = SlidingWindowBlock::<3, Matrix<2, 2, f64>, Matrix<2, 6, f64>>::default();
+/// use pictorus_traits::{Matrix, HasIc};
+/// use pictorus_blocks::{SlidingWindowBlock, SlidingWindowBlockParams};
+///
+/// // Scalar input, 3-sample window -> Matrix<1, 3>
+/// let swb_single = SlidingWindowBlock::<3, f64, Matrix<1, 3, f64>>::new(
+///     &SlidingWindowBlockParams::new(Matrix { data: [[0.0], [0.0], [0.0]] }),
+/// );
+///
+/// // Vector input (Matrix<1, 3>), 3-sample window -> Matrix<1, 9>
+/// let swb_vector = SlidingWindowBlock::<3, Matrix<1, 3, f64>, Matrix<1, 9, f64>>::new(
+///     &SlidingWindowBlockParams::new(Matrix { data: [[0.0]; 9] }),
+/// );
+///
+/// // Matrix input (Matrix<2, 2>), 3-sample window -> Matrix<2, 6>
+/// let swb_matrix = SlidingWindowBlock::<3, Matrix<2, 2, f64>, Matrix<2, 6, f64>>::new(
+///     &SlidingWindowBlockParams::new(Matrix { data: [[0.0; 2]; 6] }),
+/// );
 /// ```
 pub struct SlidingWindowBlock<const N: usize, I, O> {
     pub data: OldBlockData,
@@ -45,17 +56,10 @@ where
     OldBlockData: FromPass<O>,
 {
     fn default() -> Self {
-        log::warn!(
-            "SlidingWindowBlock constructed via Default; IC not seeded. \
-             Prefer SlidingWindowBlock::new(&parameters) — otherwise buffer() will return \
-             T::default() until the first process() call."
+        panic!(
+            "SlidingWindowBlock has initial conditions and must be constructed with \
+             SlidingWindowBlock::new(&parameters) (HasIc trait), not Default::default()."
         );
-        SlidingWindowBlock {
-            data: <OldBlockData as FromPass<O>>::from_pass(O::default().as_by()),
-            memory: Deque::new(),
-            buffer: O::default(),
-            _phantom: core::marker::PhantomData,
-        }
     }
 }
 
@@ -208,11 +212,13 @@ mod tests {
     #[test]
     fn test_sliding_window_block() {
         let c = StubContext::default();
-        let mut block = SlidingWindowBlock::<3, f64, Matrix<1, 3, f64>>::default();
 
         let initial_condition = Matrix {
             data: [[-1.0], [-1.0], [-1.0]],
         };
+
+        let mut block =
+            SlidingWindowBlock::<3, f64, Matrix<1, 3, f64>>::new(&Parameters::new(initial_condition));
 
         let output = *block.process(&Parameters::new(initial_condition), &c, 1.0);
         assert_eq!(output.data.as_flattened(), [-1.0, -1.0, 1.0]);
@@ -240,7 +246,6 @@ mod tests {
     #[test]
     fn test_sliding_window_block_vectors() {
         let c = StubContext::default();
-        let mut block = SlidingWindowBlock::<3, Matrix<1, 3, f64>, Matrix<1, 9, f64>>::default();
 
         let ic = Matrix {
             data: [
@@ -257,6 +262,8 @@ mod tests {
         };
 
         let p = Parameters::new(ic);
+        let mut block =
+            SlidingWindowBlock::<3, Matrix<1, 3, f64>, Matrix<1, 9, f64>>::new(&p);
 
         let output = block.process(
             &p,
@@ -374,7 +381,6 @@ mod tests {
     #[test]
     fn test_sliding_window_block_matrix() {
         let c = StubContext::default();
-        let mut block = SlidingWindowBlock::<3, Matrix<2, 2, f64>, Matrix<2, 6, f64>>::default();
 
         let ic = Matrix {
             data: [
@@ -388,6 +394,8 @@ mod tests {
         };
 
         let p = Parameters::new(ic);
+        let mut block =
+            SlidingWindowBlock::<3, Matrix<2, 2, f64>, Matrix<2, 6, f64>>::new(&p);
 
         let output = block.process(
             &p,

--- a/pictorus-blocks/src/core_blocks/spi_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/spi_receive_block.rs
@@ -32,6 +32,7 @@ pub struct SpiReceiveBlock {
     buffer: Vec<u8>,
     pub stale_check: StaleTracker,
     previous_stale_check_time_ms: f64,
+    last_valid: bool,
 }
 
 impl Default for SpiReceiveBlock {
@@ -41,6 +42,7 @@ impl Default for SpiReceiveBlock {
             buffer: Vec::new(),
             stale_check: StaleTracker::from_ms(0.),
             previous_stale_check_time_ms: 0.0,
+            last_valid: false,
         }
     }
 }
@@ -70,10 +72,12 @@ impl ProcessBlock for SpiReceiveBlock {
             self.stale_check.mark_updated(context.time().as_secs_f64());
         }
 
-        (
-            &self.buffer,
-            self.stale_check.is_valid_bool(context.time().as_secs_f64()),
-        )
+        self.last_valid = self.stale_check.is_valid_bool(context.time().as_secs_f64());
+        (&self.buffer, self.last_valid)
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        (&self.buffer, self.last_valid)
     }
 }
 
@@ -92,6 +96,12 @@ mod tests {
     use pictorus_traits::Context;
 
     #[test]
+    fn test_spi_receive_default_buffer_no_panic() {
+        let block = SpiReceiveBlock::default();
+        assert_eq!(block.buffer(), (b"".as_ref(), false));
+    }
+
+    #[test]
     fn test_spi_receive_block() {
         let mut block = SpiReceiveBlock::default();
         let parameters = Parameters::new(4., 100.0);
@@ -99,9 +109,13 @@ mod tests {
         let input_data = &[0x00, 0x01, 0x02, 0x03];
 
         // Buffer the input data
-        let output = block.process(&parameters, &runtime.context(), input_data);
+        let output = {
+            let (data, valid) = block.process(&parameters, &runtime.context(), input_data);
+            (data.to_vec(), valid)
+        };
         assert_eq!(output.0, input_data);
         assert_eq!(block.data.to_bytes(), input_data);
+        assert_eq!(block.buffer(), (output.0.as_slice(), output.1));
         let is_valid = block
             .stale_check
             .is_valid(runtime.context().time().as_secs_f64());

--- a/pictorus-blocks/src/core_blocks/squarewave_block.rs
+++ b/pictorus-blocks/src/core_blocks/squarewave_block.rs
@@ -1,6 +1,6 @@
 use crate::traits::Float;
 use pictorus_block_data::BlockData;
-use pictorus_traits::GeneratorBlock;
+use pictorus_traits::{GeneratorBlock, PassBy};
 
 pub struct Parameters<T: Float> {
     pub amplitude: T,
@@ -25,6 +25,7 @@ impl<T: Float> Parameters<T> {
 /// Outputs a square wave signal with specified amplitude, on duration, off duration, phase, and bias.
 pub struct SquarewaveBlock<T: Float> {
     phantom_output_type: core::marker::PhantomData<T>,
+    buffer: T,
     pub data: BlockData,
 }
 
@@ -35,6 +36,7 @@ where
     fn default() -> Self {
         Self {
             phantom_output_type: core::marker::PhantomData,
+            buffer: T::zero(),
             data: BlockData::from_scalar(T::zero().into()),
         }
     }
@@ -67,8 +69,13 @@ where
         } else {
             parameters.bias + parameters.amplitude
         };
+        self.buffer = output;
         self.data = BlockData::from_scalar(f64::from(output));
         output
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer
     }
 }
 
@@ -78,6 +85,12 @@ mod tests {
 
     use super::*;
     use core::time::Duration;
+
+    #[test]
+    fn test_squarewave_default_buffer_no_panic() {
+        let block = SquarewaveBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
 
     #[test]
     fn test_squarewave_block_f64() {
@@ -96,6 +109,7 @@ mod tests {
         block.generate(&p, &runtime.context());
         assert_eq!(block.generate(&p, &runtime.context()), bias);
         assert_eq!(block.data.scalar(), bias);
+        assert_eq!(block.buffer(), bias);
 
         runtime.set_time(Duration::from_millis(500));
         assert_eq!(block.generate(&p, &runtime.context()), bias + amplitude);

--- a/pictorus-blocks/src/core_blocks/string_format_block.rs
+++ b/pictorus-blocks/src/core_blocks/string_format_block.rs
@@ -50,6 +50,10 @@ where
         self.data = formatted_string.as_bytes().to_vec();
         &self.data
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        &self.data
+    }
 }
 
 pub trait ToString: Pass {
@@ -282,6 +286,12 @@ mod tests {
     use alloc::format;
 
     #[test]
+    fn test_string_format_default_buffer_no_panic() {
+        let block = StringFormatBlock::<f64>::default();
+        assert_eq!(block.buffer(), b"".as_ref());
+    }
+
+    #[test]
     fn test_string_format_block() {
         let formatter = |inputs: &[&str; 3]| format!("{} {} {}", inputs[0], inputs[1], inputs[2]);
         let parameters = Parameters::new(formatter);
@@ -289,12 +299,13 @@ mod tests {
 
         let input = (42.0, "Foo".as_bytes(), &Matrix::zeroed());
         let context = StubContext::default();
-        let output = block.process(&parameters, &context, input);
+        let output = block.process(&parameters, &context, input).to_vec();
 
         assert_eq!(
-            std::str::from_utf8(output).unwrap(),
+            std::str::from_utf8(&output).unwrap(),
             "42.0 Foo [[0.0,0.0],[0.0,0.0]]"
         );
+        assert_eq!(block.buffer(), output.as_slice());
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/sum_block.rs
+++ b/pictorus-blocks/src/core_blocks/sum_block.rs
@@ -7,7 +7,7 @@ pub struct SumBlock<T: Summable>
 where
     pictorus_block_data::BlockData: FromPass<<T as Summable>::Output>,
 {
-    store: Option<T::Output>,
+    store: T::Output,
     pub data: OldBlockData,
 }
 
@@ -17,7 +17,7 @@ where
 {
     fn default() -> Self {
         Self {
-            store: None,
+            store: T::Output::default(),
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
         }
     }
@@ -38,10 +38,15 @@ where
         _context: &dyn pictorus_traits::Context,
         input: PassBy<Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
-        self.store = None;
-        let result = T::get_sum(input, *parameters, &mut self.store);
-        self.data = OldBlockData::from_pass(result);
-        result
+        let mut tmp: Option<T::Output> = None;
+        T::get_sum(input, *parameters, &mut tmp);
+        self.store = tmp.expect("get_sum must initialize the buffer");
+        self.data = OldBlockData::from_pass(self.store.as_by());
+        self.store.as_by()
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.store.as_by()
     }
 }
 
@@ -475,6 +480,12 @@ mod tests {
     use approx::assert_relative_eq;
 
     #[test]
+    fn test_sum_default_buffer_no_panic() {
+        let block = SumBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_one_scalar() {
         let mut block = SumBlock::<f64>::default();
         let input = 3.0;
@@ -484,6 +495,7 @@ mod tests {
         };
         let result = block.process(&parameters, &stub_context, input);
         assert_relative_eq!(result, 3.0);
+        assert_eq!(block.buffer(), result);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/switch_block.rs
+++ b/pictorus-blocks/src/core_blocks/switch_block.rs
@@ -91,6 +91,10 @@ where
         self.data = <OldBlockData as FromPass<T::Output>>::from_pass(res);
         res
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        <T::Output as DefaultStorage>::from_storage(&self.buffer)
+    }
 }
 
 /// Parameters for the SwitchBlock
@@ -313,6 +317,12 @@ mod tests {
     use crate::testing::StubContext;
 
     #[test]
+    fn test_switch_default_buffer_no_panic() {
+        let block = SwitchBlock::<(f64, f64, f64)>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_switch_block_2_scalars() {
         let ctxt = StubContext::default();
 
@@ -323,6 +333,7 @@ mod tests {
         let output = block.process(&parameters, &ctxt, input);
         assert_eq!(output, 1.0);
         assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/timer_block.rs
+++ b/pictorus-blocks/src/core_blocks/timer_block.rs
@@ -117,6 +117,10 @@ impl ProcessBlock for TimerBlock<f64> {
         self.data.set_scalar(self.buffer);
         self.buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer
+    }
 }
 
 #[cfg(test)]
@@ -127,6 +131,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_timer_default_buffer_no_panic() {
+        let block = TimerBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_countdown_timer_non_interruptable() {
         let mut runtime = StubRuntime::default();
         let p = Parameters::new("CountDown", false, 5.0);
@@ -135,6 +145,7 @@ mod tests {
         let output = block.process(&p, &runtime.context(), 0.0);
         assert_eq!(block.data.scalar(), 0.0);
         assert_eq!(output, 0.0);
+        assert_eq!(block.buffer(), output);
 
         runtime.set_time(time::Duration::from_secs_f64(1.0));
         let output = block.process(&p, &runtime.context(), 1.0);

--- a/pictorus-blocks/src/core_blocks/transfer_function_block.rs
+++ b/pictorus-blocks/src/core_blocks/transfer_function_block.rs
@@ -154,6 +154,10 @@ macro_rules! impl_transfer_function {
                 self.data = OldBlockData::from_scalar(self.buffer.into());
                 self.buffer
             }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
+            }
         }
 
         impl<
@@ -234,6 +238,10 @@ macro_rules! impl_transfer_function {
 
                 self.data = OldBlockData::from_pass(self.buffer.as_by());
                 &self.buffer
+            }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
             }
         }
     };

--- a/pictorus-blocks/src/core_blocks/transpose_block.rs
+++ b/pictorus-blocks/src/core_blocks/transpose_block.rs
@@ -22,7 +22,7 @@ impl Default for Parameters {
 /// For scalar inputs this is just a pass-through
 pub struct TransposeBlock<T: Apply> {
     pub data: OldBlockData,
-    store: Option<T::Output>,
+    store: T::Output,
 }
 
 impl<T: Apply> Default for TransposeBlock<T>
@@ -32,7 +32,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
-            store: None,
+            store: T::Output::default(),
         }
     }
 }
@@ -55,40 +55,35 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.store.as_by()
+    }
 }
 
 pub trait Apply: Pass {
     type Output: Pass + Default;
 
-    fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
-        input: PassBy<Self>,
-    ) -> PassBy<'s, Self::Output>;
+    fn apply<'s>(store: &'s mut Self::Output, input: PassBy<Self>) -> PassBy<'s, Self::Output>;
 }
 
 impl<S: Scalar> Apply for S {
     type Output = S;
 
-    fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
-        input: PassBy<Self>,
-    ) -> PassBy<'s, Self::Output> {
-        let output = store.insert(input);
-        output.as_by()
+    fn apply<'s>(store: &'s mut Self::Output, input: PassBy<Self>) -> PassBy<'s, Self::Output> {
+        *store = input;
+        store.as_by()
     }
 }
 
 impl<const NROWS: usize, const NCOLS: usize, S: Scalar> Apply for Matrix<NROWS, NCOLS, S> {
     type Output = Matrix<NCOLS, NROWS, S>;
 
-    fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
-        input: PassBy<Self>,
-    ) -> PassBy<'s, Self::Output> {
+    fn apply<'s>(store: &'s mut Self::Output, input: PassBy<Self>) -> PassBy<'s, Self::Output> {
         let input = input.as_view();
         let transposed = input.transpose();
-        let output = store.insert(Matrix::from_view(&transposed.as_view()));
-        output
+        *store = Matrix::from_view(&transposed.as_view());
+        store
     }
 }
 
@@ -99,6 +94,15 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_transpose_default_buffer_no_panic() {
+        let block = TransposeBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = TransposeBlock::<Matrix<3, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 3, f64>::zeroed());
+    }
+
+    #[test]
     fn test_tranpose_scalar_input() {
         let ctxt = StubContext::default();
         let params = Parameters::default();
@@ -107,6 +111,7 @@ mod tests {
         let output = transpose_block.process(&params, &ctxt, 1.0);
         assert_eq!(output, 1.0);
         assert_eq!(transpose_block.data.scalar(), 1.0);
+        assert_eq!(transpose_block.buffer(), output);
 
         let output = transpose_block.process(&params, &ctxt, 42.0);
         assert_eq!(output, 42.0);

--- a/pictorus-blocks/src/core_blocks/trianglewave_block.rs
+++ b/pictorus-blocks/src/core_blocks/trianglewave_block.rs
@@ -1,6 +1,6 @@
 use crate::traits::Float;
 use pictorus_block_data::BlockData;
-use pictorus_traits::GeneratorBlock;
+use pictorus_traits::{GeneratorBlock, PassBy};
 
 #[derive(Debug, Clone)]
 /// Outputs a triangle wave signal with specified amplitude, frequency, phase, and bias.
@@ -10,6 +10,7 @@ where
     f64: From<T>,
 {
     phantom: core::marker::PhantomData<T>,
+    buffer: T,
     pub data: BlockData,
 }
 
@@ -21,6 +22,7 @@ where
     fn default() -> Self {
         Self {
             phantom: core::marker::PhantomData,
+            buffer: T::zero(),
             data: BlockData::from_scalar(f64::from(T::zero())),
         }
     }
@@ -49,8 +51,13 @@ where
         // y is in the range [0, 0.5] over a t value from 0 to 1. Scale it by 4 ( to a range of [0, 2] )
         // then shift it down by 1 to get it in the range [-1, 1], then scale it by the amplitude and add the bias.
         let val = (four * y - T::one()) * parameters.amplitude + parameters.bias;
+        self.buffer = val;
         self.data = BlockData::from_scalar(val.into());
         val
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer
     }
 }
 
@@ -82,6 +89,12 @@ mod tests {
     const PI: f64 = core::f64::consts::PI;
 
     #[test]
+    fn test_trianglewave_default_buffer_no_panic() {
+        let block = TrianglewaveBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_trianglewave_block_simple() {
         let context = StubContext::new(
             Duration::from_secs(0),
@@ -98,8 +111,9 @@ mod tests {
 
         let mut block = TrianglewaveBlock::default();
 
-        block.generate(&params, &runtime.context()); // T = 0
+        let out = block.generate(&params, &runtime.context()); // T = 0
         assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 1e-6);
+        assert_eq!(block.buffer(), out);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 2

--- a/pictorus-blocks/src/core_blocks/trigonometry_block.rs
+++ b/pictorus-blocks/src/core_blocks/trigonometry_block.rs
@@ -82,6 +82,10 @@ macro_rules! impl_trig_block {
                 self.data = OldBlockData::from_scalar(output.into());
                 output
             }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
+            }
         }
 
         impl<const ROWS: usize, const COLS: usize> ProcessBlock
@@ -119,6 +123,10 @@ macro_rules! impl_trig_block {
                 self.data = OldBlockData::from_pass(&self.buffer);
                 &self.buffer
             }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
+            }
         }
     };
 }
@@ -134,6 +142,12 @@ mod tests {
     use approx::assert_relative_eq;
     use core::f64::consts::PI;
     use rstest::rstest;
+
+    #[test]
+    fn test_trigonometry_default_buffer_no_panic() {
+        let block = TrigonometryBlock::<f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
 
     #[rstest]
     #[case::sin_0("Sine", 0.0, 0.0)]
@@ -172,6 +186,7 @@ mod tests {
         let output = block.process(&p, &c, input);
         assert_relative_eq!(output, expected, max_relative = 0.00001);
         assert_relative_eq!(block.data.scalar(), expected, max_relative = 0.00001);
+        assert_eq!(block.buffer(), output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/udp_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/udp_receive_block.rs
@@ -30,6 +30,7 @@ pub struct UdpReceiveBlock {
     pub stale_check: StaleTracker,
     buffer: Vec<u8>,
     previous_stale_check_time_ms: f64,
+    last_valid: bool,
 }
 
 impl Default for UdpReceiveBlock {
@@ -39,6 +40,7 @@ impl Default for UdpReceiveBlock {
             stale_check: StaleTracker::from_ms(0.0),
             buffer: Vec::new(),
             previous_stale_check_time_ms: 0.,
+            last_valid: false,
         }
     }
 }
@@ -73,9 +75,22 @@ impl ProcessBlock for UdpReceiveBlock {
             self.data.set_bytes(&self.buffer);
         }
 
-        (
-            &self.buffer,
-            self.stale_check.is_valid_bool(context.time().as_secs_f64()),
-        )
+        self.last_valid = self.stale_check.is_valid_bool(context.time().as_secs_f64());
+        (&self.buffer, self.last_valid)
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        (&self.buffer, self.last_valid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_udp_receive_default_buffer_no_panic() {
+        let block = UdpReceiveBlock::default();
+        assert_eq!(block.buffer(), (b"".as_ref(), false));
     }
 }

--- a/pictorus-blocks/src/core_blocks/udp_transmit_block.rs
+++ b/pictorus-blocks/src/core_blocks/udp_transmit_block.rs
@@ -61,4 +61,19 @@ impl ProcessBlock for UdpTransmitBlock {
         self.data.set_bytes(&self.buffer);
         &self.buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        &self.buffer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_udp_transmit_default_buffer_no_panic() {
+        let block = UdpTransmitBlock::default();
+        assert_eq!(block.buffer(), b"".as_ref());
+    }
 }

--- a/pictorus-blocks/src/core_blocks/vector_index_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_index_block.rs
@@ -89,6 +89,10 @@ where
         self.buffer = output.into_tuple();
         self.buffer.as_by()
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 #[cfg(test)]
@@ -103,6 +107,12 @@ mod tests {
     use std::vec::Vec;
 
     #[test]
+    fn test_vector_index_default_buffer_no_panic() {
+        let block = VectorIndexBlock::<1, f64, Matrix<3, 1, f64>>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_vector_index_block_scalar() {
         let c = StubContext::default();
         let mut index_block = VectorIndexBlock::<1, f64, Matrix<3, 1, f64>>::default();
@@ -115,6 +125,7 @@ mod tests {
         let parameters = Parameters::<1>::new(&vec_string_indexes);
         let output = index_block.process(&parameters, &c, &input);
         assert_eq!(output, 3.0);
+        assert_eq!(index_block.buffer(), output);
 
         // This also works:
         let vec_string_indexes = vec!["2".to_string()];

--- a/pictorus-blocks/src/core_blocks/vector_merge_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_merge_block.rs
@@ -32,7 +32,7 @@ where
     I: Pass + Mergeable<O>,
 {
     pub data: OldBlockData,
-    buffer: Option<<I as Mergeable<O>>::Output>,
+    buffer: <I as Mergeable<O>>::Output,
     _phantom: core::marker::PhantomData<I>,
 }
 
@@ -47,7 +47,7 @@ where
             data: <OldBlockData as FromPass<<I as Mergeable<O>>::Output>>::from_pass(
                 <I as Mergeable<O>>::Output::default().as_by(),
             ),
-            buffer: None,
+            buffer: <I as Mergeable<O>>::Output::default(),
             _phantom: core::marker::PhantomData,
         }
     }
@@ -70,11 +70,17 @@ where
         input: PassBy<Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
         let mut offset = 0;
-        let output = I::get_merge(input, &mut offset, &mut self.buffer);
-        self.data = OldBlockData::from_pass(output);
+        let mut tmp: Option<<I as Mergeable<O>>::Output> = None;
+        I::get_merge(input, &mut offset, &mut tmp);
+        self.buffer = tmp.expect("get_merge must initialize the buffer");
+        self.data = OldBlockData::from_pass(self.buffer.as_by());
         self.data
             .set_type(pictorus_block_data::BlockDataType::Vector);
-        output
+        self.buffer.as_by()
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
     }
 }
 
@@ -344,6 +350,12 @@ mod tests {
     use pictorus_block_data::{BlockData as OldBlockData, BlockDataType, ToPass};
 
     #[test]
+    fn test_vector_merge_default_buffer_no_panic() {
+        let block = VectorMergeBlock::<Matrix<1, 1, f64>, f64>::default();
+        assert_eq!(block.buffer(), &Matrix::<1, 1, f64>::zeroed());
+    }
+
+    #[test]
     fn test_vector_merge_block_scalar_original_test() {
         // Should be able to pass in scalars, vectors, or matrices,
         // and get back a flattened vector
@@ -405,8 +417,9 @@ mod tests {
         let mut block = VectorMergeBlock::<Matrix<1, 1, f64>, f64>::default();
         let stub_context = StubContext::default();
         let parameters = Parameters {};
-        let result = block.process(&parameters, &stub_context, 1.);
-        assert_eq!(result, &Matrix { data: [[1.]] });
+        let result = *block.process(&parameters, &stub_context, 1.);
+        assert_eq!(result, Matrix { data: [[1.]] });
+        assert_eq!(block.buffer(), &result);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/vector_norm_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_norm_block.rs
@@ -25,7 +25,7 @@ where
     T: Apply,
 {
     pub data: OldBlockData,
-    buffer: Option<T::Output>,
+    buffer: T::Output,
 }
 
 impl<T> Default for VectorNormBlock<T>
@@ -36,7 +36,7 @@ where
     fn default() -> Self {
         Self {
             data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
-            buffer: None,
+            buffer: T::Output::default(),
         }
     }
 }
@@ -60,15 +60,16 @@ where
         self.data = OldBlockData::from_pass(output);
         output
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 pub trait Apply: Pass {
     type Output: Pass + Default;
 
-    fn apply<'s>(
-        store: &'s mut Option<Self::Output>,
-        input: PassBy<Self>,
-    ) -> PassBy<'s, Self::Output>;
+    fn apply<'s>(store: &'s mut Self::Output, input: PassBy<Self>) -> PassBy<'s, Self::Output>;
 }
 
 // Promote i8, u8, i16, u16, i32, and u32
@@ -78,7 +79,7 @@ macro_rules! impl_vector_norm_apply {
             type Output = $otype;
 
             fn apply<'s>(
-                store: &'s mut Option<Self::Output>,
+                store: &'s mut Self::Output,
                 input: PassBy<Self>,
             ) -> PassBy<'s, Self::Output> {
                 let mut output = Matrix::<ROWS, COLS, $otype>::zeroed();
@@ -88,7 +89,7 @@ macro_rules! impl_vector_norm_apply {
                     }
                 }
                 let n = output.as_view().norm();
-                *store = Some(n);
+                *store = n;
                 n
             }
         }
@@ -109,11 +110,11 @@ macro_rules! impl_vector_norm {
             type Output = $type;
 
             fn apply<'s>(
-                store: &'s mut Option<Self::Output>,
+                store: &'s mut Self::Output,
                 input: PassBy<Self>,
             ) -> PassBy<'s, Self::Output> {
                 let n = input.as_view().norm();
-                *store = Some(n);
+                *store = n;
                 n
             }
         }
@@ -128,6 +129,12 @@ mod tests {
     use super::*;
     use crate::testing::StubContext;
     use paste::paste;
+
+    #[test]
+    fn test_vector_norm_default_buffer_no_panic() {
+        let block = VectorNormBlock::<Matrix<1, 2, f64>>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
 
     macro_rules! test_vector_norm {
         ($type:ty) => {
@@ -145,6 +152,7 @@ mod tests {
                     let output = block.process(&p, &c, &input);
                     assert_eq!(output, [<5 $type>].into());
                     assert_eq!(block.data, OldBlockData::from_scalar([<5 $type>].into()));
+                    assert_eq!(block.buffer(), output);
                 }
 
                 #[test]

--- a/pictorus-blocks/src/core_blocks/vector_reshape_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_reshape_block.rs
@@ -70,6 +70,10 @@ where
         self.data = <OldBlockData as FromPass<Self::Output>>::from_pass(&self.buffer);
         &self.buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 impl<T> ProcessBlock for VectorReshapeBlock<T, Matrix<1, 1, T>>
@@ -89,6 +93,10 @@ where
         self.buffer.data[0][0] = input;
         self.data = <OldBlockData as FromPass<Self::Output>>::from_pass(&self.buffer);
         &self.buffer
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
     }
 }
 
@@ -112,6 +120,12 @@ mod tests {
     ///      let _output = block.process(&parameters, &c, &input);
     /// }
     /// ```
+    #[test]
+    fn test_vector_reshape_default_buffer_no_panic() {
+        let block = VectorReshapeBlock::<f64, Matrix<1, 1, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<1, 1, f64>::zeroed());
+    }
+
     macro_rules! impl_vector_reshape_tests {
         ($type:ty) => {
             paste! {

--- a/pictorus-blocks/src/core_blocks/vector_slice_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_slice_block.rs
@@ -124,6 +124,10 @@ where
         self.data = OldBlockData::from_pass(&self.buffer);
         &self.buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 impl<S: Scalar, const IROWS: usize, const ICOLS: usize> ProcessBlock
@@ -155,10 +159,25 @@ where
         self.data = OldBlockData::from_scalar(self.buffer.into());
         self.buffer
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn test_vector_slice_default_buffer_no_panic() {
+        use super::*;
+
+        let block = VectorSliceBlock::<Matrix<4, 4, f64>, f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+
+        let block = VectorSliceBlock::<Matrix<4, 4, f64>, Matrix<2, 2, f64>>::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
+    }
+
     #[test]
     fn test_vector_slice_block_1x1_scalar() {
         use super::*;

--- a/pictorus-blocks/src/core_blocks/vector_sort_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_sort_block.rs
@@ -91,6 +91,10 @@ macro_rules! impl_vector_sort {
                 self.data = <OldBlockData as FromPass<Self::Output>>::from_pass(&self.buffer);
                 &self.buffer
             }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
+            }
         }
 
         impl ProcessBlock for VectorSortBlock<$type, $type> {
@@ -107,6 +111,10 @@ macro_rules! impl_vector_sort {
                 self.buffer = input;
                 self.data = OldBlockData::from_scalar(self.buffer.into());
                 self.buffer
+            }
+
+            fn buffer(&self) -> PassBy<'_, Self::Output> {
+                self.buffer.as_by()
             }
         }
     };
@@ -140,6 +148,12 @@ mod tests {
     ///     let output = block.process(&parameters, &c, &input);
     /// }
     /// ```
+    #[test]
+    fn test_vector_sort_default_buffer_no_panic() {
+        let block = VectorSortBlock::<f64, f64>::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
     macro_rules! impl_vector_sort_tests {
         ($type:ty) => {
             paste! {

--- a/pictorus-blocks/src/std_blocks/fft_block.rs
+++ b/pictorus-blocks/src/std_blocks/fft_block.rs
@@ -1,6 +1,6 @@
 use crate::traits::Float;
 use pictorus_block_data::{BlockData as OldBlockData, FromPass};
-use pictorus_traits::{Matrix, Pass, ProcessBlock};
+use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 use rustfft::{num_complex::Complex, Fft, FftPlanner};
 use std::sync::Arc;
 
@@ -68,6 +68,10 @@ impl<T: Float, const N: usize> ProcessBlock for FftBlock<T, N> {
 
         self.output.as_by()
     }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.output.as_by()
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -89,6 +93,12 @@ mod tests {
     use approx::assert_relative_eq;
     use core::time::Duration;
     use pictorus_traits::GeneratorBlock;
+
+    #[test]
+    fn test_fft_default_buffer_no_panic() {
+        let block: FftBlock<f64, 10> = FftBlock::default();
+        assert_eq!(block.buffer(), &Matrix::<2, 10, f64>::zeroed());
+    }
 
     #[test]
     fn test_fft_block() {

--- a/pictorus-blocks/src/std_blocks/fmu_block.rs
+++ b/pictorus-blocks/src/std_blocks/fmu_block.rs
@@ -163,6 +163,10 @@ impl<const N_IN: usize, const N_OUT: usize> ProcessBlock for FmuBlock<N_IN, N_OU
             .collect();
         &self.buffer
     }
+
+    fn buffer(&self) -> pictorus_traits::PassBy<'_, Self::Output> {
+        &self.buffer
+    }
 }
 
 /// Parameters for the FMU block.
@@ -202,6 +206,13 @@ impl Parameters {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_fmu_default_buffer_no_panic() {
+        use pictorus_traits::ProcessBlock;
+        let block: FmuBlock<2, 3> = FmuBlock::default();
+        assert_eq!(block.buffer(), &[0.0, 0.0, 0.0]);
+    }
 
     #[test]
     fn test_impls_associated_types() {

--- a/pictorus-blocks/src/std_blocks/system_time_block.rs
+++ b/pictorus-blocks/src/std_blocks/system_time_block.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Datelike, Local, Timelike};
 use pictorus_block_data::BlockData as OldBlockData;
-use pictorus_traits::GeneratorBlock;
+use pictorus_traits::{GeneratorBlock, PassBy};
 
 /// This block can be used in `std` environments to get the current system time.
 /// The time output can be in different formats, such as epoch time, second, minute, hour, day of the month, day of the year, month, or year.
@@ -48,6 +48,10 @@ impl GeneratorBlock for SystemTimeBlock {
         let time_now = self.start_time + elpased_time;
         self.output = get_output_value(time_now, parameters.method);
         self.data = OldBlockData::from_scalar(self.output);
+        self.output
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
         self.output
     }
 }
@@ -108,6 +112,12 @@ mod tests {
     }
 
     #[test]
+    fn test_system_time_default_buffer_no_panic() {
+        let block = SystemTimeBlock::default();
+        assert_eq!(block.buffer(), 0.0);
+    }
+
+    #[test]
     fn test_system_time_block() {
         let mut block: SystemTimeBlock = Default::default();
         let start_time = block.start_time;
@@ -123,5 +133,6 @@ mod tests {
         let output = block.generate(&params, &context);
         assert_eq!(output, start_time.timestamp() as f64 + 42.0);
         assert_eq!(block.data.scalar(), start_time.timestamp() as f64 + 42.0);
+        assert_eq!(block.buffer(), output);
     }
 }

--- a/pictorus-traits/src/lib.rs
+++ b/pictorus-traits/src/lib.rs
@@ -323,9 +323,15 @@ pub trait ProcessBlock: Default {
         context: &dyn Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output>;
+
+    /// A cache of the blocks last output.
+    fn buffer<'b>(&'b self) -> PassBy<'b, Self::Output>;
 }
 
 pub trait HasIc: ProcessBlock {
+    /// Constructs a new instance of the block with the given initial conditions. This should be
+    /// used in place of `Default::default()` when the block has initial conditions that need to be seeded 
+    /// to ensure the .buffer() method returns the correct T-0 value.
     fn new(parameters: &Self::Parameters) -> Self;
 }
 
@@ -341,6 +347,9 @@ pub trait GeneratorBlock: Default {
         parameters: &Self::Parameters,
         context: &dyn Context,
     ) -> PassBy<'_, Self::Output>;
+
+    /// A cache of the blocks last output.
+    fn buffer<'b>(&'b self) -> PassBy<'b, Self::Output>;
 }
 
 /// An output block

--- a/pictorus-traits/src/lib.rs
+++ b/pictorus-traits/src/lib.rs
@@ -330,7 +330,7 @@ pub trait ProcessBlock: Default {
 
 pub trait HasIc: ProcessBlock {
     /// Constructs a new instance of the block with the given initial conditions. This should be
-    /// used in place of `Default::default()` when the block has initial conditions that need to be seeded 
+    /// used in place of `Default::default()` when the block has initial conditions that need to be seeded
     /// to ensure the .buffer() method returns the correct T-0 value.
     fn new(parameters: &Self::Parameters) -> Self;
 }


### PR DESCRIPTION
TL; DR:
- Add .buffer() function to Generator and Process blocks.
- Implement the .buffer() function on all generator and process blocks.
- Create a valid buffer field which can be used to replace .data access and caching.
- Warn users if they use a ::default() constructor for blocks with `HasIc`

Longer winded reason for changes:

Feedback loops necessitate that any block at a feedback edge be able to reach into an upstream block before the upstream block has run and grab a valid value. This was previously done using the heap allocated .data field backed by `OldBlockData`, which we are trying to phase out.

For example, a sum block with inputs from a constant block and a delay delay:
<img width="1355" height="561" alt="Screenshot 2026-05-14 at 8 56 03 AM" src="https://github.com/user-attachments/assets/eb6d75ab-aadd-41e0-8bb7-545ba3c060d5" />

Produces:
```
impl MainState {
    pub fn new(_context: &Context) -> Self {
        // Constant1
        let constant1 = ConstantBlock::default();

        // Delay1
        let delay1 = DelayBlock::default();

        // Sum1
        let sum1 = SumBlock::default();

        MainState {
            last_time_s: -1.0,
            constant1,
            delay1,
            sum1,
        }
    }

    pub fn run(&mut self, context: &mut Context) {
        let app_time_s = context.app_time_s();
        let runtime_ctx = context.get_runtime_context();

        if self.last_time_s == -1.0 {
            self.last_time_s = app_time_s;
        }
        let timestep_s: f64 = app_time_s - self.last_time_s;

        log::debug!(
            "-- State::MainState iteration. Time: {}s (dt: {}s) ",
            app_time_s,
            timestep_s
        );

        // Constant1
        let constant1_0 = self.constant1.generate(
            &context.application_parameters.constant1_a65d6,
            &runtime_ctx,
        );

        // Delay1
        let delay1_0 = self.delay1.process(
            &context.application_parameters.delay1_a65d9,
            &runtime_ctx,
            self.sum1.data.to_pass(),
        );
        context.log_data.delay1_a65d9_0(delay1_0);
        // Sum1
        let sum1_0 = self.sum1.process(
            &context.application_parameters.sum1_a65d7,
            &runtime_ctx,
            (constant1_0, delay1_0),
        );
        context.log_data.sum1_a65d7_0(sum1_0);

        self.last_time_s = app_time_s;
    }

    pub fn post_run(&mut self) {}
}
```

The Delay block uses a value from the Sum block BEFORE the Sum block has been called. In most cases, this defaults to `T::default()` values. In a world without `BlockData`, we need a similar mechanism.

This PR bridges the gap, by forcing all `ProcessBlock` and `GeneratorBlock`s to implement a .buffer() function that returns a buffer value (preferably in a stack allocated field) for a block even before it has been run. Most blocks were pretty easy since the generics have been constrained to require the `Default` trait which was used to fill out `OldBlockData` at construction. This required blocks to have their `buffer: Option<T::Output>` converted to `buffer: T::Output` and a value of `T::default()` assigned in the constructor. Now the buffer (or store or output) field provides the same service as .data.

Several blocks had internal traits (e.g. `Apply`) and implementations that passed in an Option<T> and were updated to use the updated non-option buffer. `AggregateBlock` is an example of this.

Finally, there are 8 stateful blocks that have Initial Conditions, which are passed in via `Parameters`, which the buffer should reflect. Codegen orders block execution in a way that a stateful block will go first; in the example above, Delay executes before Sum. We call `::default()` when constructing blocks, which doesn't correctly seed either `.data` or `.buffer` fields. If the user were to hand coded blocks in such a way that they pulled `delay1.buffer()` BEFORE `delay1.process()` was run, they would get the values set in `::default()` and not the initial conditions. The correct action should be to instantiate an IC block using the `HasIc::new(...)` function so that the `.data` and `.buffer` values are correctly seeded with the IC. This is why there is a `warn!` in the `::default()` function implementation for any block that implements `HasIc`.

After all of this is said and done, the new `.data` replacement looks like:
```
impl MainState {
    pub fn new(context: &Context) -> Self {
        // Constant1
        let constant1 = ConstantBlock::default();

        // Delay1
        let delay1 = DelayBlock::new(&context.application_parameters.delay1_4d2b7);

        // Sum1
        let sum1 = SumBlock::default();

        MainState {
            last_time_s: -1.0,
            constant1,
            delay1,
            sum1,
        }
    }

    pub fn run(&mut self, context: &mut Context) {
        let app_time_s = context.app_time_s();
        let runtime_ctx = context.get_runtime_context();

        if self.last_time_s == -1.0 {
            self.last_time_s = app_time_s;
        }
        let timestep_s: f64 = app_time_s - self.last_time_s;

        log::debug!(
            "-- State::MainState iteration. Time: {}s (dt: {}s) ",
            app_time_s,
            timestep_s
        );

        // Constant1
        let constant1_0 = self.constant1.generate(
            &context.application_parameters.constant1_4d2b4,
            &runtime_ctx,
        );

        // If the user tried to grab delay1.data after using the `::default()` constructor, 
        // it would be incorrect here. Using ::new(...) avoids this issue.

        // Delay1
        let delay1_0 = self.delay1.process(
            &context.application_parameters.delay1_4d2b7,
            &runtime_ctx,
            self.sum1.buffer(),    // <--- no more .data
        );
        context.log_data.delay1_4d2b7_0(delay1_0);
        // Sum1
        let sum1_0 = self.sum1.process(
            &context.application_parameters.sum1_4d2b5,
            &runtime_ctx,
            (constant1_0, delay1_0),
        );
        context.log_data.sum1_4d2b5_0(sum1_0);

        self.last_time_s = app_time_s;
    }

    pub fn post_run(&mut self) {}
}
```

Additional things to consider:
- We might be able to go back and clean up some of the helper traits since we have a mutable place to store interim data.
- It may be worth removing the ::default() constructor for any block with `HasIc` instead of warning the user

