### PR TITLE
Remove BlockData from GeneratorBlocks

### DIFF
--- a/pictorus-blocks/src/core_blocks/app_time_block.rs
+++ b/pictorus-blocks/src/core_blocks/app_time_block.rs
@@ -1,5 +1,4 @@
 use crate::traits::Float;
-use pictorus_block_data::BlockData;
 use pictorus_traits::{GeneratorBlock, PassBy, Scalar};
 
 #[derive(Debug, Clone, Default)]
@@ -16,7 +15,6 @@ impl Parameters {
 pub struct AppTimeBlock<T: Scalar + Float> {
     phantom: core::marker::PhantomData<T>,
     buffer: T,
-    pub data: BlockData,
 }
 
 impl<T: Scalar + Float> Default for AppTimeBlock<T>
@@ -27,7 +25,6 @@ where
         Self {
             phantom: core::marker::PhantomData,
             buffer: T::zero(),
-            data: BlockData::from_scalar(f64::from(T::zero())),
         }
     }
 }
@@ -47,7 +44,6 @@ where
     ) -> pictorus_traits::PassBy<'_, Self::Output> {
         let time = T::from_duration(context.time());
         self.buffer = time;
-        self.data = BlockData::from_scalar(time.into());
         time
     }
 
@@ -78,7 +74,7 @@ mod tests {
         for _ in 0..100 {
             let context = runtime.context();
             let output = block.generate(&parameters, &context);
-            assert_eq!(output, block.data.scalar());
+            assert_eq!(output, block.buffer());
             assert_eq!(block.buffer(), output);
             runtime.tick();
         }

--- a/pictorus-blocks/src/core_blocks/app_time_block.rs
+++ b/pictorus-blocks/src/core_blocks/app_time_block.rs
@@ -75,7 +75,6 @@ mod tests {
             let context = runtime.context();
             let output = block.generate(&parameters, &context);
             assert_eq!(output, block.buffer());
-            assert_eq!(block.buffer(), output);
             runtime.tick();
         }
     }

--- a/pictorus-blocks/src/core_blocks/bytes_literal_block.rs
+++ b/pictorus-blocks/src/core_blocks/bytes_literal_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::BlockData;
 use pictorus_traits::{ByteSliceSignal, GeneratorBlock};
 
 pub struct Parameters<const CHARS: usize> {
@@ -14,15 +13,11 @@ impl<const CHARS: usize> Parameters<CHARS> {
 /// Output a constant byte slice as a signal.
 pub struct BytesLiteralBlock<const CHARS: usize> {
     buffer: [u8; CHARS],
-    pub data: BlockData,
 }
 
 impl<const CHARS: usize> Default for BytesLiteralBlock<CHARS> {
     fn default() -> Self {
-        Self {
-            data: BlockData::from_bytes(&[0; CHARS]),
-            buffer: [0; CHARS],
-        }
+        Self { buffer: [0; CHARS] }
     }
 }
 
@@ -35,7 +30,6 @@ impl<const CHARS: usize> GeneratorBlock for BytesLiteralBlock<CHARS> {
         parameters: &Self::Parameters,
         _context: &dyn pictorus_traits::Context,
     ) -> pictorus_traits::PassBy<'_, Self::Output> {
-        self.data = BlockData::from_bytes(&parameters.value);
         self.buffer = parameters.value;
         &self.buffer
     }
@@ -68,7 +62,6 @@ mod tests {
 
         let output = block.generate(&parameters, &context).to_vec();
         assert_eq!(output, "Hello World".as_bytes());
-        assert_eq!(block.data, BlockData::from_bytes("Hello World".as_bytes()));
         assert_eq!(block.buffer(), output.as_slice());
     }
 }

--- a/pictorus-blocks/src/core_blocks/constant_block.rs
+++ b/pictorus-blocks/src/core_blocks/constant_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{GeneratorBlock, Matrix, Pass, PassBy, Scalar};
 
 pub struct Parameters<T> {
@@ -16,19 +15,16 @@ pub struct ConstantBlock<T>
 where
     T: Apply,
 {
-    pub data: OldBlockData,
     buffer: T::Output,
 }
 
 impl<T> Default for ConstantBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
             buffer: <T::Output>::default(),
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
         }
     }
 }
