### PR TITLE
Remove BlockData from single-input/output Process blocks

### DIFF
--- a/pictorus-blocks/src/core_blocks/abs_block.rs
+++ b/pictorus-blocks/src/core_blocks/abs_block.rs
@@ -1,6 +1,5 @@
 use crate::matrix_ext::MatrixNalgebraExt;
 use num_traits::Float;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
 
 pub struct Parameter {}
@@ -19,18 +18,15 @@ impl Parameter {
 
 /// Computes the absolute value of a scalar, vector, or matrix.
 pub struct AbsBlock<T: Pass + Default> {
-    pub data: OldBlockData,
     buffer: T,
 }
 
 impl<T> Default for AbsBlock<T>
 where
     T: Pass + Default,
-    OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
             buffer: T::default(),
         }
     }
@@ -41,7 +37,6 @@ macro_rules! impl_abs_block {
         impl ProcessBlock for AbsBlock<$type>
         where
             $type: Scalar,
-            OldBlockData: FromPass<$type>,
         {
             type Inputs = $type;
             type Output = $type;
@@ -55,7 +50,6 @@ macro_rules! impl_abs_block {
             ) -> pictorus_traits::PassBy<'b, Self::Output> {
                 let output = Float::abs(inputs);
                 self.buffer = output;
-                self.data = OldBlockData::from_scalar(output.into());
                 output
             }
 
@@ -68,7 +62,6 @@ macro_rules! impl_abs_block {
             for AbsBlock<Matrix<ROWS, COLS, $type>>
         where
             $type: Scalar,
-            OldBlockData: FromPass<Matrix<ROWS, COLS, $type>>,
         {
             type Inputs = Matrix<ROWS, COLS, $type>;
             type Output = Matrix<ROWS, COLS, $type>;
@@ -82,7 +75,6 @@ macro_rules! impl_abs_block {
             ) -> PassBy<'_, Self::Output> {
                 let abs = input.as_view().abs();
                 self.buffer = Matrix::<ROWS, COLS, $type>::from_view(&abs.as_view());
-                self.data = OldBlockData::from_pass(&self.buffer);
                 &self.buffer
             }
 
@@ -123,12 +115,11 @@ mod tests {
 
                     let output = block.process(&Parameter::new(), &context, <$type>::one());
                     assert_eq!(output, <$type>::one());
-                    assert_eq!(block.data, OldBlockData::from_scalar(<$type>::one().into()));
                     assert_eq!(block.buffer(), output);
 
                     let output = block.process(&Parameter::new(), &context, -<$type>::one());
                     assert_eq!(output, <$type>::one());
-                    assert_eq!(block.data, OldBlockData::from_scalar(1.0));
+                    assert_eq!(block.buffer(), <$type>::one());
                 }
 
                 #[test]
@@ -142,7 +133,8 @@ mod tests {
                     let output = block.process(&Parameter::new(), &context, &input);
                     assert_eq!(output.data[0][0], <$type>::one());
                     assert_eq!(output.data[1][0], <$type>::one());
-                    assert_eq!(block.data, OldBlockData::from_matrix(&[&[<$type>::one().into(), <$type>::one().into()]]));
+                    assert_eq!(block.buffer().data[0][0], <$type>::one());
+                    assert_eq!(block.buffer().data[1][0], <$type>::one());
                 }
 
                 #[test]
@@ -156,7 +148,8 @@ mod tests {
                     let output = block.process(&Parameter::new(), &context, &input);
                     assert_eq!(output.data[0][0], <$type>::one());
                     assert_eq!(output.data[0][1], <$type>::one());
-                    assert_eq!(block.data, OldBlockData::from_matrix(&[&[<$type>::one().into()], &[<$type>::one().into()]]));
+                    assert_eq!(block.buffer().data[0][0], <$type>::one());
+                    assert_eq!(block.buffer().data[0][1], <$type>::one());
                 }
 
                 #[test]
@@ -174,10 +167,13 @@ mod tests {
                     assert_eq!(output.data[0][1], <$type>::one());
                     assert_eq!(output.data[1][0], <$type>::one());
                     assert_eq!(output.data[1][1], <$type>::one());
-                    assert_eq!(block.data, OldBlockData::from_matrix(&[&[<$type>::one().into(), <$type>::one().into()], &[<$type>::one().into(), <$type>::one().into()]]));
+                    assert_eq!(block.buffer().data[0][0], <$type>::one());
+                    assert_eq!(block.buffer().data[0][1], <$type>::one());
+                    assert_eq!(block.buffer().data[1][0], <$type>::one());
+                    assert_eq!(block.buffer().data[1][1], <$type>::one());
                 }
             }
-        }
+        };
     }
 
     test_abs_block!(f32, f32);

--- a/pictorus-blocks/src/core_blocks/abs_block.rs
+++ b/pictorus-blocks/src/core_blocks/abs_block.rs
@@ -126,51 +126,54 @@ mod tests {
                 fn [<test_abs_block_vector_1x2_ $name>]() {
                     let mut block = AbsBlock::<Matrix<1, 2, $type>>::default();
                     let context = StubContext::default();
-                    let mut input = Matrix::<1, 2, $type>::zeroed();
-                    input.data[0][0] = <$type>::one();
-                    input.data[1][0] = -<$type>::one();
+                    let input = Matrix {
+                        data: [[<$type>::one()], [-<$type>::one()]],
+                    };
+                    let expected = Matrix {
+                        data: [[<$type>::one()], [<$type>::one()]],
+                    };
 
                     let output = block.process(&Parameter::new(), &context, &input);
-                    assert_eq!(output.data[0][0], <$type>::one());
-                    assert_eq!(output.data[1][0], <$type>::one());
-                    assert_eq!(block.buffer().data[0][0], <$type>::one());
-                    assert_eq!(block.buffer().data[1][0], <$type>::one());
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
                 }
 
                 #[test]
                 fn [<test_abs_block_vector_2x1_ $name>]() {
                     let mut block = AbsBlock::<Matrix<2, 1, $type>>::default();
                     let context = StubContext::default();
-                    let mut input = Matrix::<2, 1, $type>::zeroed();
-                    input.data[0][0] = <$type>::one();
-                    input.data[0][1] = -<$type>::one();
+                    let input = Matrix {
+                        data: [[<$type>::one(), -<$type>::one()]],
+                    };
+                    let expected = Matrix {
+                        data: [[<$type>::one(), <$type>::one()]],
+                    };
 
                     let output = block.process(&Parameter::new(), &context, &input);
-                    assert_eq!(output.data[0][0], <$type>::one());
-                    assert_eq!(output.data[0][1], <$type>::one());
-                    assert_eq!(block.buffer().data[0][0], <$type>::one());
-                    assert_eq!(block.buffer().data[0][1], <$type>::one());
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
                 }
 
                 #[test]
                 fn [<test_abs_block_matrix_ $name>]() {
                     let mut block = AbsBlock::<Matrix<2, 2, $type>>::default();
                     let context = StubContext::default();
-                    let mut input = Matrix::<2, 2, $type>::zeroed();
-                    input.data[0][0] = <$type>::one();
-                    input.data[0][1] = -<$type>::one();
-                    input.data[1][0] = <$type>::one();
-                    input.data[1][1] = -<$type>::one();
+                    let input = Matrix {
+                        data: [
+                            [<$type>::one(), -<$type>::one()],
+                            [<$type>::one(), -<$type>::one()],
+                        ],
+                    };
+                    let expected = Matrix {
+                        data: [
+                            [<$type>::one(), <$type>::one()],
+                            [<$type>::one(), <$type>::one()],
+                        ],
+                    };
 
                     let output = block.process(&Parameter::new(), &context, &input);
-                    assert_eq!(output.data[0][0], <$type>::one());
-                    assert_eq!(output.data[0][1], <$type>::one());
-                    assert_eq!(output.data[1][0], <$type>::one());
-                    assert_eq!(output.data[1][1], <$type>::one());
-                    assert_eq!(block.buffer().data[0][0], <$type>::one());
-                    assert_eq!(block.buffer().data[0][1], <$type>::one());
-                    assert_eq!(block.buffer().data[1][0], <$type>::one());
-                    assert_eq!(block.buffer().data[1][1], <$type>::one());
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
                 }
             }
         };

--- a/pictorus-blocks/src/core_blocks/bias_block.rs
+++ b/pictorus-blocks/src/core_blocks/bias_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Promote, Promotion, Scalar};
 
 /// Outputs the input data with an added bias (offset).
@@ -7,7 +6,6 @@ where
     B: Scalar,
     T: Apply<B>,
 {
-    pub data: OldBlockData,
     buffer: T::Output,
 }
 
@@ -15,11 +13,9 @@ impl<B, T> Default for BiasBlock<B, T>
 where
     B: Scalar,
     T: Apply<B> + Default,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
             buffer: <T::Output>::default(),
         }
     }
