### PR TITLE
Changes:

### DIFF
--- a/pictorus-blocks/src/core_blocks/change_detection_block.rs
+++ b/pictorus-blocks/src/core_blocks/change_detection_block.rs
@@ -28,10 +28,12 @@ where
     OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
-        panic!(
-            "ChangeDetectionBlock has initial conditions and must be constructed with \
-             ChangeDetectionBlock::new(&parameters) (HasIc trait), not Default::default()."
-        );
+        const {
+            panic!(
+                "ChangeDetectionBlock has initial conditions and must be constructed with \
+                 ChangeDetectionBlock::new(&parameters) (HasIc trait), not Default::default()."
+            )
+        }
     }
 }
 

--- a/pictorus-blocks/src/core_blocks/delay_block.rs
+++ b/pictorus-blocks/src/core_blocks/delay_block.rs
@@ -36,10 +36,12 @@ where
     pictorus_block_data::BlockData: FromPass<T>,
 {
     fn default() -> Self {
-        panic!(
-            "DelayBlock has initial conditions and must be constructed with \
-             DelayBlock::new(&parameters) (HasIc trait), not Default::default()."
-        );
+        const {
+            panic!(
+                "DelayBlock has initial conditions and must be constructed with \
+                 DelayBlock::new(&parameters) (HasIc trait), not Default::default()."
+            )
+        }
     }
 }
 

--- a/pictorus-blocks/src/core_blocks/derivative_block.rs
+++ b/pictorus-blocks/src/core_blocks/derivative_block.rs
@@ -21,10 +21,12 @@ where
     pictorus_block_data::BlockData: FromPass<T>,
 {
     fn default() -> Self {
-        panic!(
-            "DerivativeBlock has initial conditions and must be constructed with \
-             DerivativeBlock::new(&parameters) (HasIc trait), not Default::default()."
-        );
+        const {
+            panic!(
+                "DerivativeBlock has initial conditions and must be constructed with \
+                 DerivativeBlock::new(&parameters) (HasIc trait), not Default::default()."
+            )
+        }
     }
 }
 

--- a/pictorus-blocks/src/core_blocks/frequency_filter_block.rs
+++ b/pictorus-blocks/src/core_blocks/frequency_filter_block.rs
@@ -30,10 +30,12 @@ where
     OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
-        panic!(
-            "FrequencyFilterBlock has initial conditions and must be constructed with \
-             FrequencyFilterBlock::new(&parameters) (HasIc trait), not Default::default()."
-        );
+        const {
+            panic!(
+                "FrequencyFilterBlock has initial conditions and must be constructed with \
+                 FrequencyFilterBlock::new(&parameters) (HasIc trait), not Default::default()."
+            )
+        }
     }
 }
 

--- a/pictorus-blocks/src/core_blocks/iir_filter_block.rs
+++ b/pictorus-blocks/src/core_blocks/iir_filter_block.rs
@@ -22,10 +22,12 @@ where
     OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
-        panic!(
-            "IirFilterBlock has initial conditions and must be constructed with \
-             IirFilterBlock::new(&parameters) (HasIc trait), not Default::default()."
-        );
+        const {
+            panic!(
+                "IirFilterBlock has initial conditions and must be constructed with \
+                 IirFilterBlock::new(&parameters) (HasIc trait), not Default::default()."
+            )
+        }
     }
 }
 

--- a/pictorus-blocks/src/core_blocks/iir_filter_block.rs
+++ b/pictorus-blocks/src/core_blocks/iir_filter_block.rs
@@ -5,10 +5,6 @@ use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{HasIc, Matrix, Pass, PassBy, ProcessBlock};
 
 /// Block for applying an Infinite Impulse Response (IIR) filter to an input signal.
-///
-/// Construct via `HasIc::new(¶ms)` to seed the buffer with the IC, or
-/// `Default::default()` to start at `T::default()`. Codegen uses `::new` for HasIc
-/// blocks so the buffer is always sensibly seeded before the first `process()`.
 pub struct IirFilterBlock<T: Pass + Default>
 where
     OldBlockData: FromPass<T>,

--- a/pictorus-blocks/src/core_blocks/integral_block.rs
+++ b/pictorus-blocks/src/core_blocks/integral_block.rs
@@ -29,10 +29,12 @@ where
     OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