@@ -36,7 +32,6 @@ where
 impl<T> GeneratorBlock for ConstantBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     type Output = T::Output;
     type Parameters = Parameters<T>;
@@ -46,9 +41,7 @@ where
         parameters: &Self::Parameters,
         _context: &dyn pictorus_traits::Context,
     ) -> pictorus_traits::PassBy<'_, Self::Output> {
-        let output = T::apply(&mut self.buffer, parameters);
-        self.data = OldBlockData::from_pass(output);
-        output
+        T::apply(&mut self.buffer, parameters)
     }
 
     fn buffer(&self) -> PassBy<'_, Self::Output> {
@@ -96,7 +89,6 @@ where
 mod tests {
     use super::*;
     use crate::testing::StubContext;
-    use pictorus_block_data::{BlockData, ToPass};
 
     #[test]
     fn test_constant_default_buffer_no_panic() {
@@ -115,31 +107,31 @@ mod tests {
 
         let output = block.generate(&parameters, &context);
         assert_eq!(output, 3.0);
-        assert_eq!(block.data, BlockData::from_scalar(3.0));
         assert_eq!(block.buffer(), output);
     }
 
     #[test]
     fn test_constant_vector() {
-        let vector: [f64; 2] = [1.0, 2.0];
-
         let mut block = ConstantBlock::<Matrix<1, 2, f64>>::default();
-        let parameters = Parameters::new(BlockData::from_vector(&vector).to_pass());
+        let parameters = Parameters::new(Matrix {
+            data: [[1.0], [2.0]],
+        });
         let context = StubContext::default();
 
-        let output = block.generate(&parameters, &context); // <-- Converts Vector to Matrix in from_pass
+        let output = block.generate(&parameters, &context);
         assert_eq!(output.data[0][0], 1.0);
         assert_eq!(output.data[1][0], 2.0);
 
-        assert_eq!(block.data, BlockData::from_matrix(&[&vector]));
+        assert_eq!(block.buffer().data[0][0], 1.0);
+        assert_eq!(block.buffer().data[1][0], 2.0);
     }
 
     #[test]
     fn test_constant_matrix() {
-        let matrix_as_blockdata = BlockData::from_matrix(&[&[1.0, 2.0], &[3.0, 4.0]]);
-
         let mut block = ConstantBlock::<Matrix<2, 2, f64>>::default();
-        let parameters = Parameters::new(matrix_as_blockdata.to_pass());
+        let parameters = Parameters::new(Matrix {
+            data: [[1.0, 3.0], [2.0, 4.0]],
+        });
         let context = StubContext::default();
 
         let output = block.generate(&parameters, &context);
@@ -147,6 +139,9 @@ mod tests {
         assert_eq!(output.data[1][0], 2.0);
         assert_eq!(output.data[0][1], 3.0);
         assert_eq!(output.data[1][1], 4.0);
-        assert_eq!(block.data, matrix_as_blockdata);
+        assert_eq!(block.buffer().data[0][0], 1.0);
+        assert_eq!(block.buffer().data[1][0], 2.0);
+        assert_eq!(block.buffer().data[0][1], 3.0);
+        assert_eq!(block.buffer().data[1][1], 4.0);
     }
 }

--- a/pictorus-blocks/src/core_blocks/ramp_block.rs
+++ b/pictorus-blocks/src/core_blocks/ramp_block.rs
@@ -1,5 +1,4 @@
 use crate::traits::Float;
-use pictorus_block_data::BlockData;
 use pictorus_traits::{GeneratorBlock, PassBy, Scalar};
 
 #[derive(Debug, Clone)]
@@ -7,7 +6,6 @@ use pictorus_traits::{GeneratorBlock, PassBy, Scalar};
 pub struct RampBlock<T: Scalar + Float> {
     phantom: core::marker::PhantomData<T>,
     buffer: T,
-    pub data: BlockData,
 }
 
 impl<T: Scalar + Float> Default for RampBlock<T>
@@ -18,7 +16,6 @@ where
         Self {
             phantom: core::marker::PhantomData,
             buffer: T::default(),
-            data: BlockData::from_scalar(f64::from(T::default())),
         }
     }
 }