@@ -29,7 +25,6 @@ impl<B, T> ProcessBlock for BiasBlock<B, T>
 where
     B: Scalar,
     T: Apply<B> + Default,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -42,7 +37,6 @@ where
         input: PassBy<Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
         let output = T::apply(&mut self.buffer, input, parameters.offset);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 
@@ -140,7 +134,6 @@ mod tests {
     use super::*;
     use crate::testing::StubContext;
     use approx::assert_relative_eq;
-    use pictorus_block_data::ToPass;
 
     #[test]
     fn test_bias_default_buffer_no_panic() {
@@ -159,7 +152,6 @@ mod tests {
 
         let output = block.process(&parameters, &context, 2.0);
         assert_eq!(output, 5.0);
-        assert_eq!(block.data.scalar(), 5.0);
         assert_eq!(block.buffer(), output);
     }
 
@@ -168,11 +160,10 @@ mod tests {
         let mut block = BiasBlock::<f64, f64>::default();
         let parameters = Parameters::new(3.0);
         let context = StubContext::default();
-        let input = OldBlockData::from_scalar(-3.1);
 
-        let output = block.process(&parameters, &context, input.to_pass());
+        let output = block.process(&parameters, &context, -3.1);
         assert_relative_eq!(output, -0.1);
-        assert_relative_eq!(block.data.scalar(), -0.1);
+        assert_relative_eq!(block.buffer(), -0.1);
     }
 
     #[test]
@@ -185,23 +176,19 @@ mod tests {
         let parameters = Parameters::new(2.0);
         let output = block.process(&parameters, &context, &input);
         assert_eq!(output.data, [[3.0, 4.0], [5.0, 6.0]]);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            [[3.0, 4.0], [5.0, 6.0]].as_flattened()
-        );
+        assert_eq!(block.buffer().data, [[3.0, 4.0], [5.0, 6.0]]);
     }
 
     #[test]
     fn test_bias_matrix_to_pass() {
         let mut block = BiasBlock::<f64, Matrix<2, 2, f64>>::default();
         let context = StubContext::default();
-        let input = OldBlockData::from_matrix(&[&[1.0, 3.0], &[2.0, 4.0]]);
+        let input = Matrix {
+            data: [[1.0, 2.0], [3.0, 4.0]],
+        };
         let parameters = Parameters::new(2.0);
-        let output = block.process(&parameters, &context, &input.to_pass());
+        let output = block.process(&parameters, &context, &input);
         assert_eq!(output.data, [[3.0, 4.0], [5.0, 6.0]]);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            [[3.0, 4.0], [5.0, 6.0]].as_flattened()
-        );
+        assert_eq!(block.buffer().data, [[3.0, 4.0], [5.0, 6.0]]);
     }
 }

--- a/pictorus-blocks/src/core_blocks/bit_shift_block.rs
+++ b/pictorus-blocks/src/core_blocks/bit_shift_block.rs
@@ -1,5 +1,4 @@
 use num_traits::NumCast;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Shifts the bits of the input by a specified number of positions to the left or right.
@@ -9,18 +8,15 @@ pub struct BitShiftBlock<T>
 where
     T: Apply,
 {
-    pub data: OldBlockData,
     buffer: T::Output,
 }
 
 impl<T> Default for BitShiftBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
             buffer: T::Output::default(),
         }
     }
@@ -51,7 +47,6 @@ impl Parameters {
 impl<T> ProcessBlock for BitShiftBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -64,7 +59,6 @@ where
         input: PassBy<Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
         let output = T::apply(&mut self.buffer, input, parameters);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 
@@ -157,7 +151,6 @@ mod tests {
                     let params = Parameters::new("Left", 2);
                     let output = block.process(&params, &context, [<1 $type>]);
                     assert_eq!(output, [<4 $type>]);
-                    assert_eq!(block.data.scalar(), 4.0);
                     assert_eq!(block.buffer(), output);
                 }
 
@@ -168,11 +161,11 @@ mod tests {
                     let params = Parameters::new("Right", 2);
                     let output = block.process(&params, &context, [<8 $type>]);
                     assert_eq!(output, [<2 $type>]);
-                    assert_eq!(block.data.scalar(), 2.0);
+                    assert_eq!(block.buffer(), [<2 $type>]);
 
                     let output = block.process(&params, &context, [<2 $type>]);
                     assert_eq!(output, [<0 $type>]);
-                    assert_eq!(block.data.scalar(), 0.0);
+                    assert_eq!(block.buffer(), [<0 $type>]);
                 }
 
                 #[test]
@@ -185,10 +178,7 @@ mod tests {
                     };
                     let output = block.process(&params, &context, &input);
                     assert_eq!(output.data, [[[<4 $type>], [<8 $type>]], [[<12 $type>], [<16 $type>]]]);
-                    assert_eq!(
-                        block.data.get_data().as_slice(),
-                        [[4., 8.], [12., 16.]].as_flattened()
-                    );
+                    assert_eq!(block.buffer().data, [[[<4 $type>], [<8 $type>]], [[<12 $type>], [<16 $type>]]]);
                 }
 
                 #[test]
@@ -201,10 +191,7 @@ mod tests {
                     };
                     let output = block.process(&params, &context, &input);
                     assert_eq!(output.data, [[[<1 $type>], [<2 $type>]], [[<3 $type>], [<4 $type>]]]);
-                    assert_eq!(
-                        block.data.get_data().as_slice(),
-                        [[1., 2.], [3., 4.]].as_flattened()
-                    );
+                    assert_eq!(block.buffer().data, [[[<1 $type>], [<2 $type>]], [[<3 $type>], [<4 $type>]]]);
                 }
             }
         };

--- a/pictorus-blocks/src/core_blocks/clamp_block.rs
+++ b/pictorus-blocks/src/core_blocks/clamp_block.rs
@@ -166,17 +166,12 @@ mod test {
                     let input = Matrix {
                         data: [[pos_2.into(), $type::zero().into()], [$type::one().into(), neg_2.into()]]
                     };
+                    let expected = Matrix {
+                        data: [[$type::one(), $type::zero()], [$type::one(), -$type::one()]],
+                    };
                     let output = block.process(&parameters, &c, &input);
-                    assert_eq!(
-                        output,
-                        &Matrix {
-                            data: [[$type::one(), $type::zero()], [$type::one(), -$type::one()]]
-                        }
-                    );
-                    assert_eq!(block.buffer().data[0][0], $type::one());
-                    assert_eq!(block.buffer().data[0][1], $type::zero());
-                    assert_eq!(block.buffer().data[1][0], $type::one());
-                    assert_eq!(block.buffer().data[1][1], -$type::one());
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
                 }
             }
         };
@@ -229,17 +224,12 @@ mod test {
                     let input = Matrix {
                         data: [[pos_3.into(), $type::zero().into()], [$type::one().into(), pos_2.into()]]
                     };
+                    let expected = Matrix {
+                        data: [[pos_2, $type::one()], [$type::one(), pos_2]],
+                    };
                     let output = block.process(&parameters, &c, &input);
-                    assert_eq!(
-                        output,
-                        &Matrix {
-                            data: [[pos_2, $type::one()], [$type::one(), pos_2]]
-                        }
-                    );
-                    assert_eq!(block.buffer().data[0][0], pos_2);
-                    assert_eq!(block.buffer().data[0][1], $type::one());
-                    assert_eq!(block.buffer().data[1][0], $type::one());
-                    assert_eq!(block.buffer().data[1][1], pos_2);
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
                 }
             }
         };

--- a/pictorus-blocks/src/core_blocks/clamp_block.rs
+++ b/pictorus-blocks/src/core_blocks/clamp_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 pub struct Parameters<T> {
@@ -19,18 +18,15 @@ impl<T> Parameters<T> {
 /// If an input is larger than the max value, it will be set to the max value. If
 /// the input is less than the min value, it will be set to the min value.
 pub struct ClampBlock<T> {
-    pub data: OldBlockData,
     buffer: T,
 }
 
 impl<T> Default for ClampBlock<T>
 where
     T: Pass + Default,
-    OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
             buffer: T::default(),
         }
     }