-        panic!(
-            "IntegralBlock has initial conditions and must be constructed with \
-             IntegralBlock::new(&parameters) (HasIc trait), not Default::default()."
-        );
+        const {
+            panic!(
+                "IntegralBlock has initial conditions and must be constructed with \
+                 IntegralBlock::new(&parameters) (HasIc trait), not Default::default()."
+            )
+        }
     }
 }
 

--- a/pictorus-blocks/src/core_blocks/mod.rs
+++ b/pictorus-blocks/src/core_blocks/mod.rs
@@ -225,9 +225,9 @@ mod sinewave_block;
 pub use sinewave_block::SinewaveBlock;
 
 mod sliding_window_block;
-pub use sliding_window_block::SlidingWindowBlock;
 #[doc(hidden)]
 pub use sliding_window_block::Parameters as SlidingWindowBlockParams;
+pub use sliding_window_block::SlidingWindowBlock;
 
 mod spi_receive_block;
 #[doc(hidden)]

--- a/pictorus-blocks/src/core_blocks/pid_block.rs
+++ b/pictorus-blocks/src/core_blocks/pid_block.rs
@@ -32,10 +32,12 @@ where
     (T, R): IntegralApply<Output = T>,
 {
     fn default() -> Self {
-        panic!(
-            "PidBlock has initial conditions and must be constructed with \
-             PidBlock::new(&parameters) (HasIc trait), not Default::default()."
-        );
+        const {
+            panic!(
+                "PidBlock has initial conditions and must be constructed with \
+                 PidBlock::new(&parameters) (HasIc trait), not Default::default()."
+            )
+        }
     }
 }
 

--- a/pictorus-blocks/src/core_blocks/sliding_window_block.rs
+++ b/pictorus-blocks/src/core_blocks/sliding_window_block.rs
@@ -56,10 +56,12 @@ where
     OldBlockData: FromPass<O>,
 {
     fn default() -> Self {
-        panic!(
-            "SlidingWindowBlock has initial conditions and must be constructed with \
-             SlidingWindowBlock::new(&parameters) (HasIc trait), not Default::default()."
-        );
+        const {
+            panic!(
+                "SlidingWindowBlock has initial conditions and must be constructed with \
+                 SlidingWindowBlock::new(&parameters) (HasIc trait), not Default::default()."
+            )
+        }
     }
 }
 
@@ -217,8 +219,9 @@ mod tests {
             data: [[-1.0], [-1.0], [-1.0]],
         };
 
-        let mut block =
-            SlidingWindowBlock::<3, f64, Matrix<1, 3, f64>>::new(&Parameters::new(initial_condition));
+        let mut block = SlidingWindowBlock::<3, f64, Matrix<1, 3, f64>>::new(&Parameters::new(
+            initial_condition,
+        ));
 
         let output = *block.process(&Parameters::new(initial_condition), &c, 1.0);
         assert_eq!(output.data.as_flattened(), [-1.0, -1.0, 1.0]);
@@ -262,8 +265,7 @@ mod tests {
         };
 
         let p = Parameters::new(ic);
-        let mut block =
-            SlidingWindowBlock::<3, Matrix<1, 3, f64>, Matrix<1, 9, f64>>::new(&p);
+        let mut block = SlidingWindowBlock::<3, Matrix<1, 3, f64>, Matrix<1, 9, f64>>::new(&p);
 
         let output = block.process(
             &p,
@@ -394,8 +396,7 @@ mod tests {
         };
 
         let p = Parameters::new(ic);
-        let mut block =
-            SlidingWindowBlock::<3, Matrix<2, 2, f64>, Matrix<2, 6, f64>>::new(&p);
+        let mut block = SlidingWindowBlock::<3, Matrix<2, 2, f64>, Matrix<2, 6, f64>>::new(&p);
 
         let output = block.process(
             &p,


### PR DESCRIPTION
Blocks that implement HasIc should not use the ::default() constructor and are configured to panic! if ::default() is invoked.

This PR changes the failure to be at compile time instead of runtime.

<img width="1210" height="472" alt="Screenshot 2026-05-15 at 2 13 06 PM" src="https://github.com/user-attachments/assets/e44d4551-1904-4f96-a9c5-4ccdabaa72f4" />

Also has some `cargo fmt` adjustments.