@@ -40,7 +37,6 @@ where
         let ramp_val =
             parameters.rate * num_traits::Float::max(time - parameters.start_time, T::zero());
         self.buffer = ramp_val;
-        self.data = BlockData::from_scalar(ramp_val.into());
         ramp_val
     }
 

--- a/pictorus-blocks/src/core_blocks/random_number_block.rs
+++ b/pictorus-blocks/src/core_blocks/random_number_block.rs
@@ -1,5 +1,4 @@
 use num_traits::Float;
-use pictorus_block_data::BlockData;
 use pictorus_traits::{GeneratorBlock, PassBy, Scalar};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use rand_distr::{Distribution, Normal, StandardNormal};
@@ -15,7 +14,6 @@ where
     phantom: core::marker::PhantomData<T>,
     rng: SmallRng,
     buffer: T,
-    pub data: BlockData,
 }
 
 impl<T> Default for RandomNumberBlock<T>
@@ -29,7 +27,6 @@ where
             phantom: core::marker::PhantomData,
             rng: SmallRng::seed_from_u64(0u64),
             buffer: T::default(),
-            data: BlockData::from_scalar(f64::from(T::default())),
         }
     }
 }
@@ -53,7 +50,6 @@ where
             //Will Fail if std2 is infinite: https://docs.rs/rand_distr/latest/src/rand_distr/normal.rs.html#156-161
             .sample(Normal::new(parameters.mean, parameters.std2).unwrap());
         self.buffer = val;
-        self.data = BlockData::from_scalar(f64::from(val));
         val
     }
 

--- a/pictorus-blocks/src/core_blocks/sawtoothwave_block.rs
+++ b/pictorus-blocks/src/core_blocks/sawtoothwave_block.rs
@@ -1,5 +1,4 @@
 use crate::traits::Float;
-use pictorus_block_data::BlockData;
 use pictorus_traits::{GeneratorBlock, PassBy};
 
 #[derive(Debug, Clone)]
@@ -11,7 +10,6 @@ where
 {
     phantom: core::marker::PhantomData<T>,
     buffer: T,
-    pub data: BlockData,
 }
 
 impl<T> Default for SawtoothwaveBlock<T>
@@ -23,7 +21,6 @@ where
         Self {
             phantom: core::marker::PhantomData,
             buffer: T::zero(),
-            data: BlockData::from_scalar(f64::from(T::zero())),
         }
     }
 }
@@ -47,7 +44,6 @@ where
         let x = two * (time - num_traits::Float::floor(time)) - T::one();
         let val = parameters.amplitude * x + parameters.bias;
         self.buffer = val;
-        self.data = BlockData::from_scalar(val.into());
         val
     }
 
@@ -110,24 +106,24 @@ mod tests {
         let mut block = SawtoothwaveBlock::default();
 
         let out = block.generate(&params, &runtime.context()); // T = 0
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 0.00001);
         assert_eq!(block.buffer(), out);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 2
-        assert_relative_eq!(block.data.scalar(), -0.5, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -0.5, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 3 * PI / 2
-        assert_relative_eq!(block.data.scalar(), 0.5, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 0.5, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 2 * PI
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 0.00001);
     }
 
     #[test]