@@ -38,10 +34,7 @@ where
 
 macro_rules! impl_clamp_block {
     ($type:ty) => {
-        impl ProcessBlock for ClampBlock<$type>
-        where
-            OldBlockData: FromPass<$type>,
-        {
+        impl ProcessBlock for ClampBlock<$type> {
             type Inputs = $type;
             type Output = $type;
             type Parameters = Parameters<$type>;
@@ -53,7 +46,6 @@ macro_rules! impl_clamp_block {
                 input: PassBy<Self::Inputs>,
             ) -> PassBy<'_, Self::Output> {
                 self.buffer = input.clamp(parameters.min, parameters.max);
-                self.data = OldBlockData::from_scalar(self.buffer.into());
                 self.buffer
             }
 
@@ -64,8 +56,6 @@ macro_rules! impl_clamp_block {
 
         impl<const ROWS: usize, const COLS: usize> ProcessBlock
             for ClampBlock<Matrix<ROWS, COLS, $type>>
-        where
-            OldBlockData: FromPass<Matrix<ROWS, COLS, $type>>,
         {
             type Inputs = Matrix<ROWS, COLS, $type>;
             type Output = Matrix<ROWS, COLS, $type>;
@@ -83,7 +73,6 @@ macro_rules! impl_clamp_block {
                             input.data[c][r].clamp(parameters.min, parameters.max);
                     }
                 }
-                self.data = OldBlockData::from_pass(&self.buffer);
                 &self.buffer
             }
 
@@ -108,7 +97,6 @@ mod test {
     use crate::testing::StubContext;
     use num_traits::{One, Zero};
     use paste::paste;
-    use pictorus_block_data::ToPass;
 
     use super::*;
 
@@ -126,20 +114,18 @@ mod test {
         let c = StubContext::default();
         let lower_limit: f64 = -1.5;
         let upper_limit: f64 = -0.5;
-        let input = &OldBlockData::from_vector(&[1.0, -0.5, -1.2345, -1.6]);
+        let input = Matrix {
+            data: [[1.0], [-0.5], [-1.2345], [-1.6]],
+        };
         let mut block = ClampBlock::<Matrix<1, 4, f64>>::default();
         let p = Parameters::new(lower_limit, upper_limit);
 
-        let output = *block.process(&p, &c, &input.to_pass());
+        let output = *block.process(&p, &c, &input);
         assert_eq!(
             output,
             Matrix {
                 data: [[-0.5], [-0.5], [-1.2345], [-1.5]]
             }
-        );
-        assert_eq!(
-            block.data,
-            OldBlockData::from_matrix(&[&[-0.5, -0.5, -1.2345, -1.5]])
         );
         assert_eq!(block.buffer(), &output);
     }
@@ -187,10 +173,10 @@ mod test {
                             data: [[$type::one(), $type::zero()], [$type::one(), -$type::one()]]
                         }
                     );
-                    assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[$type::one().into(), $type::one().into()], &[$type::zero().into(), (-$type::one()).into()]])
-                    );
+                    assert_eq!(block.buffer().data[0][0], $type::one());
+                    assert_eq!(block.buffer().data[0][1], $type::zero());
+                    assert_eq!(block.buffer().data[1][0], $type::one());
+                    assert_eq!(block.buffer().data[1][1], -$type::one());
                 }
             }
         };
@@ -250,10 +236,10 @@ mod test {
                             data: [[pos_2, $type::one()], [$type::one(), pos_2]]
                         }
                     );
-                    assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[pos_2.into(), $type::one().into()], &[$type::one().into(), pos_2.into()]])
-                    );
+                    assert_eq!(block.buffer().data[0][0], pos_2);
+                    assert_eq!(block.buffer().data[0][1], $type::one());
+                    assert_eq!(block.buffer().data[1][0], $type::one());
+                    assert_eq!(block.buffer().data[1][1], pos_2);
                 }
             }
         };

--- a/pictorus-blocks/src/core_blocks/compare_to_value_block.rs
+++ b/pictorus-blocks/src/core_blocks/compare_to_value_block.rs
@@ -188,70 +188,52 @@ mod tests {
                         data: [[<$type>::one(), <$type>::zero()], [<$type>::zero(), <$type>::one() + <$type>::one()]],
                     };
 
+                    let expected = Matrix {
+                        data: [[<$type>::one(), <$type>::zero()], [<$type>::zero(), <$type>::zero()]],
+                    };
                     let output = block.process(&parameters, &context, &input);
-                    assert_eq!(output.data[0][0], <$type>::one());
-                    assert_eq!(output.data[0][1], <$type>::zero());
-                    assert_eq!(output.data[1][0], <$type>::zero());
-                    assert_eq!(output.data[1][1], <$type>::zero());
-                    assert_eq!(block.buffer().data[0][0], <$type>::one());
-                    assert_eq!(block.buffer().data[0][1], <$type>::zero());
-                    assert_eq!(block.buffer().data[1][0], <$type>::zero());
-                    assert_eq!(block.buffer().data[1][1], <$type>::zero());
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
 
                     parameters.comparison_type = ComparisonType::NotEqual;
+                    let expected = Matrix {
+                        data: [[<$type>::zero(), <$type>::one()], [<$type>::one(), <$type>::one()]],
+                    };
                     let output = block.process(&parameters, &context, &input);
-                    assert_eq!(output.data[0][0], <$type>::zero());
-                    assert_eq!(output.data[0][1], <$type>::one());
-                    assert_eq!(output.data[1][0], <$type>::one());
-                    assert_eq!(output.data[1][1], <$type>::one());
-                    assert_eq!(block.buffer().data[0][0], <$type>::zero());
-                    assert_eq!(block.buffer().data[0][1], <$type>::one());
-                    assert_eq!(block.buffer().data[1][0], <$type>::one());
-                    assert_eq!(block.buffer().data[1][1], <$type>::one());
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
 
                     parameters.comparison_type = ComparisonType::LessThan;
+                    let expected = Matrix {
+                        data: [[<$type>::zero(), <$type>::one()], [<$type>::one(), <$type>::zero()]],
+                    };
                     let output = block.process(&parameters, &context, &input);
-                    assert_eq!(output.data[0][0], <$type>::zero());
-                    assert_eq!(output.data[0][1], <$type>::one());
-                    assert_eq!(output.data[1][0], <$type>::one());
-                    assert_eq!(output.data[1][1], <$type>::zero());
-                    assert_eq!(block.buffer().data[0][0], <$type>::zero());
-                    assert_eq!(block.buffer().data[0][1], <$type>::one());
-                    assert_eq!(block.buffer().data[1][0], <$type>::one());
-                    assert_eq!(block.buffer().data[1][1], <$type>::zero());
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
 
                     parameters.comparison_type = ComparisonType::LessOrEqual;
+                    let expected = Matrix {
+                        data: [[<$type>::one(), <$type>::one()], [<$type>::one(), <$type>::zero()]],
+                    };
                     let output = block.process(&parameters, &context, &input);
-                    assert_eq!(output.data[0][0], <$type>::one());
-                    assert_eq!(output.data[0][1], <$type>::one());
-                    assert_eq!(output.data[1][0], <$type>::one());
-                    assert_eq!(output.data[1][1], <$type>::zero());
-                    assert_eq!(block.buffer().data[0][0], <$type>::one());
-                    assert_eq!(block.buffer().data[0][1], <$type>::one());
-                    assert_eq!(block.buffer().data[1][0], <$type>::one());
-                    assert_eq!(block.buffer().data[1][1], <$type>::zero());
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
 
                     parameters.comparison_type = ComparisonType::GreaterThan;
+                    let expected = Matrix {
+                        data: [[<$type>::zero(), <$type>::zero()], [<$type>::zero(), <$type>::one()]],
+                    };
                     let output = block.process(&parameters, &context, &input);
-                    assert_eq!(output.data[0][0], <$type>::zero());
-                    assert_eq!(output.data[0][1], <$type>::zero());
-                    assert_eq!(output.data[1][0], <$type>::zero());
-                    assert_eq!(output.data[1][1], <$type>::one());
-                    assert_eq!(block.buffer().data[0][0], <$type>::zero());
-                    assert_eq!(block.buffer().data[0][1], <$type>::zero());
-                    assert_eq!(block.buffer().data[1][0], <$type>::zero());
-                    assert_eq!(block.buffer().data[1][1], <$type>::one());
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
 
                     parameters.comparison_type = ComparisonType::GreaterOrEqual;
+                    let expected = Matrix {
+                        data: [[<$type>::one(), <$type>::zero()], [<$type>::zero(), <$type>::one()]],
+                    };
                     let output = block.process(&parameters, &context, &input);
-                    assert_eq!(output.data[0][0], <$type>::one());
-                    assert_eq!(output.data[0][1], <$type>::zero());
-                    assert_eq!(output.data[1][0], <$type>::zero());
-                    assert_eq!(output.data[1][1], <$type>::one());
-                    assert_eq!(block.buffer().data[0][0], <$type>::one());
-                    assert_eq!(block.buffer().data[0][1], <$type>::zero());
-                    assert_eq!(block.buffer().data[1][0], <$type>::zero());
-                    assert_eq!(block.buffer().data[1][1], <$type>::one());
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
                 }
             }
         };

--- a/pictorus-blocks/src/core_blocks/compare_to_value_block.rs
+++ b/pictorus-blocks/src/core_blocks/compare_to_value_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
 
 use super::comparison_block::ComparisonType;
@@ -28,18 +27,15 @@ where
 ///
 /// The output is the same size as the input and each element is the result of the comparison.
 pub struct CompareToValueBlock<T: Pass> {
-    pub data: OldBlockData,
     buffer: T,
 }
 
 impl<T> Default for CompareToValueBlock<T>
 where
     T: Pass + Default,