@@ -148,23 +144,23 @@ mod tests {
         let mut block = SawtoothwaveBlock::default();
 
         block.generate(&params, &runtime.context()); // T = 0
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 2
-        assert_relative_eq!(block.data.scalar(), 0.5, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 0.5, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 3 * PI / 2
-        assert_relative_eq!(block.data.scalar(), -0.5, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -0.5, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 2 * PI
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 0.00001);
     }
 
     #[test]
@@ -185,23 +181,23 @@ mod tests {
         let mut block = SawtoothwaveBlock::default();
 
         block.generate(&params, &runtime.context()); // T = 0
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 2
-        assert_relative_eq!(block.data.scalar(), 0.5, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 0.5, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI
-        assert_relative_eq!(block.data.scalar(), 1.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 1.0, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 3 * PI / 2
-        assert_relative_eq!(block.data.scalar(), 1.5, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 1.5, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 2 * PI
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 0.00001);
     }
 
     #[test]
@@ -222,23 +218,23 @@ mod tests {
         let mut block = SawtoothwaveBlock::default();
 
         block.generate(&params, &runtime.context()); // T = 0
-        assert_relative_eq!(block.data.scalar(), -2.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -2.0, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 2
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 3 * PI / 2
-        assert_relative_eq!(block.data.scalar(), 1.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 1.0, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 2 * PI
-        assert_relative_eq!(block.data.scalar(), -2.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -2.0, epsilon = 0.00001);
     }
 
     #[test]
@@ -259,21 +255,21 @@ mod tests {
         let mut block = SawtoothwaveBlock::default();
 
         block.generate(&params, &runtime.context()); // T = 0
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 0.00001);
 
         // This was a little weird it was just shy of hitting the discontinuity at 2PI so it was just barely less than 1.0,
         // this fudge factor pushes it over the line. Testing on the edge of the discontinuity might not be the best approach
         runtime.context.time = Duration::from_secs_f64(2.0 * PI + 0.0000001);
         block.generate(&params, &runtime.context()); // T = 2*PI
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 0.00001);
 
         runtime.context.time = Duration::from_secs_f64(400.0 * PI);
         block.generate(&params, &runtime.context()); // T = 400 * PI
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 0.00001);
 
         runtime.context.time = Duration::from_secs_f64(400.5 * PI);
         block.generate(&params, &runtime.context()); // T = 400.5 * PI
-        assert_relative_eq!(block.data.scalar(), -0.5, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -0.5, epsilon = 0.00001);
     }
 
     #[test]
@@ -294,18 +290,18 @@ mod tests {
         let mut block = SawtoothwaveBlock::default();
 
         block.generate(&params, &runtime.context()); // T = 0
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 2
-        assert_relative_eq!(block.data.scalar(), -0.5, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), -0.5, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 0.00001);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 3 * PI / 2
-        assert_relative_eq!(block.data.scalar(), 0.5, epsilon = 0.00001);
+        assert_relative_eq!(block.buffer(), 0.5, epsilon = 0.00001);
     }
 }

--- a/pictorus-blocks/src/core_blocks/sinewave_block.rs
+++ b/pictorus-blocks/src/core_blocks/sinewave_block.rs
@@ -1,5 +1,4 @@
 use crate::traits::Float;
-use pictorus_block_data::BlockData;
 use pictorus_traits::{GeneratorBlock, PassBy};
 
 #[derive(Debug, Clone)]
@@ -11,7 +10,6 @@ where
 {
     phantom: core::marker::PhantomData<T>,
     buffer: T,
-    pub data: BlockData,
 }
 
 impl<T> Default for SinewaveBlock<T>
@@ -23,7 +21,6 @@ where
         Self {
             phantom: core::marker::PhantomData,
             buffer: T::zero(),
-            data: BlockData::from_scalar(f64::from(T::zero())),
         }
     }
 }
@@ -46,7 +43,6 @@ where
             * num_traits::Float::sin(parameters.frequency * time + parameters.phase)
             + parameters.bias;
         self.buffer = sin_val;
-        self.data = BlockData::from_scalar(sin_val.into());
         sin_val
     }
 
@@ -101,11 +97,10 @@ mod tests {
         let mut context = StubContext::default();
 
         assert_eq!(block.generate(&parameters, &context), Float::sin(0.5));
-        assert_eq!(block.data.scalar(), Float::sin(0.5));
         assert_eq!(block.buffer(), Float::sin(0.5));
         context.time = Duration::from_secs(1);
 
         assert_eq!(block.generate(&parameters, &context), Float::sin(1.5));
-        assert_eq!(block.data.scalar(), Float::sin(1.5));
+        assert_eq!(block.buffer(), Float::sin(1.5));
     }
 }