-    OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
             buffer: T::default(),
         }
     }
@@ -47,10 +43,7 @@ where
 
 macro_rules! impl_compare_to_value_block {
     ($type:ty) => {
-        impl ProcessBlock for CompareToValueBlock<$type>
-        where
-            OldBlockData: FromPass<$type>,
-        {
+        impl ProcessBlock for CompareToValueBlock<$type> {
             type Inputs = $type;
             type Output = $type;
             type Parameters = Parameter<$type>;
@@ -70,7 +63,6 @@ macro_rules! impl_compare_to_value_block {
                     ComparisonType::GreaterOrEqual => input >= parameters.value,
                 };
                 self.buffer = val.into();
-                self.data = OldBlockData::from_scalar(self.buffer.into());
                 self.buffer
             }
 
@@ -81,8 +73,6 @@ macro_rules! impl_compare_to_value_block {
 
         impl<const ROWS: usize, const COLS: usize> ProcessBlock
             for CompareToValueBlock<Matrix<ROWS, COLS, $type>>
-        where
-            OldBlockData: FromPass<Matrix<ROWS, COLS, $type>>,
         {
             type Inputs = Matrix<ROWS, COLS, $type>;
             type Output = Matrix<ROWS, COLS, $type>;
@@ -107,7 +97,6 @@ macro_rules! impl_compare_to_value_block {
                         self.buffer.data[c][r] = val.into();
                     }
                 }
-                self.data = OldBlockData::from_pass(&self.buffer);
                 &self.buffer
             }
 
@@ -158,33 +147,32 @@ mod tests {
 
                     let output = block.process(&parameters, &context, <$type>::one());
                     assert_eq!(output, <$type>::one());
-                    assert_eq!(block.data.scalar(), <$type>::one().into());
                     assert_eq!(block.buffer(), output);
 
                     parameters.comparison_type = ComparisonType::NotEqual;
                     let output = block.process(&parameters, &context, <$type>::zero());
                     assert_eq!(output, <$type>::one());
-                    assert_eq!(block.data.scalar(), <$type>::one().into());
+                    assert_eq!(block.buffer(), <$type>::one());
 
                     parameters.comparison_type = ComparisonType::LessThan;
                     let output = block.process(&parameters, &context, <$type>::zero());
                     assert_eq!(output, <$type>::one());
-                    assert_eq!(block.data.scalar(), <$type>::one().into());
+                    assert_eq!(block.buffer(), <$type>::one());
 
                     parameters.comparison_type = ComparisonType::LessOrEqual;
                     let output = block.process(&parameters, &context, <$type>::one());
                     assert_eq!(output, <$type>::one());
-                    assert_eq!(block.data.scalar(), <$type>::one().into());
+                    assert_eq!(block.buffer(), <$type>::one());
 
                     parameters.comparison_type = ComparisonType::GreaterThan;
                     let output = block.process(&parameters, &context, <$type>::one() + <$type>::one());
                     assert_eq!(output, <$type>::one());
-                    assert_eq!(block.data.scalar(), <$type>::one().into());
+                    assert_eq!(block.buffer(), <$type>::one());
 
                     parameters.comparison_type = ComparisonType::GreaterOrEqual;
                     let output = block.process(&parameters, &context, <$type>::one());
                     assert_eq!(output, <$type>::one());
-                    assert_eq!(block.data.scalar(), <$type>::one().into());
+                    assert_eq!(block.buffer(), <$type>::one());
                 }
 
                 #[test]
@@ -205,10 +193,10 @@ mod tests {
                     assert_eq!(output.data[0][1], <$type>::zero());
                     assert_eq!(output.data[1][0], <$type>::zero());
                     assert_eq!(output.data[1][1], <$type>::zero());
-                    assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[<$type>::one().into(), <$type>::zero().into()], &[<$type>::zero().into(), <$type>::zero().into()]])
-                    );
+                    assert_eq!(block.buffer().data[0][0], <$type>::one());
+                    assert_eq!(block.buffer().data[0][1], <$type>::zero());
+                    assert_eq!(block.buffer().data[1][0], <$type>::zero());
+                    assert_eq!(block.buffer().data[1][1], <$type>::zero());
 
                     parameters.comparison_type = ComparisonType::NotEqual;
                     let output = block.process(&parameters, &context, &input);
@@ -216,10 +204,10 @@ mod tests {
                     assert_eq!(output.data[0][1], <$type>::one());
                     assert_eq!(output.data[1][0], <$type>::one());
                     assert_eq!(output.data[1][1], <$type>::one());
-                    assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[<$type>::zero().into(), <$type>::one().into()], &[<$type>::one().into(), <$type>::one().into()]])
-                    );
+                    assert_eq!(block.buffer().data[0][0], <$type>::zero());
+                    assert_eq!(block.buffer().data[0][1], <$type>::one());
+                    assert_eq!(block.buffer().data[1][0], <$type>::one());
+                    assert_eq!(block.buffer().data[1][1], <$type>::one());
 
                     parameters.comparison_type = ComparisonType::LessThan;
                     let output = block.process(&parameters, &context, &input);
@@ -227,10 +215,10 @@ mod tests {
                     assert_eq!(output.data[0][1], <$type>::one());
                     assert_eq!(output.data[1][0], <$type>::one());
                     assert_eq!(output.data[1][1], <$type>::zero());
-                    assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[<$type>::zero().into(), <$type>::one().into()], &[<$type>::one().into(), <$type>::zero().into()]])
-                    );
+                    assert_eq!(block.buffer().data[0][0], <$type>::zero());
+                    assert_eq!(block.buffer().data[0][1], <$type>::one());
+                    assert_eq!(block.buffer().data[1][0], <$type>::one());
+                    assert_eq!(block.buffer().data[1][1], <$type>::zero());
 
                     parameters.comparison_type = ComparisonType::LessOrEqual;
                     let output = block.process(&parameters, &context, &input);
@@ -238,10 +226,10 @@ mod tests {
                     assert_eq!(output.data[0][1], <$type>::one());
                     assert_eq!(output.data[1][0], <$type>::one());
                     assert_eq!(output.data[1][1], <$type>::zero());
-                    assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[<$type>::one().into(), <$type>::one().into()], &[<$type>::one().into(), <$type>::zero().into()]])
-                    );
+                    assert_eq!(block.buffer().data[0][0], <$type>::one());
+                    assert_eq!(block.buffer().data[0][1], <$type>::one());
+                    assert_eq!(block.buffer().data[1][0], <$type>::one());
+                    assert_eq!(block.buffer().data[1][1], <$type>::zero());
 
                     parameters.comparison_type = ComparisonType::GreaterThan;
                     let output = block.process(&parameters, &context, &input);
@@ -249,10 +237,10 @@ mod tests {
                     assert_eq!(output.data[0][1], <$type>::zero());
                     assert_eq!(output.data[1][0], <$type>::zero());
                     assert_eq!(output.data[1][1], <$type>::one());
-                    assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[<$type>::zero().into(), <$type>::zero().into()], &[<$type>::zero().into(), <$type>::one().into()]])
-                    );
+                    assert_eq!(block.buffer().data[0][0], <$type>::zero());
+                    assert_eq!(block.buffer().data[0][1], <$type>::zero());
+                    assert_eq!(block.buffer().data[1][0], <$type>::zero());
+                    assert_eq!(block.buffer().data[1][1], <$type>::one());
 
                     parameters.comparison_type = ComparisonType::GreaterOrEqual;
                     let output = block.process(&parameters, &context, &input);
@@ -260,10 +248,10 @@ mod tests {
                     assert_eq!(output.data[0][1], <$type>::zero());
                     assert_eq!(output.data[1][0], <$type>::zero());
                     assert_eq!(output.data[1][1], <$type>::one());
-                    assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[<$type>::one().into(), <$type>::zero().into()], &[<$type>::zero().into(), <$type>::one().into()]])
-                    );
+                    assert_eq!(block.buffer().data[0][0], <$type>::one());
+                    assert_eq!(block.buffer().data[0][1], <$type>::zero());
+                    assert_eq!(block.buffer().data[1][0], <$type>::zero());
+                    assert_eq!(block.buffer().data[1][1], <$type>::one());
                 }
             }
         };

--- a/pictorus-blocks/src/core_blocks/deadband_block.rs
+++ b/pictorus-blocks/src/core_blocks/deadband_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::traits::MatrixOps;
@@ -23,18 +22,15 @@ impl<T> Parameters<T> {
 ///
 /// If the input is within the deadband, the output is zero. Otherwise, the input value is passed through.
 pub struct DeadbandBlock<T> {
-    pub data: OldBlockData,
     buffer: T,
 }
 
 impl<T> Default for DeadbandBlock<T>
 where
     T: Pass + Default,
-    OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
             buffer: T::default(),
         }
     }