--- a/pictorus-blocks/src/core_blocks/squarewave_block.rs
+++ b/pictorus-blocks/src/core_blocks/squarewave_block.rs
@@ -105,7 +105,6 @@ mod tests {
         block.generate(&p, &runtime.context());
         assert_eq!(block.generate(&p, &runtime.context()), bias);
         assert_eq!(block.buffer(), bias);
-        assert_eq!(block.buffer(), bias);
 
         runtime.set_time(Duration::from_millis(500));
         assert_eq!(block.generate(&p, &runtime.context()), bias + amplitude);

--- a/pictorus-blocks/src/core_blocks/squarewave_block.rs
+++ b/pictorus-blocks/src/core_blocks/squarewave_block.rs
@@ -1,5 +1,4 @@
 use crate::traits::Float;
-use pictorus_block_data::BlockData;
 use pictorus_traits::{GeneratorBlock, PassBy};
 
 pub struct Parameters<T: Float> {
@@ -26,7 +25,6 @@ impl<T: Float> Parameters<T> {
 pub struct SquarewaveBlock<T: Float> {
     phantom_output_type: core::marker::PhantomData<T>,
     buffer: T,
-    pub data: BlockData,
 }
 
 impl<T: Float> Default for SquarewaveBlock<T>
@@ -37,7 +35,6 @@ where
         Self {
             phantom_output_type: core::marker::PhantomData,
             buffer: T::zero(),
-            data: BlockData::from_scalar(T::zero().into()),
         }
     }
 }
@@ -70,7 +67,6 @@ where
             parameters.bias + parameters.amplitude
         };
         self.buffer = output;
-        self.data = BlockData::from_scalar(f64::from(output));
         output
     }
 
@@ -108,38 +104,38 @@ mod tests {
 
         block.generate(&p, &runtime.context());
         assert_eq!(block.generate(&p, &runtime.context()), bias);
-        assert_eq!(block.data.scalar(), bias);
+        assert_eq!(block.buffer(), bias);
         assert_eq!(block.buffer(), bias);
 
         runtime.set_time(Duration::from_millis(500));
         assert_eq!(block.generate(&p, &runtime.context()), bias + amplitude);
-        assert_eq!(block.data.scalar(), bias + amplitude);
+        assert_eq!(block.buffer(), bias + amplitude);
 
         runtime.set_time(Duration::from_secs_f64(1.0));
         assert_eq!(block.generate(&p, &runtime.context()), bias + amplitude);
-        assert_eq!(block.data.scalar(), bias + amplitude);
+        assert_eq!(block.buffer(), bias + amplitude);
 
         runtime.set_time(Duration::from_secs_f64(1.499));
         assert_eq!(block.generate(&p, &runtime.context()), bias + amplitude);
-        assert_eq!(block.data.scalar(), bias + amplitude);
+        assert_eq!(block.buffer(), bias + amplitude);
 
         runtime.set_time(Duration::from_secs_f64(1.5));
         assert_eq!(block.generate(&p, &runtime.context()), bias + amplitude);
-        assert_eq!(block.data.scalar(), bias + amplitude);
+        assert_eq!(block.buffer(), bias + amplitude);
 
         // Off duration
         runtime.set_time(Duration::from_secs_f64(2.5));
         assert_eq!(block.generate(&p, &runtime.context()), bias);
-        assert_eq!(block.data.scalar(), bias);
+        assert_eq!(block.buffer(), bias);
 
         runtime.set_time(Duration::from_secs_f64(3.499));
         assert_eq!(block.generate(&p, &runtime.context()), bias);
-        assert_eq!(block.data.scalar(), bias);
+        assert_eq!(block.buffer(), bias);
 
         // Back on
         runtime.set_time(Duration::from_secs_f64(3.5));
         assert_eq!(block.generate(&p, &runtime.context()), bias + amplitude);
-        assert_eq!(block.data.scalar(), bias + amplitude);
+        assert_eq!(block.buffer(), bias + amplitude);
     }
 
     #[test]
@@ -158,37 +154,37 @@ mod tests {
 
         block.generate(&p, &runtime.context());
         assert_eq!(block.generate(&p, &runtime.context()), bias);
-        assert_eq!(block.data.scalar() as f32, bias);
+        assert_eq!(block.buffer(), bias);
 
         runtime.set_time(Duration::from_millis(500));
         assert_eq!(block.generate(&p, &runtime.context()), bias + amplitude);
-        assert_eq!(block.data.scalar() as f32, bias + amplitude);
+        assert_eq!(block.buffer(), bias + amplitude);
 
         runtime.set_time(Duration::from_secs_f32(1.0));
         assert_eq!(block.generate(&p, &runtime.context()), bias + amplitude);
-        assert_eq!(block.data.scalar() as f32, bias + amplitude);
+        assert_eq!(block.buffer(), bias + amplitude);
 
         runtime.set_time(Duration::from_secs_f32(1.499));
         assert_eq!(block.generate(&p, &runtime.context()), bias + amplitude);
-        assert_eq!(block.data.scalar() as f32, bias + amplitude);
+        assert_eq!(block.buffer(), bias + amplitude);
 
         runtime.set_time(Duration::from_secs_f32(1.5));
         assert_eq!(block.generate(&p, &runtime.context()), bias + amplitude);
-        assert_eq!(block.data.scalar() as f32, bias + amplitude);
+        assert_eq!(block.buffer(), bias + amplitude);
 
         // Off duration
         runtime.set_time(Duration::from_secs_f32(2.5));
         assert_eq!(block.generate(&p, &runtime.context()), bias);
-        assert_eq!(block.data.scalar() as f32, bias);
+        assert_eq!(block.buffer(), bias);
 
         runtime.set_time(Duration::from_secs_f32(3.499));
         assert_eq!(block.generate(&p, &runtime.context()), bias);
-        assert_eq!(block.data.scalar() as f32, bias);
+        assert_eq!(block.buffer(), bias);
 
         // Back on
         runtime.set_time(Duration::from_secs_f32(3.5));
         assert_eq!(block.generate(&p, &runtime.context()), bias + amplitude);
-        assert_eq!(block.data.scalar() as f32, bias + amplitude);
+        assert_eq!(block.buffer(), bias + amplitude);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/trianglewave_block.rs
+++ b/pictorus-blocks/src/core_blocks/trianglewave_block.rs
@@ -1,5 +1,4 @@
 use crate::traits::Float;
-use pictorus_block_data::BlockData;
 use pictorus_traits::{GeneratorBlock, PassBy};
 
 #[derive(Debug, Clone)]
@@ -11,7 +10,6 @@ where
 {
     phantom: core::marker::PhantomData<T>,
     buffer: T,
-    pub data: BlockData,
 }
 
 impl<T> Default for TrianglewaveBlock<T>
@@ -23,7 +21,6 @@ where
         Self {
             phantom: core::marker::PhantomData,
             buffer: T::zero(),
-            data: BlockData::from_scalar(f64::from(T::zero())),
         }
     }
 }
@@ -52,7 +49,6 @@ where
         // then shift it down by 1 to get it in the range [-1, 1], then scale it by the amplitude and add the bias.
         let val = (four * y - T::one()) * parameters.amplitude + parameters.bias;
         self.buffer = val;
-        self.data = BlockData::from_scalar(val.into());
         val
     }
 
@@ -112,24 +108,24 @@ mod tests {
         let mut block = TrianglewaveBlock::default();
 
         let out = block.generate(&params, &runtime.context()); // T = 0
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 1e-6);
         assert_eq!(block.buffer(), out);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 2
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI
-        assert_relative_eq!(block.data.scalar(), 1.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 1.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 3PI / 2
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 2PI
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 1e-6);
     }
 
     #[test]
@@ -150,23 +146,23 @@ mod tests {
         let mut block = TrianglewaveBlock::default();
 
         block.generate(&params, &runtime.context()); // T = 0
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 2
-        assert_relative_eq!(block.data.scalar(), 1.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 1.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 3PI / 2
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 2PI
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 1e-6);
     }
 
     #[test]