@@ -42,10 +38,7 @@ where
 
 macro_rules! impl_deadband_block {
     ($type:ty) => {
-        impl ProcessBlock for DeadbandBlock<$type>
-        where
-            OldBlockData: FromPass<$type>,
-        {
+        impl ProcessBlock for DeadbandBlock<$type> {
             type Inputs = $type;
             type Output = $type;
             type Parameters = Parameters<$type>;
@@ -59,7 +52,6 @@ macro_rules! impl_deadband_block {
                 let in_deadband = input < parameters.upper_limit && input > parameters.lower_limit;
                 let res = if in_deadband { 0.0 } else { input };
                 self.buffer = res;
-                self.data = OldBlockData::from_scalar(res.into());
                 self.buffer
             }
 
@@ -70,8 +62,6 @@ macro_rules! impl_deadband_block {
 
         impl<const ROWS: usize, const COLS: usize> ProcessBlock
             for DeadbandBlock<Matrix<ROWS, COLS, $type>>
-        where
-            OldBlockData: FromPass<Matrix<ROWS, COLS, $type>>,
         {
             type Inputs = Matrix<ROWS, COLS, $type>;
             type Output = Matrix<ROWS, COLS, $type>;
@@ -88,7 +78,6 @@ macro_rules! impl_deadband_block {
                     let in_deadband = v < parameters.upper_limit && v > parameters.lower_limit;
                     self.buffer.data[c][r] = if in_deadband { 0.0 } else { v };
                 });
-                self.data = OldBlockData::from_pass(&self.buffer);
                 &self.buffer
             }
 

--- a/pictorus-blocks/src/core_blocks/exponent_block.rs
+++ b/pictorus-blocks/src/core_blocks/exponent_block.rs
@@ -1,5 +1,4 @@
 use crate::traits::Scalar;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Raises the input to a specified power (coefficient),
@@ -16,26 +15,18 @@ use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 /// a panic will occur.
 #[derive(Debug)]
 pub struct ExponentBlock<T: Pass + Default> {
-    pub data: OldBlockData,
     output: T,
 }
 
-impl<T: Pass + Default> Default for ExponentBlock<T>
-where
-    OldBlockData: FromPass<T>,
-{
+impl<T: Pass + Default> Default for ExponentBlock<T> {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
             output: T::default(),
         }
     }
 }
 
-impl<S: Scalar + num_traits::Float + num_traits::Zero> ProcessBlock for ExponentBlock<S>
-where
-    OldBlockData: FromPass<S>,
-{
+impl<S: Scalar + num_traits::Float + num_traits::Zero> ProcessBlock for ExponentBlock<S> {
     type Inputs = S;
     type Output = S;
     type Parameters = Parameters<S>;
@@ -61,7 +52,6 @@ where
                 self.output = self.output.neg();
             };
         }
-        self.data = OldBlockData::from_pass(self.output);
         self.output
     }
 
@@ -72,8 +62,6 @@ where
 
 impl<S: Scalar + num_traits::Float + num_traits::Zero, const NROWS: usize, const NCOLS: usize>
     ProcessBlock for ExponentBlock<Matrix<NROWS, NCOLS, S>>
-where
-    OldBlockData: FromPass<Matrix<NROWS, NCOLS, S>>,
 {
     type Inputs = Matrix<NROWS, NCOLS, S>;
     type Output = Matrix<NROWS, NCOLS, S>;
@@ -108,7 +96,6 @@ where
                 }
                 *x = x_local;
             });
-        self.data = OldBlockData::from_pass(&self.output);
         &self.output
     }
 

--- a/pictorus-blocks/src/core_blocks/fix_non_finite_block.rs
+++ b/pictorus-blocks/src/core_blocks/fix_non_finite_block.rs
@@ -1,5 +1,4 @@
 use crate::traits::Float;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Pass, PassBy, ProcessBlock};
 
 // A block that ensures all data passed into it is finite, replacing non-finite values with zero.
@@ -7,21 +6,13 @@ use pictorus_traits::{Pass, PassBy, ProcessBlock};
 // This block is needed to support legacy behavior where we fix values passed in by user-defined functions
 // i.e. EquationBlock and RustBlock. It's unclear if we want to support this behavior in the future.
 #[doc(hidden)]
-pub struct FixNonFiniteBlock<T: Pass>
-where
-    OldBlockData: FromPass<T>,
-{
-    pub data: OldBlockData,
+pub struct FixNonFiniteBlock<T: Pass> {
     buffer: T,
 }
 
-impl<T: Float> Default for FixNonFiniteBlock<T>
-where
-    OldBlockData: FromPass<T>,
-{
+impl<T: Float> Default for FixNonFiniteBlock<T> {
     fn default() -> Self {
         FixNonFiniteBlock {
-            data: OldBlockData::from_pass(T::default().as_by()),
             buffer: T::default(),
         }
     }
@@ -36,10 +27,7 @@ impl Parameters {
     }
 }
 
-impl<T: Float> ProcessBlock for FixNonFiniteBlock<T>
-where
-    OldBlockData: FromPass<T>,
-{
+impl<T: Float> ProcessBlock for FixNonFiniteBlock<T> {
     type Parameters = Parameters;
     type Inputs = T;
     type Output = T;
@@ -56,7 +44,6 @@ where
             input
         };
         self.buffer = res;
-        self.data = OldBlockData::from_pass(res);
         res
     }
 
@@ -86,12 +73,11 @@ mod tests {
         let input = 99.999;
         let output = block.process(&params, &ctxt, input.as_by());
         assert_eq!(output, input);
-        assert_eq!(block.data.scalar(), input);
         assert_eq!(block.buffer(), output);
 
         let input = f64::NAN;
         let output = block.process(&params, &ctxt, input.as_by());
         assert_eq!(output, 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
     }
 }

--- a/pictorus-blocks/src/core_blocks/gain_block.rs
+++ b/pictorus-blocks/src/core_blocks/gain_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Promote, Promotion, Scalar};
 
 /// Multiplies the input by a gain factor.
@@ -7,7 +6,6 @@ where
     G: Scalar,
     T: Apply<G>,
 {
-    pub data: OldBlockData,
     buffer: T::Output,
 }
 
@@ -15,11 +13,9 @@ impl<G, T> Default for GainBlock<G, T>
 where
     G: Scalar,
     T: Apply<G>,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
             buffer: <T::Output>::default(),
         }
     }
@@ -29,7 +25,6 @@ impl<G, T> ProcessBlock for GainBlock<G, T>
 where
     G: Scalar,
     T: Apply<G>,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -42,7 +37,6 @@ where
         input: PassBy<Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
         let output = T::apply(&mut self.buffer, input, parameters.gain);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 
@@ -136,7 +130,6 @@ impl<G: Scalar> Parameters<G> {
 mod tests {
     use super::*;
     use crate::testing::StubContext;
-    use pictorus_block_data::ToPass;
 
     #[test]
     fn test_gain_default_buffer_no_panic() {
@@ -155,7 +148,6 @@ mod tests {
         let parameters = Parameters::new(2.0);
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, 2.0);
-        assert_eq!(block.data.scalar(), 2.0);
         assert_eq!(block.buffer(), output);
     }
 
@@ -169,42 +161,30 @@ mod tests {
         let parameters = Parameters::new(2.0);
         let output = block.process(&parameters, &context, &input);
         assert_eq!(output.data, [[2.0, 4.0], [6.0, 8.0]]);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            [[2.0, 4.0], [6.0, 8.0]].as_flattened()
-        );
+        assert_eq!(block.buffer().data, [[2.0, 4.0], [6.0, 8.0]]);
     }
 
     #[test]
     fn test_scalar_with_to_pass() {
         let mut block = GainBlock::<f64, f64>::default();
         let context = StubContext::default();
-        let input = OldBlockData::from_scalar(1.0);
+        let input = 1.0;
         let parameters = Parameters::new(2.0);
-        let output = block.process(&parameters, &context, input.to_pass());
+        let output = block.process(&parameters, &context, input);
         assert_eq!(output, 2.0);
-        assert_eq!(block.data.scalar(), 2.0);
+        assert_eq!(block.buffer(), 2.0);
     }
 
     #[test]
     fn test_matrix_with_to_pass() {
-        // Just to prove the test below makes sense. Rows and cols get flipped along the way in conversions
-        assert_eq!(
-            OldBlockData::from_matrix(&[&[1.0, 2.0], &[3.0, 4.0]])
-                .get_data()
-                .as_slice(),
-            [[1.0, 3.0], [2.0, 4.0]].as_flattened()
-        );
-
         let mut block = GainBlock::<f64, Matrix<2, 2, f64>>::default();
         let context = StubContext::default();
-        let input = OldBlockData::from_matrix(&[&[1.0, 2.0], &[3.0, 4.0]]);
+        let input = Matrix {
+            data: [[1.0, 3.0], [2.0, 4.0]],
+        };
         let parameters = Parameters::new(2.0);
-        let output = block.process(&parameters, &context, &input.to_pass());
+        let output = block.process(&parameters, &context, &input);
         assert_eq!(output.data, [[2.0, 6.0], [4.0, 8.0]]);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            [[2.0, 6.0], [4.0, 8.0]].as_flattened()
-        );
+        assert_eq!(block.buffer().data, [[2.0, 6.0], [4.0, 8.0]]);
     }
 }