@@ -187,23 +183,23 @@ mod tests {
         let mut block = TrianglewaveBlock::default();
 
         block.generate(&params, &runtime.context()); // T = 0
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 2
-        assert_relative_eq!(block.data.scalar(), 1.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 1.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI
-        assert_relative_eq!(block.data.scalar(), 2.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 2.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 3PI / 2
-        assert_relative_eq!(block.data.scalar(), 1.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 1.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 2PI
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 1e-6);
     }
 
     #[test]
@@ -224,23 +220,23 @@ mod tests {
         let mut block = TrianglewaveBlock::default();
 
         block.generate(&params, &runtime.context()); // T = 0
-        assert_relative_eq!(block.data.scalar(), -2.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), -2.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 2
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI
-        assert_relative_eq!(block.data.scalar(), 2.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 2.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 3PI / 2
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 2PI
-        assert_relative_eq!(block.data.scalar(), -2.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), -2.0, epsilon = 1e-6);
     }
 
     #[test]
@@ -261,11 +257,11 @@ mod tests {
         let mut block = TrianglewaveBlock::default();
 
         block.generate(&params, &runtime.context()); // T = 0
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 1e-6);
 
         runtime.set_time(Duration::from_secs_f64(400.0 * PI));
         block.generate(&params, &runtime.context()); // T = 400PI
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 1e-6);
     }
 
     #[test]
@@ -286,22 +282,22 @@ mod tests {
         let mut block = TrianglewaveBlock::default();
 
         block.generate(&params, &runtime.context()); // T = 0
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 4
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI / 2
-        assert_relative_eq!(block.data.scalar(), 1.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 1.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = 3PI / 4
-        assert_relative_eq!(block.data.scalar(), 0.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), 0.0, epsilon = 1e-6);
 
         runtime.tick();
         block.generate(&params, &runtime.context()); // T = PI
-        assert_relative_eq!(block.data.scalar(), -1.0, epsilon = 1e-6);
+        assert_relative_eq!(block.buffer(), -1.0, epsilon = 1e-6);
     }
 }

--- a/pictorus-blocks/src/std_blocks/system_time_block.rs
+++ b/pictorus-blocks/src/std_blocks/system_time_block.rs
@@ -41,8 +41,8 @@ impl GeneratorBlock for SystemTimeBlock {
     ) -> pictorus_traits::PassBy<'_, Self::Output> {
         // Since simulations can run faster than real-time, we'll use the delta between system start
         // and now, as measured by app_time, for system clock.
-        let elpased_time = context.time();
-        let time_now = self.start_time + elpased_time;
+        let elapsed_time = context.time();
+        let time_now = self.start_time + elapsed_time;
         self.output = get_output_value(time_now, parameters.method);
         self.output
     }

--- a/pictorus-blocks/src/std_blocks/system_time_block.rs
+++ b/pictorus-blocks/src/std_blocks/system_time_block.rs
@@ -1,11 +1,9 @@
 use chrono::{DateTime, Datelike, Local, Timelike};
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{GeneratorBlock, PassBy};
 
 /// This block can be used in `std` environments to get the current system time.
 /// The time output can be in different formats, such as epoch time, second, minute, hour, day of the month, day of the year, month, or year.
 pub struct SystemTimeBlock {
-    pub data: OldBlockData,
     output: f64,
     start_time: DateTime<Local>,
 }
@@ -13,7 +11,6 @@ pub struct SystemTimeBlock {
 impl Default for SystemTimeBlock {
     fn default() -> Self {
         Self {
-            data: OldBlockData::from_scalar(0.0),
             output: 0.0,
             start_time: Local::now(),
         }
@@ -47,7 +44,6 @@ impl GeneratorBlock for SystemTimeBlock {
         let elpased_time = context.time();
         let time_now = self.start_time + elpased_time;
         self.output = get_output_value(time_now, parameters.method);
-        self.data = OldBlockData::from_scalar(self.output);
         self.output
     }
 
@@ -132,7 +128,7 @@ mod tests {
         );
         let output = block.generate(&params, &context);
         assert_eq!(output, start_time.timestamp() as f64 + 42.0);
-        assert_eq!(block.data.scalar(), start_time.timestamp() as f64 + 42.0);
+        assert_eq!(block.buffer(), start_time.timestamp() as f64 + 42.0);
         assert_eq!(block.buffer(), output);
     }
 }


### PR DESCRIPTION
- Remove BlockData from GeneratorBlocks
- Updated unit tests, swapping .buffer() for .data
- Changed to no-BlockData constructors in the constant block unit tests