--- a/pictorus-blocks/src/core_blocks/lookup_1d_block.rs
+++ b/pictorus-blocks/src/core_blocks/lookup_1d_block.rs
@@ -1,6 +1,5 @@
 use core::marker::PhantomData;
 
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::traits::{Float, MatrixOps};
@@ -15,15 +14,11 @@ where
     S: Float,
     T: Apply<N, S>,
 {
-    pub data: OldBlockData,
     buffer: T,
     _unused: PhantomData<S>,
 }
 
-impl<const N: usize, S: Float, T: Apply<N, S>> ProcessBlock for Lookup1DBlock<N, S, T>
-where
-    OldBlockData: FromPass<T>,
-{
+impl<const N: usize, S: Float, T: Apply<N, S>> ProcessBlock for Lookup1DBlock<N, S, T> {
     type Inputs = T;
     type Output = T;
     type Parameters = Parameters<N, S>;
@@ -35,7 +30,6 @@ where
         inputs: pictorus_traits::PassBy<'_, Self::Inputs>,
     ) -> pictorus_traits::PassBy<'b, Self::Output> {
         let output = T::apply(&mut self.buffer, inputs, parameters);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 
@@ -44,13 +38,9 @@ where
     }
 }
 
-impl<const N: usize, S: Float, T: Apply<N, S>> Default for Lookup1DBlock<N, S, T>
-where
-    OldBlockData: FromPass<T>,
-{
+impl<const N: usize, S: Float, T: Apply<N, S>> Default for Lookup1DBlock<N, S, T> {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
             buffer: T::default(),
             _unused: PhantomData,
         }
@@ -192,30 +182,29 @@ mod tests {
         let mut block = Lookup1DBlock::<3, f64, f64>::default();
         let res = block.process(&params, &ctxt, 0.0);
         assert_eq!(res, -1.0);
-        assert_eq!(block.data.scalar(), -1.0);
         assert_eq!(block.buffer(), res);
 
         let res = block.process(&params, &ctxt, 1.0);
         assert_eq!(res, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
 
         let res = block.process(&params, &ctxt, 0.5);
         assert_eq!(res, 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
 
         let res = block.process(&params, &ctxt, 1.5);
         let expected = 11.0 / 2.0;
         assert_eq!(res, expected);
-        assert_eq!(block.data.scalar(), expected);
+        assert_eq!(block.buffer(), expected);
 
         // Verify clamps output
         let res = block.process(&params, &ctxt, 3.0);
         assert_eq!(res, 10.0);
-        assert_eq!(block.data.scalar(), 10.0);
+        assert_eq!(block.buffer(), 10.0);
 
         let res = block.process(&params, &ctxt, -100.0);
         assert_eq!(res, -1.0);
-        assert_eq!(block.data.scalar(), -1.0);
+        assert_eq!(block.buffer(), -1.0);
     }
 
     #[test]
@@ -228,32 +217,32 @@ mod tests {
         let mut block = Lookup1DBlock::<3, f64, f64>::default();
         let res = block.process(&params, &ctxt, 0.0);
         assert_eq!(res, -1.0);
-        assert_eq!(block.data.scalar(), -1.0);
+        assert_eq!(block.buffer(), -1.0);
 
         let res = block.process(&params, &ctxt, 0.25);
         assert_eq!(res, -1.0);
-        assert_eq!(block.data.scalar(), -1.0);
+        assert_eq!(block.buffer(), -1.0);
 
         let res = block.process(&params, &ctxt, 0.5);
         assert_eq!(res, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
 
         let res = block.process(&params, &ctxt, 0.75);
         assert_eq!(res, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
 
         let res = block.process(&params, &ctxt, 1.75);
         assert_eq!(res, 10.0);
-        assert_eq!(block.data.scalar(), 10.0);
+        assert_eq!(block.buffer(), 10.0);
 
         // Verify clamps output
         let res = block.process(&params, &ctxt, 3.0);
         assert_eq!(res, 10.0);
-        assert_eq!(block.data.scalar(), 10.0);
+        assert_eq!(block.buffer(), 10.0);
 
         let res = block.process(&params, &ctxt, -100.0);
         assert_eq!(res, -1.0);
-        assert_eq!(block.data.scalar(), -1.0);
+        assert_eq!(block.buffer(), -1.0);
     }
 
     #[test]
@@ -272,10 +261,7 @@ mod tests {
             data: [[-1.0, 1.0], [0.0, 11.0 / 2.0]],
         };
         assert_eq!(res.data, expected.data);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer().data, expected.data);
 
         // Verify clamps output
         let input = Matrix {
@@ -286,10 +272,7 @@ mod tests {
             data: [[10.0, 10.0], [-1.0, -1.0]],
         };
         assert_eq!(res.data, expected.data);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer().data, expected.data);
     }
 
     #[test]
@@ -308,10 +291,7 @@ mod tests {
             data: [[-1.0, -1.0], [1.0, 10.0]],
         };
         assert_eq!(res.data, expected.data);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer().data, expected.data);
 
         // Verify clamps output
         let input = Matrix {
@@ -322,9 +302,6 @@ mod tests {
             data: [[10.0, 10.0], [-1.0, -1.0]],
         };
         assert_eq!(res.data, expected.data);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer().data, expected.data);
     }
 }

--- a/pictorus-blocks/src/core_blocks/not_block.rs
+++ b/pictorus-blocks/src/core_blocks/not_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 #[derive(strum::EnumString, Clone, Copy)]
@@ -11,20 +10,16 @@ pub enum NotMethod {
 pub struct NotBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
-    pub data: OldBlockData,
     buffer: T::Output,
 }
 
 impl<T> Default for NotBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
             buffer: T::Output::default(),
         }
     }
@@ -33,7 +28,6 @@ where
 impl<T> ProcessBlock for NotBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -46,7 +40,6 @@ where
         input: PassBy<Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
         let output = T::apply(&mut self.buffer, input, parameters.method);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 
@@ -209,20 +202,19 @@ mod tests {
 
                     let res = block.process(&parameters, &context, 1.0);
                     assert_eq!(res, 0.0);
-                    assert_eq!(block.data.scalar(), 0.0);
                     assert_eq!(block.buffer(), res);
 
                     let res = block.process(&parameters, &context, 0.0);
                     assert_eq!(res, 1.0);
-                    assert_eq!(block.data.scalar(), 1.0);
+                    assert_eq!(block.buffer(), 1.0);
 
                     let res = block.process(&parameters, &context, -1.2);
                     assert_eq!(res, 0.0);
-                    assert_eq!(block.data.scalar(), 0.0);
+                    assert_eq!(block.buffer(), 0.0);
 
                     let res = block.process(&parameters, &context, 1.2);
                     assert_eq!(res, 0.0);
-                    assert_eq!(block.data.scalar(), 0.0);
+                    assert_eq!(block.buffer(), 0.0);
                 }
 
                 #[test]
@@ -236,7 +228,7 @@ mod tests {
                     };
                     let res = block.process(&parameters, &context, &input);
                     assert_eq!(res.data, [[0.0, 1.0, 0.0, 0.0]]);
-                    assert_eq!(block.data.get_data().as_slice(), [[0.0, 1.0, 0.0, 0.0]].as_flattened());
+                    assert_eq!(block.buffer().data, [[0.0, 1.0, 0.0, 0.0]]);
                 }
 
                 #[test]
@@ -247,19 +239,19 @@ mod tests {
 
                     let res = block.process(&parameters, &context, 1.0);
                     assert_eq!(res, -2.0);
-                    assert_eq!(block.data.scalar(), -2.0);
+                    assert_eq!(block.buffer(), -2.0);
 
                     let res = block.process(&parameters, &context, 42.0);
                     assert_eq!(res, -43.0);
-                    assert_eq!(block.data.scalar(), -43.0);
+                    assert_eq!(block.buffer(), -43.0);
 
                     let res = block.process(&parameters, &context, -1.2);
                     assert_eq!(res, 0.0);
-                    assert_eq!(block.data.scalar(), 0.0);
+                    assert_eq!(block.buffer(), 0.0);
 
                     let res = block.process(&parameters, &context, 1.2);
                     assert_eq!(res, -2.0);
-                    assert_eq!(block.data.scalar(), -2.0);
+                    assert_eq!(block.buffer(), -2.0);
                 }
 
                 #[test]
@@ -273,7 +265,7 @@ mod tests {
                     };
                     let res = block.process(&parameters, &context, &input);
                     assert_eq!(res.data, [[-2.0, -43.0], [0.0, -2.0]]);
-                    assert_eq!(block.data.get_data().as_slice(), [[-2.0, -43.0], [0.0, -2.0]].as_flattened());
+                    assert_eq!(block.buffer().data, [[-2.0, -43.0], [0.0, -2.0]]);
                 }
             }
         };
@@ -290,20 +282,20 @@ mod tests {
 
         let res = block.process(&parameters, &context, true);
         assert!(!res);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert!(!block.buffer());
 
         let res = block.process(&parameters, &context, false);
         assert!(res);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert!(block.buffer());
 
         let parameters = Parameters::new("Bitwise");
         let res = block.process(&parameters, &context, true);
         assert!(!res);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert!(!block.buffer());
 
         let res = block.process(&parameters, &context, false);
         assert!(res);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert!(block.buffer());
     }
 
     #[test]
@@ -317,9 +309,6 @@ mod tests {
         };
         let res = block.process(&parameters, &context, &input);
         assert_eq!(res.data, [[false, true], [true, false]]);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            [[0.0, 1.0], [1.0, 0.0]].as_flattened()
-        );
+        assert_eq!(block.buffer().data, [[false, true], [true, false]]);
     }
 }

--- a/pictorus-blocks/src/core_blocks/passthrough_block.rs
+++ b/pictorus-blocks/src/core_blocks/passthrough_block.rs
@@ -1,10 +1,4 @@
-// TODO: Currently we require alloc in this crate to support OldBlockData,
-// but eventually this crate should be no_std and no_alloc. When we remove
-// OldBlockData, we should also update this block to function without alloc
-extern crate alloc;
-
 use crate::traits::DefaultStorage;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{PassBy, ProcessBlock};
 
 // A block that passes through the input data, storing it in a buffer.
@@ -12,23 +6,13 @@ use pictorus_traits::{PassBy, ProcessBlock};
 // Eventually it would be better to remove this block and just use the input value directly,
 // but we need to maintain it for now to keep the old block data system working.
 #[doc(hidden)]
-pub struct PassthroughBlock<T: DefaultStorage>
-where
-    OldBlockData: FromPass<T>,
-{
-    pub data: OldBlockData,
+pub struct PassthroughBlock<T: DefaultStorage> {
     buffer: T::Storage,
 }
 
-impl<T: DefaultStorage> Default for PassthroughBlock<T>
-where
-    OldBlockData: FromPass<T>,
-{
+impl<T: DefaultStorage> Default for PassthroughBlock<T> {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T>>::from_pass(<T as DefaultStorage>::from_storage(
-                &T::default_storage(),
-            )),
             buffer: T::default_storage(),
         }
     }
@@ -44,10 +28,7 @@ impl Parameters {
     }
 }
 
-impl<T: DefaultStorage> ProcessBlock for PassthroughBlock<T>
-where
-    OldBlockData: FromPass<T>,
-{
+impl<T: DefaultStorage> ProcessBlock for PassthroughBlock<T> {
     type Parameters = Parameters;
     type Inputs = T;
     type Output = T;
@@ -59,9 +40,7 @@ where
         input: PassBy<'_, Self::Inputs>,
     ) -> pictorus_traits::PassBy<'b, Self::Output> {
         T::copy_into(input, &mut self.buffer);
-        let res = <T as DefaultStorage>::from_storage(&self.buffer);
-        self.data = <OldBlockData as FromPass<T>>::from_pass(res);
-        res
+        <T as DefaultStorage>::from_storage(&self.buffer)
     }
 
     fn buffer(&self) -> PassBy<'_, Self::Output> {
@@ -91,7 +70,6 @@ mod tests {
         let input = 99.999;
         let output = block.process(&params, &ctxt, input.as_by());
         assert_eq!(output, input);
-        assert_eq!(block.data.scalar(), input);
         assert_eq!(block.buffer(), output);
     }
 
@@ -104,12 +82,12 @@ mod tests {
         let input = b"hello world";
         let output = block.process(&params, &ctxt, input.as_slice());
         assert_eq!(output, input);
-        assert_eq!(block.data.to_raw_bytes(), input);
+        assert_eq!(block.buffer(), input);
 
         let input = b"";
         let output = block.process(&params, &ctxt, input.as_slice());
         assert_eq!(output, input);
-        assert_eq!(block.data.to_raw_bytes(), input);
+        assert_eq!(block.buffer(), input);
     }
 
     #[test]
@@ -123,6 +101,6 @@ mod tests {
         };
         let output = block.process(&params, &ctxt, input.as_by());
         assert_eq!(output, &input);
-        assert_eq!(block.data.get_data().as_slice(), input.data.as_flattened());
+        assert_eq!(block.buffer(), &input);
     }
 }

--- a/pictorus-blocks/src/core_blocks/passthrough_block.rs
+++ b/pictorus-blocks/src/core_blocks/passthrough_block.rs
@@ -4,7 +4,7 @@ use pictorus_traits::{PassBy, ProcessBlock};
 // A block that passes through the input data, storing it in a buffer.
 //
 // Eventually it would be better to remove this block and just use the input value directly,
-// but we need to maintain it for now to keep the old block data system working.
+// but we need to maintain it for now to keep the buffered block system working.
 #[doc(hidden)]
 pub struct PassthroughBlock<T: DefaultStorage> {
     buffer: T::Storage,

--- a/pictorus-blocks/src/core_blocks/quantize_block.rs
+++ b/pictorus-blocks/src/core_blocks/quantize_block.rs
@@ -4,7 +4,6 @@ use crate::matrix_ext::MatrixNalgebraExt;
 use crate::traits::{MatrixOps, Scalar};
 use nalgebra::ClosedDivAssign;
 use num_traits::Float;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 pub struct Parameters<I: Scalar + Float> {
@@ -27,9 +26,7 @@ pub struct QuantizeBlock<I, T>
 where
     I: Scalar + Float,
     T: Apply<I>,
-    OldBlockData: FromPass<T::Output>,
 {
-    pub data: OldBlockData,
     buffer: T::Output,
 }
 
@@ -37,11 +34,9 @@ impl<I, T> Default for QuantizeBlock<I, T>
 where
     I: Scalar + Float,
     T: Apply<I>,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
             buffer: T::Output::default(),
         }
     }
@@ -51,7 +46,6 @@ impl<I, T> ProcessBlock for QuantizeBlock<I, T>
 where
     I: Scalar + Float,
     T: Apply<I>,
-    OldBlockData: FromPass<T::Output>,
 {
     type Parameters = Parameters<I>;
     type Inputs = T;
@@ -64,7 +58,6 @@ where
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
         let res = T::apply(inputs, parameters.interval, &mut self.buffer);
-        self.data = OldBlockData::from_pass(res);
         res
     }
 
@@ -120,8 +113,6 @@ impl<const R: usize, const C: usize, I: Scalar + Float + ClosedDivAssign + MulAs
 
 #[cfg(test)]
 mod tests {
-    use std::vec::Vec;
-
     use crate::testing::StubContext;
     use paste::paste;
 
@@ -145,7 +136,6 @@ mod tests {
                     let res = block.process(&params, &context, input);
 
                     assert_eq!(res, 0.5);
-                    assert_eq!(block.data.scalar(), 0.5);
                     assert_eq!(block.buffer(), res);
                 }
 
@@ -163,15 +153,7 @@ mod tests {
                     let res = block.process(&params, &context, &input);
 
                     assert_eq!(res.data, expected.data);
-                    assert_eq!(
-                        block.data.get_data().as_slice(),
-                        expected
-                            .data
-                            .as_flattened()
-                            .iter()
-                            .map(|x| *x as f64)
-                            .collect::<Vec<f64>>()
-                    );
+                    assert_eq!(block.buffer().data, expected.data);
                 }
             }
         };

--- a/pictorus-blocks/src/core_blocks/rate_limit_block.rs
+++ b/pictorus-blocks/src/core_blocks/rate_limit_block.rs
@@ -1,6 +1,5 @@
 use crate::traits::{Float, MatrixOps};
 use num_traits::Zero;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
 
 /// Rate limit block parameters
@@ -27,18 +26,15 @@ where
 /// the rate of change of the signal as specified by the Rising and
 /// Falling rates.
 pub struct RateLimitBlock<T> {
-    pub data: OldBlockData,
     buffer: T,
 }
 
 impl<T> Default for RateLimitBlock<T>
 where
     T: Pass + Default,
-    OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
             buffer: T::default(),
         }
     }
@@ -49,7 +45,6 @@ macro_rules! impl_rate_limit_block {
         impl ProcessBlock for RateLimitBlock<$type>
         where
             $type: num_traits::Zero,
-            OldBlockData: FromPass<$type>,
         {
             type Inputs = $type;
             type Output = $type;
@@ -74,7 +69,6 @@ macro_rules! impl_rate_limit_block {
                         // b + clamped_change_rate * timestep_s;
                         self.buffer + clamped_change_rate * timestep_s
                     };
-                    self.data = OldBlockData::from_scalar(self.buffer.into());
                     self.buffer
                 } else {
                     //First Run ever
@@ -89,8 +83,6 @@ macro_rules! impl_rate_limit_block {
 
         impl<const ROWS: usize, const COLS: usize> ProcessBlock
             for RateLimitBlock<Matrix<ROWS, COLS, $type>>
-        where
-            OldBlockData: FromPass<Matrix<ROWS, COLS, $type>>,
         {
             type Inputs = Matrix<ROWS, COLS, $type>;
             type Output = Matrix<ROWS, COLS, $type>;
@@ -118,7 +110,6 @@ macro_rules! impl_rate_limit_block {
                     });
 
                     self.buffer = output;
-                    self.data = OldBlockData::from_pass(&output);
                     &self.buffer
                 } else {
                     //First Run ever
@@ -144,7 +135,6 @@ mod tests {
     use crate::testing::StubRuntime;
     use core::time::Duration;
     use paste::paste;
-    use pictorus_block_data::BlockData as OldBlockData;
 
     #[test]
     fn test_rate_limit_default_buffer_no_panic() {
@@ -175,39 +165,38 @@ mod tests {
                     // Test rising rate
                     runtime.tick();
                     let output = block.process(&parameters, &runtime.context(), 3.0);
-                    assert_eq!(block.data.scalar(), 2.0);
                     assert_eq!(output, 2.0);
                     assert_eq!(block.buffer(), output);
 
                     // Test rising rate
                     runtime.tick();
                     let output = block.process(&parameters, &runtime.context(), 30.0);
-                    assert_eq!(block.data.scalar(), 4.0);
                     assert_eq!(output, 4.0);
+                    assert_eq!(block.buffer(), 4.0);
 
                     // Value doesn't change if input matches current state
                     runtime.tick();
                     let output = block.process(&parameters, &runtime.context(), 4.0);
-                    assert_eq!(block.data.scalar(), 4.0);
                     assert_eq!(output, 4.0);
+                    assert_eq!(block.buffer(), 4.0);
 
                     // Test falling rate
                     runtime.tick();
                     let output = block.process(&parameters, &runtime.context(), -30.0);
-                    assert_eq!(block.data.scalar(), 3.0);
                     assert_eq!(output, 3.0);
+                    assert_eq!(block.buffer(), 3.0);
 
                     // Test falling rate
                     runtime.tick();
                     let output = block.process(&parameters, &runtime.context(), -0.5);
-                    assert_eq!(block.data.scalar(), 2.0);
                     assert_eq!(output, 2.0);
+                    assert_eq!(block.buffer(), 2.0);
 
                     // Test passing in no timestep does not change output
                     runtime.context.timestep = Some(Duration::from_secs(0));
                     let output = block.process(&parameters, &runtime.context(), -30.0);
-                    assert_eq!(block.data.scalar(), 2.0);
                     assert_eq!(output, 2.0);
+                    assert_eq!(block.buffer(), 2.0);
                 }
 
                 #[test]
@@ -237,8 +226,10 @@ mod tests {
                         }
                     );
                     assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[2.0, 2.0], &[2.0, 2.0]])
+                        block.buffer(),
+                        &Matrix {
+                            data: [[2.0, 2.0], [2.0, 2.0]],
+                        }
                     );
 
                     // Test rising rate
@@ -254,8 +245,10 @@ mod tests {
                         }
                     );
                     assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[4.0, 4.0], &[4.0, 4.0]])
+                        block.buffer(),
+                        &Matrix {
+                            data: [[4.0, 4.0], [4.0, 4.0]],
+                        }
                     );
 
                     // Value doesn't change if input matches current state
@@ -271,8 +264,10 @@ mod tests {
                         }
                     );
                     assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[4.0, 4.0], &[4.0, 4.0]])
+                        block.buffer(),
+                        &Matrix {
+                            data: [[4.0, 4.0], [4.0, 4.0]],
+                        }
                     );
 
                     // Test falling rate
@@ -288,8 +283,10 @@ mod tests {
                         }
                     );
                     assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[3.0, 3.0], &[3.0, 3.8]])
+                        block.buffer(),
+                        &Matrix {
+                            data: [[3.0, 3.0], [3.0, 3.8]],
+                        }
                     );
 
                     // Test falling rate
@@ -305,8 +302,10 @@ mod tests {
                         }
                     );
                     assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[2.0, 2.0], &[2.5, 3.6]])
+                        block.buffer(),
+                        &Matrix {
+                            data: [[2.0, 2.5], [2.0, 3.6]],
+                        }
                     );
 
                     // Test passing in no timestep does not change output
@@ -322,8 +321,10 @@ mod tests {
                         }
                     );
                     assert_eq!(
-                        block.data,
-                        OldBlockData::from_matrix(&[&[2.0, 2.0], &[2.5, 3.6]])
+                        block.buffer(),
+                        &Matrix {
+                            data: [[2.0, 2.5], [2.0, 3.6]],
+                        }
                     );
                 }
             }

--- a/pictorus-blocks/src/core_blocks/trigonometry_block.rs
+++ b/pictorus-blocks/src/core_blocks/trigonometry_block.rs
@@ -1,6 +1,5 @@
 use crate::traits::MatrixOps;
 use num_traits::Float;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 #[derive(strum::EnumString, PartialEq)]
@@ -34,18 +33,15 @@ impl Parameters {
 }
 
 pub struct TrigonometryBlock<T> {
-    pub data: OldBlockData,
     buffer: T,
 }
 
 impl<T> Default for TrigonometryBlock<T>
 where
     T: Default + Pass,
-    OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
             buffer: T::default(),
         }
     }
@@ -79,7 +75,6 @@ macro_rules! impl_trig_block {
                     TrigonometryFunction::ArcTangentHyperbolic => Float::atanh(inputs),
                 };
                 self.buffer = output;
-                self.data = OldBlockData::from_scalar(output.into());
                 output
             }
 
@@ -90,8 +85,6 @@ macro_rules! impl_trig_block {
 
         impl<const ROWS: usize, const COLS: usize> ProcessBlock
             for TrigonometryBlock<Matrix<ROWS, COLS, $type>>
-        where
-            OldBlockData: FromPass<Matrix<ROWS, COLS, $type>>,
         {
             type Inputs = Matrix<ROWS, COLS, $type>;
             type Output = Matrix<ROWS, COLS, $type>;
@@ -120,7 +113,6 @@ macro_rules! impl_trig_block {
                     };
                     self.buffer.data[c][r] = output;
                 });
-                self.data = OldBlockData::from_pass(&self.buffer);
                 &self.buffer
             }
 
@@ -185,7 +177,7 @@ mod tests {
 
         let output = block.process(&p, &c, input);
         assert_relative_eq!(output, expected, max_relative = 0.00001);
-        assert_relative_eq!(block.data.scalar(), expected, max_relative = 0.00001);
+        assert_relative_eq!(block.buffer(), expected, max_relative = 0.00001);
         assert_eq!(block.buffer(), output);
     }
 

--- a/pictorus-blocks/src/std_blocks/fft_block.rs
+++ b/pictorus-blocks/src/std_blocks/fft_block.rs
@@ -1,5 +1,4 @@
 use crate::traits::Float;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 use rustfft::{num_complex::Complex, Fft, FftPlanner};
 use std::sync::Arc;
@@ -8,11 +7,7 @@ use std::sync::Arc;
 ///
 /// On each time step a new sample is added to the buffer. When the buffer is full, FFT is performed on the samples.
 /// The size of this buffer is set by the generic parameter `N`.
-pub struct FftBlock<T: Float, const N: usize>
-where
-    OldBlockData: FromPass<Matrix<2, N, T>>,
-{
-    pub data: OldBlockData,
+pub struct FftBlock<T: Float, const N: usize> {
     /// Samples buffer that stores samples as we accumulate them.
     samples: [T; N],
     /// Index of the next sample to be added to the buffer.
@@ -31,7 +26,6 @@ impl<T: Float, const N: usize> Default for FftBlock<T, N> {
             samples: [T::default(); N],
             sample_index: 0,
             output: Matrix::zeroed(),
-            data: <OldBlockData as FromPass<Matrix<2, N, T>>>::from_pass(Matrix::zeroed().as_by()),
             fft,
         }
     }
@@ -61,7 +55,6 @@ impl<T: Float, const N: usize> ProcessBlock for FftBlock<T, N> {
                 self.output.data[i][0] = buf_val.re;
                 self.output.data[i][1] = buf_val.im;
             }
-            self.data = <OldBlockData as FromPass<Matrix<2, N, T>>>::from_pass(self.output.as_by());
         } else {
             self.sample_index += 1;
         }


### PR DESCRIPTION
- Remove BlockData from Process blocks that are single input / single output
- Update unit tests