### PR TITLE
Remove BlockData from remaining ProcessBlocks

### DIFF
--- a/pictorus-blocks/src/core_blocks/adc_block.rs
+++ b/pictorus-blocks/src/core_blocks/adc_block.rs
@@ -1,5 +1,4 @@
 use num_traits::Float;
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{Context, PassBy, ProcessBlock, Scalar};
 
 /// Parameters for the ADC block
@@ -26,7 +25,6 @@ impl Parameters {
 /// Each platform will need to implement an `InputBlock` on the ADC hardware
 /// and pass those results into this block.
 pub struct AdcBlock<I: Scalar, O: Float> {
-    pub data: OldBlockData,
     buffer: O,
     phantom: core::marker::PhantomData<I>,
 }
@@ -38,7 +36,6 @@ where
 {
     fn default() -> Self {
         AdcBlock {
-            data: OldBlockData::from_scalar(0.0),
             buffer: O::zero(),
             phantom: core::marker::PhantomData,
         }
@@ -61,7 +58,6 @@ where
         input: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         self.buffer = O::from(input).expect("Failed to convert input to output");
-        self.data = OldBlockData::from_scalar(self.buffer.into());
         self.buffer
     }
 

--- a/pictorus-blocks/src/core_blocks/aggregate_block.rs
+++ b/pictorus-blocks/src/core_blocks/aggregate_block.rs
@@ -1,21 +1,17 @@
 use crate::matrix_ext::MatrixNalgebraExt;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
 
 /// Block for performing an aggregation operation (i.e. sum, min, max) on input data.
 pub struct AggregateBlock<T: Apply> {
-    pub data: OldBlockData,
     buffer: T::Output,
 }
 
 impl<T: Apply> Default for AggregateBlock<T>
 where
     T: Pass + Default,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
             buffer: <T::Output>::default(),
         }
     }
@@ -24,7 +20,6 @@ where
 impl<T> ProcessBlock for AggregateBlock<T>
 where
     T: Apply + Default,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -37,7 +32,6 @@ where
         inputs: pictorus_traits::PassBy<'_, Self::Inputs>,
     ) -> pictorus_traits::PassBy<'b, Self::Output> {
         let output = T::apply(&mut self.buffer, inputs, parameters.method);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 
@@ -170,7 +164,6 @@ mod tests {
         };
         let output = block.process(&params, &context, &input);
         assert_relative_eq!(output, 28.0);
-        assert_relative_eq!(block.data.scalar(), 28.0);
         assert_relative_eq!(block.buffer(), output);
     }
 
@@ -186,7 +179,7 @@ mod tests {
         };
         let output = block.process(&params, &context, &input);
         assert_relative_eq!(output, 28.0);
-        assert_relative_eq!(block.data.scalar(), 28.0);
+        assert_relative_eq!(block.buffer(), output);
     }
 
     #[test]
@@ -202,7 +195,7 @@ mod tests {
         input.data[5][3] = 42.0;
         let output = block.process(&params, &context, &input);
         assert_relative_eq!(output, 42.0);
-        assert_relative_eq!(block.data.scalar(), 42.0);
+        assert_relative_eq!(block.buffer(), output);
     }
 
     #[test]
@@ -218,7 +211,7 @@ mod tests {
         input.data[1][2] = 10.99;
         let output = block.process(&params, &context, &input);
         assert_relative_eq!(output, 10.99);
-        assert_relative_eq!(block.data.scalar(), 10.99);
+        assert_relative_eq!(block.buffer(), output);
     }
 
     #[test]
@@ -235,7 +228,7 @@ mod tests {
 
         let output = block.process(&params, &context, &input);
         assert_relative_eq!(output, 13.5);
-        assert_relative_eq!(block.data.scalar(), 13.5);
+        assert_relative_eq!(block.buffer(), output);
     }
 
     #[test]
@@ -252,7 +245,7 @@ mod tests {
 
         let output = block.process(&params, &context, &input);
         assert_relative_eq!(output, 13.5);
-        assert_relative_eq!(block.data.scalar(), 13.5);
+        assert_relative_eq!(block.buffer(), output);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/arg_min_max_block.rs
+++ b/pictorus-blocks/src/core_blocks/arg_min_max_block.rs
@@ -1,5 +1,4 @@
 use num_traits::{FromPrimitive, Zero};
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
 
 /// Gets the index of the minimum or maximum value in the input.
@@ -14,18 +13,15 @@ use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
 /// | 2 | 5 | 8 | 11| 14 |
 /// ----------------------
 pub struct ArgMinMaxBlock<T: Apply> {
-    pub data: OldBlockData,
     buffer: T::Output,
 }
 
 impl<T: Apply> Default for ArgMinMaxBlock<T>
 where
     T: Pass + Default,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
             buffer: <T::Output>::default(),
         }
     }
@@ -34,7 +30,6 @@ where
 impl<T> ProcessBlock for ArgMinMaxBlock<T>
 where
     T: Apply + Default,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -47,7 +42,6 @@ where
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         let output = T::apply(&mut self.buffer, inputs, parameters.method);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 
@@ -163,7 +157,6 @@ mod tests {
         let params = Parameters::new("Min");
         let output = block.process(&params, &context, input);
         assert_eq!(output, 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
         assert_eq!(block.buffer(), output);
     }
 
@@ -180,7 +173,7 @@ mod tests {
         let params = Parameters::new("Min");
         let output = block.process(&params, &context, &input);
         assert_eq!(output, 3.0);
-        assert_eq!(block.data.scalar(), 3.0);
+        assert_eq!(block.buffer(), output);
 
         // |  1  3  5 |
         // | 12  4  6 |
@@ -191,6 +184,6 @@ mod tests {
         let params = Parameters::new("Max");
         let output = block.process(&params, &context, &input);
         assert_eq!(output, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), output);
     }
 }

--- a/pictorus-blocks/src/core_blocks/bitwise_operator_block.rs
+++ b/pictorus-blocks/src/core_blocks/bitwise_operator_block.rs
@@ -1,5 +1,4 @@
 use crate::traits::{CopyInto, Scalar, SizePromotion};
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Performs a bitwise operation on the input values.
@@ -11,21 +10,17 @@ use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 pub struct BitwiseOperatorBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<<T as Apply>::Output>,
 {
     store: T::Output,
-    pub data: OldBlockData,
 }
 
 impl<T> Default for BitwiseOperatorBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<<T as Apply>::Output>,
 {
     fn default() -> Self {
         Self {
             store: T::Output::default(),
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
         }
     }
 }
@@ -33,7 +28,6 @@ where
 impl<T> ProcessBlock for BitwiseOperatorBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<<T as Apply>::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -46,7 +40,6 @@ where
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         let result = T::apply(inputs, *parameters, &mut self.store);
-        self.data = OldBlockData::from_pass(result);
         result
     }
 

--- a/pictorus-blocks/src/core_blocks/bytes_join_block.rs
+++ b/pictorus-blocks/src/core_blocks/bytes_join_block.rs
@@ -2,13 +2,11 @@ extern crate alloc;
 use crate::byte_data::parse_string_to_bytes;
 use crate::traits::Serialize;
 use alloc::vec::Vec;
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, Pass, PassBy, ProcessBlock};
 
 /// Joins multiple signals into a single byte slice by
 /// serializing each signal and joining them with a delimiter.
 pub struct BytesJoinBlock<T: Apply> {
-    pub data: OldBlockData,
     buffer: Vec<u8>,
     _unused: core::marker::PhantomData<T>,
 }
@@ -30,7 +28,6 @@ impl Parameters {
 impl<T: Apply> Default for BytesJoinBlock<T> {
     fn default() -> Self {
         Self {
-            data: OldBlockData::from_bytes(b""),
             buffer: Vec::new(),
             _unused: core::marker::PhantomData,
         }
@@ -49,7 +46,6 @@ impl<T: Apply> ProcessBlock for BytesJoinBlock<T> {
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
         self.buffer = T::apply(inputs, parameters);
-        self.data.set_bytes(&self.buffer);
         &self.buffer
     }
 
@@ -222,7 +218,6 @@ mod tests {
 
         let expected_string = "1.0/ [[1.0,2.0,3.0],[4.0,5.0,6.0]]/ hello there".to_string();
         assert_eq!(res, expected_string.as_bytes());
-        assert_eq!(block.data.raw_string(), expected_string);
         assert_eq!(block.buffer(), expected_string.as_bytes());
     }
 
@@ -238,7 +233,7 @@ mod tests {
 
         let expected_string = "привет⚡こんにちは".to_string();
         assert_eq!(res, expected_string.as_bytes());
-        assert_eq!(block.data.raw_string(), expected_string);
+        assert_eq!(block.buffer(), expected_string.as_bytes());
     }
 
     #[test]
@@ -253,6 +248,6 @@ mod tests {
 
         let expected = b"\x80\x81\x82\x83\x99\x84\x85\x86\x87";
         assert_eq!(res, expected);
-        assert_eq!(block.data.to_bytes().as_slice(), expected);
+        assert_eq!(block.buffer(), expected);
     }
 }

--- a/pictorus-blocks/src/core_blocks/bytes_pack_block.rs
+++ b/pictorus-blocks/src/core_blocks/bytes_pack_block.rs
@@ -2,12 +2,10 @@ extern crate alloc;
 use crate::byte_data::{parse_byte_data_spec, try_pack_data, ByteOrderSpec, DataType};
 use crate::traits::Scalar;
 use alloc::vec::Vec;
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, Pass, PassBy, ProcessBlock};
 
 /// Packs scalar inputs into a byte buffer according to the provided data spec.
 pub struct BytesPackBlock<T: Apply> {
-    pub data: OldBlockData,
     buffer: Vec<u8>,
     _unused: core::marker::PhantomData<T>,
 }
@@ -15,7 +13,6 @@ pub struct BytesPackBlock<T: Apply> {
 impl<T: Apply> Default for BytesPackBlock<T> {
     fn default() -> Self {
         Self {
-            data: OldBlockData::from_bytes(b""),
             buffer: Vec::new(),
             _unused: core::marker::PhantomData,
         }
@@ -34,7 +31,6 @@ impl<T: Apply> ProcessBlock for BytesPackBlock<T> {
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         self.buffer = T::pack_bytes(inputs, parameters);
-        self.data = OldBlockData::from_bytes(&self.buffer);
         self.buffer.as_slice()
     }
 
@@ -229,7 +225,6 @@ mod tests {
 
         let output = block.process(&params, &context, inputs);
         assert_eq!(output, expected.as_slice());
-        assert_eq!(block.data, OldBlockData::from_bytes(&expected));
         assert_eq!(block.buffer(), expected.as_slice());
     }
 
@@ -253,7 +248,7 @@ mod tests {
 
         let output = block.process(&params, &context, inputs);
         assert_eq!(output, expected.as_slice());
-        assert_eq!(block.data, OldBlockData::from_bytes(&expected));
+        assert_eq!(block.buffer(), expected.as_slice());
 
         // Make sure buffer is cleared between runs, this logic is just in one test because it is written
         // for the ProcessBlock impl and so is shared between all input possibilities
@@ -270,7 +265,7 @@ mod tests {
         };
         let output = block.process(&params, &context, inputs);
         assert_eq!(output, expected.as_slice());
-        assert_eq!(block.data, OldBlockData::from_bytes(&expected));
+        assert_eq!(block.buffer(), expected.as_slice());
     }
 
     #[test]
@@ -296,7 +291,7 @@ mod tests {
 
         let output = block.process(&params, &context, inputs);
         assert_eq!(output, expected.as_slice());
-        assert_eq!(block.data, OldBlockData::from_bytes(&expected));
+        assert_eq!(block.buffer(), expected.as_slice());
     }
 
     #[test]
@@ -330,7 +325,7 @@ mod tests {
 
         let output = block.process(&params, &context, inputs);
         assert_eq!(output, expected.as_slice());
-        assert_eq!(block.data, OldBlockData::from_bytes(&expected));
+        assert_eq!(block.buffer(), expected.as_slice());
     }
 
     #[test]
@@ -366,7 +361,7 @@ mod tests {
 
         let output = block.process(&params, &context, inputs);
         assert_eq!(output, expected.as_slice());
-        assert_eq!(block.data, OldBlockData::from_bytes(&expected));
+        assert_eq!(block.buffer(), expected.as_slice());
     }
 
     #[test]
@@ -406,7 +401,7 @@ mod tests {
 
         let output = block.process(&params, &context, inputs);
         assert_eq!(output, expected.as_slice());
-        assert_eq!(block.data, OldBlockData::from_bytes(&expected));
+        assert_eq!(block.buffer(), expected.as_slice());
     }
 
     #[test]
@@ -450,7 +445,7 @@ mod tests {
 
         let output = block.process(&params, &context, inputs);
         assert_eq!(output, expected.as_slice());
-        assert_eq!(block.data, OldBlockData::from_bytes(&expected));
+        assert_eq!(block.buffer(), expected.as_slice());
     }
 
     #[test]
@@ -507,6 +502,6 @@ mod tests {
 
         let output = block.process(&params, &context, inputs);
         assert_eq!(output, expected.as_slice());
-        assert_eq!(block.data, OldBlockData::from_bytes(&expected));
+        assert_eq!(block.buffer(), expected.as_slice());
     }
 }

--- a/pictorus-blocks/src/core_blocks/bytes_split_block.rs
+++ b/pictorus-blocks/src/core_blocks/bytes_split_block.rs
@@ -107,8 +107,8 @@ impl<T: Apply> ProcessBlock for BytesSplitBlock<T> {
 }
 
 impl<T: Apply> IsValid for BytesSplitBlock<T> {
-    fn is_valid(&self, _app_time_s: f64) -> f64 {
-        f64::from(T::is_valid(&self.buffer))
+    fn is_valid(&self, _app_time_s: f64) -> bool {
+        T::is_valid(&self.buffer)
     }
 }
 
@@ -798,20 +798,20 @@ mod tests {
         let output = block.process(&params, &context, input);
         assert_eq!(output, (123.0, 42.0, b"4.56".as_slice(), true));
         assert_eq!(block.buffer(), (123.0, 42.0, b"4.56".as_slice(), true));
-        assert_ne!(block.is_valid(0.0), 0.0);
+        assert!(block.is_valid(0.0));
 
         context.time += context.fundamental_timestep;
         let input = br#"123:4.56:78.9"#;
         let output = block.process(&params, &context, input);
         assert_eq!(output, (123.0, 42.0, b"4.56".as_slice(), true)); // stale time has not elapsed
         assert_eq!(block.buffer(), (123.0, 42.0, b"4.56".as_slice(), true));
-        assert_ne!(block.is_valid(0.0), 0.0);
+        assert!(block.is_valid(0.0));
 
         context.time = Duration::from_secs_f64(2.0);
         let output = block.process(&params, &context, input);
         assert_eq!(output, (123.0, 42.0, b"4.56".as_slice(), false)); // stale time has elapsed
         assert_eq!(block.buffer(), (123.0, 42.0, b"4.56".as_slice(), false));
-        assert_eq!(block.is_valid(0.0), 0.0);
+        assert!(!block.is_valid(0.0));
 
         // Now input is valid again
         context.time += context.fundamental_timestep;
@@ -819,7 +819,7 @@ mod tests {
         let output = block.process(&params, &context, input);
         assert_eq!(output, (1.03, 11.0, b"17".as_slice(), true));
         assert_eq!(block.buffer(), (1.03, 11.0, b"17".as_slice(), true));
-        assert_ne!(block.is_valid(0.0), 0.0);
+        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -833,7 +833,7 @@ mod tests {
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (b"\x00".as_ref(), b"\x02".as_ref(), true));
         assert_eq!(block.buffer(), (b"\x00".as_ref(), b"\x02".as_ref(), true));
-        assert_ne!(block.is_valid(0.0), 0.0);
+        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -846,7 +846,7 @@ mod tests {
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (42.0, true));
         assert_eq!(block.buffer(), (42.0, true));
-        assert_ne!(block.is_valid(0.0), 0.0);
+        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -859,7 +859,7 @@ mod tests {
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (123.0, b"42.0".as_slice(), true));
         assert_eq!(block.buffer(), (123.0, b"42.0".as_slice(), true));
-        assert_ne!(block.is_valid(0.0), 0.0);
+        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -872,7 +872,7 @@ mod tests {
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (123.0, 42.0, b"4.56".as_slice(), true));
         assert_eq!(block.buffer(), (123.0, 42.0, b"4.56".as_slice(), true));
-        assert_ne!(block.is_valid(0.0), 0.0);
+        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -892,7 +892,7 @@ mod tests {
             block.buffer(),
             (123.0, 42.0, 4.56, b"78.9".as_slice(), true)
         );
-        assert_ne!(block.is_valid(0.0), 0.0);
+        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -918,7 +918,7 @@ mod tests {
             block.buffer(),
             (123.0, 42.0, 4.56, 78.9, b"78.9".as_slice(), true)
         );
-        assert_ne!(block.is_valid(0.0), 0.0);
+        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -948,7 +948,7 @@ mod tests {
             block.buffer(),
             (123.0, 42.0, b"78.9".as_slice(), 4.56, 78.9, 4.56, true)
         );
-        assert_ne!(block.is_valid(0.0), 0.0);
+        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -1005,6 +1005,6 @@ mod tests {
                 true
             )
         );
-        assert_ne!(block.is_valid(0.0), 0.0);
+        assert!(block.is_valid(0.0));
     }
 }

--- a/pictorus-blocks/src/core_blocks/bytes_split_block.rs
+++ b/pictorus-blocks/src/core_blocks/bytes_split_block.rs
@@ -3,9 +3,8 @@ use crate::byte_data::{find_all_bytes_idx, parse_string_to_read_delimiter};
 use crate::traits::{DefaultStorage, Scalar};
 use crate::IsValid;
 use alloc::borrow::ToOwned;
-use alloc::{string::String, vec, vec::Vec};
+use alloc::{string::String, vec::Vec};
 use core::time::Duration;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{ByteSliceSignal, Pass, PassBy, ProcessBlock};
 
 /// Splits input bytes based on a specified delimiter and maps outputs to specific indices of the split chunks.
@@ -18,7 +17,6 @@ use pictorus_traits::{ByteSliceSignal, Pass, PassBy, ProcessBlock};
 /// If the time since the last successful parse is greater than the stale age,
 /// the block will output false for the "is_valid" output.
 pub struct BytesSplitBlock<T: Apply> {
-    pub data: Vec<OldBlockData>,
     buffer: T::Storage,
     last_valid_time: Option<Duration>,
 }
@@ -63,7 +61,6 @@ impl Parameters {
 impl<T: Apply> Default for BytesSplitBlock<T> {
     fn default() -> Self {
         Self {
-            data: T::default_block_data(),
             buffer: T::default_storage_value(),
             last_valid_time: None,
         }
@@ -101,7 +98,6 @@ impl<T: Apply> ProcessBlock for BytesSplitBlock<T> {
         if parse_success {
             self.last_valid_time = Some(context.time());
         }
-        self.data = T::build_block_data(&self.buffer);
         <T as Apply>::storage_as_by(&self.buffer)
     }
 
@@ -111,8 +107,8 @@ impl<T: Apply> ProcessBlock for BytesSplitBlock<T> {
 }
 
 impl<T: Apply> IsValid for BytesSplitBlock<T> {
-    fn is_valid(&self, _app_time_s: f64) -> OldBlockData {
-        <OldBlockData as FromPass<bool>>::from_pass(T::is_valid(&self.buffer))
+    fn is_valid(&self, _app_time_s: f64) -> f64 {
+        f64::from(T::is_valid(&self.buffer))
     }
 }
 
@@ -172,19 +168,12 @@ pub trait Apply: Pass {
 
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output>;
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData>;
-
-    fn default_block_data() -> Vec<OldBlockData>;
-
     fn default_storage_value() -> Self::Storage;
 
     fn is_valid(storage: &Self::Storage) -> bool;
 }
 
-impl<A: FromBytes> Apply for A
-where
-    OldBlockData: FromPass<A>,
-{
+impl<A: FromBytes> Apply for A {
     type Storage = (A::Storage, bool);
     type Output = (A, bool);
 
@@ -213,16 +202,6 @@ where
         }
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![OldBlockData::from_pass(A::from_storage(&storage.0))]
-    }
-
-    fn default_block_data() -> Vec<OldBlockData> {
-        vec![OldBlockData::from_pass(A::from_storage(
-            &A::default_storage(),
-        ))]
-    }
-
     fn default_storage_value() -> Self::Storage {
         (A::default_storage(), false)
     }
@@ -236,11 +215,7 @@ where
     }
 }
 
-impl<A: FromBytes, B: FromBytes> Apply for (A, B)
-where
-    OldBlockData: FromPass<A>,
-    OldBlockData: FromPass<B>,
-{
+impl<A: FromBytes, B: FromBytes> Apply for (A, B) {
     type Output = (A, B, bool);
     type Storage = (A::Storage, B::Storage, bool);
 
@@ -275,20 +250,6 @@ where
         }
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&storage.0)),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&storage.1)),
-        ]
-    }
-
-    fn default_block_data() -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&A::default_storage())),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&B::default_storage())),
-        ]
-    }
-
     fn default_storage_value() -> Self::Storage {
         (A::default_storage(), B::default_storage(), false)
     }
@@ -305,12 +266,7 @@ where
     }
 }
 
-impl<A: FromBytes, B: FromBytes, C: FromBytes> Apply for (A, B, C)
-where
-    OldBlockData: FromPass<A>,
-    OldBlockData: FromPass<B>,
-    OldBlockData: FromPass<C>,
-{
+impl<A: FromBytes, B: FromBytes, C: FromBytes> Apply for (A, B, C) {
     type Output = (A, B, C, bool);
     type Storage = (A::Storage, B::Storage, C::Storage, bool);
 
@@ -353,22 +309,6 @@ where
         }
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&storage.0)),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&storage.1)),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&storage.2)),
-        ]
-    }
-
-    fn default_block_data() -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&A::default_storage())),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&B::default_storage())),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&C::default_storage())),
-        ]
-    }
-
     fn default_storage_value() -> Self::Storage {
         (
             A::default_storage(),
@@ -391,13 +331,7 @@ where
     }
 }
 
-impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes> Apply for (A, B, C, D)
-where
-    OldBlockData: FromPass<A>,
-    OldBlockData: FromPass<B>,
-    OldBlockData: FromPass<C>,
-    OldBlockData: FromPass<D>,
-{
+impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes> Apply for (A, B, C, D) {
     type Output = (A, B, C, D, bool);
     type Storage = (A::Storage, B::Storage, C::Storage, D::Storage, bool);
 
@@ -456,24 +390,6 @@ where
         }
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&storage.0)),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&storage.1)),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&storage.2)),
-            <OldBlockData as FromPass<D>>::from_pass(D::from_storage(&storage.3)),
-        ]
-    }
-
-    fn default_block_data() -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&A::default_storage())),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&B::default_storage())),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&C::default_storage())),
-            <OldBlockData as FromPass<D>>::from_pass(D::from_storage(&D::default_storage())),
-        ]
-    }
-
     fn default_storage_value() -> Self::Storage {
         (
             A::default_storage(),
@@ -499,13 +415,8 @@ where
     }
 }
 
-impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes, E: FromBytes> Apply for (A, B, C, D, E)
-where
-    OldBlockData: FromPass<A>,
-    OldBlockData: FromPass<B>,
-    OldBlockData: FromPass<C>,
-    OldBlockData: FromPass<D>,
-    OldBlockData: FromPass<E>,
+impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes, E: FromBytes> Apply
+    for (A, B, C, D, E)
 {
     type Output = (A, B, C, D, E, bool);
     type Storage = (
@@ -585,26 +496,6 @@ where
         }
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&storage.0)),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&storage.1)),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&storage.2)),
-            <OldBlockData as FromPass<D>>::from_pass(D::from_storage(&storage.3)),
-            <OldBlockData as FromPass<E>>::from_pass(E::from_storage(&storage.4)),
-        ]
-    }
-
-    fn default_block_data() -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&A::default_storage())),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&B::default_storage())),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&C::default_storage())),
-            <OldBlockData as FromPass<D>>::from_pass(D::from_storage(&D::default_storage())),
-            <OldBlockData as FromPass<E>>::from_pass(E::from_storage(&E::default_storage())),
-        ]
-    }
-
     fn default_storage_value() -> Self::Storage {
         (
             A::default_storage(),
@@ -634,13 +525,6 @@ where
 
 impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes, E: FromBytes, F: FromBytes> Apply
     for (A, B, C, D, E, F)
-where
-    OldBlockData: FromPass<A>,
-    OldBlockData: FromPass<B>,
-    OldBlockData: FromPass<C>,
-    OldBlockData: FromPass<D>,
-    OldBlockData: FromPass<E>,
-    OldBlockData: FromPass<F>,
 {
     type Output = (A, B, C, D, E, F, bool);
     type Storage = (
@@ -730,28 +614,6 @@ where
         }
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&storage.0)),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&storage.1)),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&storage.2)),
-            <OldBlockData as FromPass<D>>::from_pass(D::from_storage(&storage.3)),
-            <OldBlockData as FromPass<E>>::from_pass(E::from_storage(&storage.4)),
-            <OldBlockData as FromPass<F>>::from_pass(F::from_storage(&storage.5)),
-        ]
-    }
-
-    fn default_block_data() -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&A::default_storage())),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&B::default_storage())),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&C::default_storage())),
-            <OldBlockData as FromPass<D>>::from_pass(D::from_storage(&D::default_storage())),
-            <OldBlockData as FromPass<E>>::from_pass(E::from_storage(&E::default_storage())),
-            <OldBlockData as FromPass<F>>::from_pass(F::from_storage(&F::default_storage())),
-        ]
-    }
-
     fn default_storage_value() -> Self::Storage {
         (
             A::default_storage(),
@@ -790,14 +652,6 @@ impl<
         F: FromBytes,
         G: FromBytes,
     > Apply for (A, B, C, D, E, F, G)
-where
-    OldBlockData: FromPass<A>,
-    OldBlockData: FromPass<B>,
-    OldBlockData: FromPass<C>,
-    OldBlockData: FromPass<D>,
-    OldBlockData: FromPass<E>,
-    OldBlockData: FromPass<F>,
-    OldBlockData: FromPass<G>,
 {
     type Output = (A, B, C, D, E, F, G, bool);
     type Storage = (
@@ -897,30 +751,6 @@ where
         }
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&storage.0)),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&storage.1)),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&storage.2)),
-            <OldBlockData as FromPass<D>>::from_pass(D::from_storage(&storage.3)),
-            <OldBlockData as FromPass<E>>::from_pass(E::from_storage(&storage.4)),
-            <OldBlockData as FromPass<F>>::from_pass(F::from_storage(&storage.5)),
-            <OldBlockData as FromPass<G>>::from_pass(G::from_storage(&storage.6)),
-        ]
-    }
-
-    fn default_block_data() -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&A::default_storage())),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&B::default_storage())),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&C::default_storage())),
-            <OldBlockData as FromPass<D>>::from_pass(D::from_storage(&D::default_storage())),
-            <OldBlockData as FromPass<E>>::from_pass(E::from_storage(&E::default_storage())),
-            <OldBlockData as FromPass<F>>::from_pass(F::from_storage(&F::default_storage())),
-            <OldBlockData as FromPass<G>>::from_pass(G::from_storage(&G::default_storage())),
-        ]
-    }
-
     fn default_storage_value() -> Self::Storage {
         (
             A::default_storage(),
@@ -967,41 +797,29 @@ mod tests {
         let input = br#"123:4.56:78.9:42.0"#;
         let output = block.process(&params, &context, input);
         assert_eq!(output, (123.0, 42.0, b"4.56".as_slice(), true));
-        assert_eq!(block.data[0].scalar(), 123.0);
-        assert_eq!(block.data[1].scalar(), 42.0);
-        assert_eq!(block.data[2].to_bytes(), b"4.56");
-        assert_eq!(block.data.len(), 3);
-        assert_ne!(block.is_valid(0.0).scalar(), 0.0);
+        assert_eq!(block.buffer(), (123.0, 42.0, b"4.56".as_slice(), true));
+        assert_ne!(block.is_valid(0.0), 0.0);
 
         context.time += context.fundamental_timestep;
         let input = br#"123:4.56:78.9"#;
         let output = block.process(&params, &context, input);
         assert_eq!(output, (123.0, 42.0, b"4.56".as_slice(), true)); // stale time has not elapsed
-        assert_eq!(block.data[0].scalar(), 123.0);
-        assert_eq!(block.data[1].scalar(), 42.0);
-        assert_eq!(block.data[2].to_bytes(), b"4.56");
-        assert_eq!(block.data.len(), 3);
-        assert_ne!(block.is_valid(0.0).scalar(), 0.0);
+        assert_eq!(block.buffer(), (123.0, 42.0, b"4.56".as_slice(), true));
+        assert_ne!(block.is_valid(0.0), 0.0);
 
         context.time = Duration::from_secs_f64(2.0);
         let output = block.process(&params, &context, input);
         assert_eq!(output, (123.0, 42.0, b"4.56".as_slice(), false)); // stale time has elapsed
-        assert_eq!(block.data[0].scalar(), 123.0);
-        assert_eq!(block.data[1].scalar(), 42.0);
-        assert_eq!(block.data[2].to_bytes(), b"4.56");
-        assert_eq!(block.data.len(), 3);
-        assert_eq!(block.is_valid(0.0).scalar(), 0.0);
+        assert_eq!(block.buffer(), (123.0, 42.0, b"4.56".as_slice(), false));
+        assert_eq!(block.is_valid(0.0), 0.0);
 
         // Now input is valid again
         context.time += context.fundamental_timestep;
         let input = br#"1.03:17:23.4:11.0"#;
         let output = block.process(&params, &context, input);
         assert_eq!(output, (1.03, 11.0, b"17".as_slice(), true));
-        assert_eq!(block.data[0].scalar(), 1.03);
-        assert_eq!(block.data[1].scalar(), 11.0);
-        assert_eq!(block.data[2].to_bytes(), b"17");
-        assert_eq!(block.data.len(), 3);
-        assert_ne!(block.is_valid(0.0).scalar(), 0.0);
+        assert_eq!(block.buffer(), (1.03, 11.0, b"17".as_slice(), true));
+        assert_ne!(block.is_valid(0.0), 0.0);
     }
 
     #[test]
@@ -1014,10 +832,8 @@ mod tests {
         let input = b"\x00\xAA\xAA\xAB\x01\xAA\xFF\xAB\x02";
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (b"\x00".as_ref(), b"\x02".as_ref(), true));
-        assert_eq!(block.data[0].to_bytes(), b"\x00");
-        assert_eq!(block.data[1].to_bytes(), b"\x02");
-        assert_eq!(block.data.len(), 2);
-        assert_ne!(block.is_valid(0.0).scalar(), 0.0);
+        assert_eq!(block.buffer(), (b"\x00".as_ref(), b"\x02".as_ref(), true));
+        assert_ne!(block.is_valid(0.0), 0.0);
     }
 
     #[test]
@@ -1029,9 +845,8 @@ mod tests {
         let input = b"123:4.56:78.9:42.0";
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (42.0, true));
-        assert_eq!(block.data[0].scalar(), 42.0);
-        assert_eq!(block.data.len(), 1);
-        assert_ne!(block.is_valid(0.0).scalar(), 0.0);
+        assert_eq!(block.buffer(), (42.0, true));
+        assert_ne!(block.is_valid(0.0), 0.0);
     }
 
     #[test]
@@ -1043,10 +858,8 @@ mod tests {
         let input = b"123:4.56:78.9:42.0";
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (123.0, b"42.0".as_slice(), true));
-        assert_eq!(block.data[0].scalar(), 123.0);
-        assert_eq!(block.data[1].to_bytes(), b"42.0");
-        assert_eq!(block.data.len(), 2);
-        assert_ne!(block.is_valid(0.0).scalar(), 0.0);
+        assert_eq!(block.buffer(), (123.0, b"42.0".as_slice(), true));
+        assert_ne!(block.is_valid(0.0), 0.0);
     }
 
     #[test]
@@ -1058,11 +871,8 @@ mod tests {
         let input = b"123:4.56:78.9:42.0";
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (123.0, 42.0, b"4.56".as_slice(), true));
-        assert_eq!(block.data[0].scalar(), 123.0);
-        assert_eq!(block.data[1].scalar(), 42.0);
-        assert_eq!(block.data[2].to_bytes(), b"4.56");
-        assert_eq!(block.data.len(), 3);
-        assert_ne!(block.is_valid(0.0).scalar(), 0.0);
+        assert_eq!(block.buffer(), (123.0, 42.0, b"4.56".as_slice(), true));
+        assert_ne!(block.is_valid(0.0), 0.0);
     }
 
     #[test]
@@ -1078,12 +888,11 @@ mod tests {
         let input = b"123:4.56:78.9:42.0";
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (123.0, 42.0, 4.56, b"78.9".as_slice(), true));
-        assert_eq!(block.data[0].scalar(), 123.0);
-        assert_eq!(block.data[1].scalar(), 42.0);
-        assert_eq!(block.data[2].scalar(), 4.56);
-        assert_eq!(block.data[3].to_bytes(), b"78.9");
-        assert_eq!(block.data.len(), 4);
-        assert_ne!(block.is_valid(0.0).scalar(), 0.0);
+        assert_eq!(
+            block.buffer(),
+            (123.0, 42.0, 4.56, b"78.9".as_slice(), true)
+        );
+        assert_ne!(block.is_valid(0.0), 0.0);
     }
 
     #[test]
@@ -1105,13 +914,11 @@ mod tests {
         let input = b"123:4.56:78.9:42.0";
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (123.0, 42.0, 4.56, 78.9, b"78.9".as_slice(), true));
-        assert_eq!(block.data[0].scalar(), 123.0);
-        assert_eq!(block.data[1].scalar(), 42.0);
-        assert_eq!(block.data[2].scalar(), 4.56);
-        assert_eq!(block.data[3].scalar(), 78.9);
-        assert_eq!(block.data[4].to_bytes(), b"78.9");
-        assert_eq!(block.data.len(), 5);
-        assert_ne!(block.is_valid(0.0).scalar(), 0.0);
+        assert_eq!(
+            block.buffer(),
+            (123.0, 42.0, 4.56, 78.9, b"78.9".as_slice(), true)
+        );
+        assert_ne!(block.is_valid(0.0), 0.0);
     }
 
     #[test]
@@ -1137,15 +944,11 @@ mod tests {
             output,
             (123.0, 42.0, b"78.9".as_slice(), 4.56, 78.9, 4.56, true)
         );
-        assert_eq!(block.data[0].scalar(), 123.0);
-        assert_eq!(block.data[1].scalar(), 42.0);
-        assert_eq!(block.data[2].to_bytes(), b"78.9");
-        assert_eq!(block.data[3].scalar(), 4.56);
-        assert_eq!(block.data[4].scalar(), 78.9);
-        assert_eq!(block.data[5].scalar(), 4.56);
-
-        assert_eq!(block.data.len(), 6);
-        assert_ne!(block.is_valid(0.0).scalar(), 0.0);
+        assert_eq!(
+            block.buffer(),
+            (123.0, 42.0, b"78.9".as_slice(), 4.56, 78.9, 4.56, true)
+        );
+        assert_ne!(block.is_valid(0.0), 0.0);
     }
 
     #[test]
@@ -1189,15 +992,19 @@ mod tests {
                 true
             )
         );
-        assert_eq!(block.data[0].scalar(), 123.0);
-        assert_eq!(block.data[1].scalar(), 42.0);
-        assert_eq!(block.data[2].to_bytes(), b"78.9");
-        assert_eq!(block.data[3].scalar(), 4.56);
-        assert_eq!(block.data[4].scalar(), 78.9);
-        assert_eq!(block.data[5].scalar(), 4.56);
-        assert_eq!(block.data[6].to_bytes(), b"78.9");
-
-        assert_eq!(block.data.len(), 7);
-        assert_ne!(block.is_valid(0.0).scalar(), 0.0);
+        assert_eq!(
+            block.buffer(),
+            (
+                123.0,
+                42.0,
+                b"78.9".as_slice(),
+                4.56,
+                78.9,
+                4.56,
+                b"78.9".as_slice(),
+                true
+            )
+        );
+        assert_ne!(block.is_valid(0.0), 0.0);
     }
 }

--- a/pictorus-blocks/src/core_blocks/bytes_unpack_block.rs
+++ b/pictorus-blocks/src/core_blocks/bytes_unpack_block.rs
@@ -2,17 +2,14 @@ extern crate alloc;
 use core::time::Duration;
 
 use crate::{traits::Scalar, IsValid};
-use alloc::vec::Vec;
 use generic_array::{ArrayLength, GenericArray};
 use typenum::{Const, NonZero, Sub1, ToUInt, B1, U};
 
 use crate::byte_data::{parse_byte_data_spec, try_unpack_data, ByteOrderSpec, DataType};
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, PassBy, ProcessBlock};
 
 /// Unpacks a byte slice into a specified number of outputs based on the provided data types and byte order.
 pub struct BytesUnpackBlock<const N: usize> {
-    pub data: Vec<OldBlockData>,
     buffer: [f64; N],
     last_valid_time: Option<Duration>,
 }
@@ -20,12 +17,7 @@ pub struct BytesUnpackBlock<const N: usize> {
 impl<const N: usize> Default for BytesUnpackBlock<N> {
     fn default() -> Self {
         let buffer = [0.0; N];
-        let data = buffer
-            .iter()
-            .map(|_| OldBlockData::from_scalar(0.0))
-            .collect();
         BytesUnpackBlock {
-            data,
             buffer,
             last_valid_time: None,
         }
@@ -86,11 +78,6 @@ where
             // If we failed to unpack and it is stale, keep the old buffer but mark as invalid
             self.buffer[N - 1] = 0.0; // last element is is_valid flag
         }
-        self.data = self
-            .buffer
-            .iter()
-            .map(|&x| OldBlockData::from_scalar(x))
-            .collect();
         &self.buffer
     }
 
@@ -100,8 +87,8 @@ where
 }
 
 impl<const N: usize> IsValid for BytesUnpackBlock<N> {
-    fn is_valid(&self, _app_time_s: f64) -> OldBlockData {
-        OldBlockData::from_scalar(self.buffer[N - 1])
+    fn is_valid(&self, _app_time_s: f64) -> f64 {
+        self.buffer[N - 1]
     }
 }
 

--- a/pictorus-blocks/src/core_blocks/bytes_unpack_block.rs
+++ b/pictorus-blocks/src/core_blocks/bytes_unpack_block.rs
@@ -87,8 +87,8 @@ where
 }
 
 impl<const N: usize> IsValid for BytesUnpackBlock<N> {
-    fn is_valid(&self, _app_time_s: f64) -> f64 {
-        self.buffer[N - 1]
+    fn is_valid(&self, _app_time_s: f64) -> bool {
+        self.buffer[N - 1] != 0.0
     }
 }
 

--- a/pictorus-blocks/src/core_blocks/can_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/can_receive_block.rs
@@ -115,7 +115,7 @@ where
 impl<const N: usize, S: Float, C, O: Pass + Default + ToTupleOutput<S>> IsValid
     for CanReceiveBlock<N, S, C, O>
 {
-    fn is_valid(&self, app_time_s: f64) -> f64 {
+    fn is_valid(&self, app_time_s: f64) -> bool {
         self.stale_check.is_valid(app_time_s)
     }
 }
@@ -285,14 +285,14 @@ mod tests {
 
         let output = block.process(&parameters, &runtime.context(), &[42, 0, 0, 0, 0, 0, 0, 0]);
         assert_eq!(output.0, 42.);
-        assert_eq!(block.is_valid(runtime.context().time.as_secs_f64()), 1.0);
+        assert!(block.is_valid(runtime.context().time.as_secs_f64()));
 
         runtime.set_time(Duration::from_secs(2));
 
         // Simulate a stale message
         let output = block.process(&parameters, &runtime.context(), &[]);
         assert_eq!(output.0, 42.);
-        assert_eq!(block.is_valid(runtime.context().time.as_secs_f64()), 0.0);
+        assert!(!block.is_valid(runtime.context().time.as_secs_f64()));
     }
 
     #[test]
@@ -309,14 +309,14 @@ mod tests {
 
         let output = block.process(&parameters, &runtime.context(), &[42, 1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(output, (42., 1., 2., 3., 4., 5., 6., true));
-        assert_eq!(block.is_valid(runtime.context().time.as_secs_f64()), 1.0);
+        assert!(block.is_valid(runtime.context().time.as_secs_f64()));
 
         // Simulate stale message
         runtime.set_time(Duration::from_secs(2));
 
         let output = block.process(&parameters, &runtime.context(), &[]);
         assert_eq!(output, (42., 1., 2., 3., 4., 5., 6., false));
-        assert_eq!(block.is_valid(runtime.context().time.as_secs_f64()), 0.0);
+        assert!(!block.is_valid(runtime.context().time.as_secs_f64()));
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/can_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/can_receive_block.rs
@@ -1,5 +1,4 @@
 extern crate alloc;
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, Pass, ProcessBlock};
 
 use crate::{stale_tracker::StaleTracker, traits::Float, IsValid};
@@ -41,7 +40,6 @@ pub struct CanReceiveBlock<
     stale_check: StaleTracker,
     _phantom: core::marker::PhantomData<O>,
     output_buffer: O::Output,
-    pub data: [OldBlockData; N],
     cache: [S; N],
     previous_stale_check_time_ms: f64,
 }
@@ -58,13 +56,11 @@ impl<const N: usize, S: Float, C, O: Pass + Default + ToTupleOutput<S>>
     CanReceiveBlock<N, S, C, O>
 {
     pub fn new(rx_cb: RxCallback<C, S>) -> Self {
-        let data = core::array::from_fn(|_f| OldBlockData::from_scalar(0.));
         let cache = [S::zero(); N];
         CanReceiveBlock {
             rx_cb,
             stale_check: StaleTracker::from_ms(0.),
             _phantom: core::marker::PhantomData,
-            data,
             output_buffer: O::Output::default(),
             cache,
             previous_stale_check_time_ms: 0.0,
@@ -99,10 +95,6 @@ where
             if let Some(can_decoder) = C::new(parameters.frame_id, inputs) {
                 (self.rx_cb)(&can_decoder, self.cache.as_mut_slice());
                 self.stale_check.mark_updated(context.time().as_secs_f64());
-
-                for (i, val) in self.cache.iter().enumerate() {
-                    self.data[i] = OldBlockData::from_scalar((*val).into());
-                }
             }
         }
 
@@ -123,7 +115,7 @@ where
 impl<const N: usize, S: Float, C, O: Pass + Default + ToTupleOutput<S>> IsValid
     for CanReceiveBlock<N, S, C, O>
 {
-    fn is_valid(&self, app_time_s: f64) -> OldBlockData {
+    fn is_valid(&self, app_time_s: f64) -> f64 {
         self.stale_check.is_valid(app_time_s)
     }
 }
@@ -293,24 +285,14 @@ mod tests {
 
         let output = block.process(&parameters, &runtime.context(), &[42, 0, 0, 0, 0, 0, 0, 0]);
         assert_eq!(output.0, 42.);
-        assert_eq!(
-            block
-                .is_valid(runtime.context().time.as_secs_f64())
-                .scalar(),
-            1.0
-        );
+        assert_eq!(block.is_valid(runtime.context().time.as_secs_f64()), 1.0);
 
         runtime.set_time(Duration::from_secs(2));
 
         // Simulate a stale message
         let output = block.process(&parameters, &runtime.context(), &[]);
         assert_eq!(output.0, 42.);
-        assert_eq!(
-            block
-                .is_valid(runtime.context().time.as_secs_f64())
-                .scalar(),
-            0.0
-        );
+        assert_eq!(block.is_valid(runtime.context().time.as_secs_f64()), 0.0);
     }
 
     #[test]
@@ -327,24 +309,14 @@ mod tests {
 
         let output = block.process(&parameters, &runtime.context(), &[42, 1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(output, (42., 1., 2., 3., 4., 5., 6., true));
-        assert_eq!(
-            block
-                .is_valid(runtime.context().time.as_secs_f64())
-                .scalar(),
-            1.0
-        );
+        assert_eq!(block.is_valid(runtime.context().time.as_secs_f64()), 1.0);
 
         // Simulate stale message
         runtime.set_time(Duration::from_secs(2));
 
         let output = block.process(&parameters, &runtime.context(), &[]);
         assert_eq!(output, (42., 1., 2., 3., 4., 5., 6., false));
-        assert_eq!(
-            block
-                .is_valid(runtime.context().time.as_secs_f64())
-                .scalar(),
-            0.0
-        );
+        assert_eq!(block.is_valid(runtime.context().time.as_secs_f64()), 0.0);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/can_transmit_block.rs
+++ b/pictorus-blocks/src/core_blocks/can_transmit_block.rs
@@ -1,7 +1,6 @@
 extern crate alloc;
 use crate::traits::{Float, Scalar};
 use alloc::vec::Vec;
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, Pass, PassBy, ProcessBlock};
 
 // Ideally this would not have to return a new vec, but that added a lot of complexity
@@ -30,7 +29,6 @@ pub struct CanTransmitBlock<
     // A tuple of input data (1 to 8 values of type S) to convert to an 8 byte CAN data payload.
     I: Pass,
 > {
-    pub data: Vec<OldBlockData>,
     byte_buffer: Vec<u8>,
     _phantom: core::marker::PhantomData<I>,
     tx_cb: TxCallback<S, C>,
@@ -39,14 +37,15 @@ pub struct CanTransmitBlock<
 
 impl<S: Float, C, I: Pass> Default for CanTransmitBlock<S, C, I> {
     fn default() -> Self {
-        panic!("CanTransmitBlock must be initialized using the ::new method");
+        const {
+            panic!("CanTransmitBlock must be initialized using the ::new method");
+        }
     }
 }
 
 impl<S: Float, C, I: Pass> CanTransmitBlock<S, C, I> {
     pub fn new(tx_cb: TxCallback<S, C>, msg: C) -> Self {
         CanTransmitBlock {
-            data: Vec::new(),
             _phantom: core::marker::PhantomData,
             tx_cb,
             msg,

--- a/pictorus-blocks/src/core_blocks/change_detection_block.rs
+++ b/pictorus-blocks/src/core_blocks/change_detection_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{HasIc, Matrix, Pass, PassBy, ProcessBlock, Scalar};
 use strum::EnumString;
 
@@ -17,7 +16,6 @@ use strum::EnumString;
 /// The first execution of this block has no value to compare with
 /// so it will always emit `false`
 pub struct ChangeDetectionBlock<T: Apply> {
-    pub data: OldBlockData,
     buffer: T::Output,
     last_input: Option<T>,
 }
@@ -25,7 +23,6 @@ pub struct ChangeDetectionBlock<T: Apply> {
 impl<T> Default for ChangeDetectionBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         const {
@@ -40,12 +37,10 @@ where
 impl<T> HasIc for ChangeDetectionBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     fn new(parameters: &Self::Parameters) -> Self {
         ChangeDetectionBlock::<T> {
             buffer: T::Output::default(),
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
             last_input: Some(parameters.ic),
         }
     }
@@ -54,7 +49,6 @@ where
 impl<T> ProcessBlock for ChangeDetectionBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -67,7 +61,6 @@ where
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         let output = T::apply(&mut self.buffer, inputs, parameters, &mut self.last_input);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 

--- a/pictorus-blocks/src/core_blocks/comparison_block.rs
+++ b/pictorus-blocks/src/core_blocks/comparison_block.rs
@@ -1,5 +1,4 @@
 use crate::traits::{Apply, ApplyInto, MatrixOps, Scalar};
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// The type of comparison operation to perform
@@ -46,20 +45,16 @@ impl Parameters {
 pub struct ComparisonBlock<T>
 where
     T: Apply<Parameters>,
-    OldBlockData: FromPass<<T as Apply<Parameters>>::Output>,
 {
-    pub data: OldBlockData,
     buffer: T::Output,
 }
 
 impl<T> Default for ComparisonBlock<T>
 where
     T: Apply<Parameters>,
-    OldBlockData: FromPass<<T as Apply<Parameters>>::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
             buffer: T::Output::default(),
         }
     }
@@ -68,7 +63,6 @@ where
 impl<T> ProcessBlock for ComparisonBlock<T>
 where
     T: Apply<Parameters>,
-    OldBlockData: FromPass<<T as Apply<Parameters>>::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -83,7 +77,6 @@ where
         let mut tmp: Option<T::Output> = None;
         T::apply(inputs, parameters, &mut tmp);
         self.buffer = tmp.expect("apply must initialize the buffer");
-        self.data = OldBlockData::from_pass(self.buffer.as_by());
         self.buffer.as_by()
     }
 

--- a/pictorus-blocks/src/core_blocks/counter_block.rs
+++ b/pictorus-blocks/src/core_blocks/counter_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::traits::Scalar;
@@ -28,18 +27,11 @@ impl Parameters {
 /// or a matrix of scalars. However they are interpreted as bools or matrices of bools, where true or
 /// false is determined by whether the value is non-zero or zero respectively. See the [`Scalar::is_truthy`]
 /// function for more details.
-pub struct CounterBlock<T: Apply>
-where
-    OldBlockData: FromPass<T::Counter>,
-{
-    pub data: OldBlockData,
+pub struct CounterBlock<T: Apply> {
     counter: T::Counter,
 }
 
-impl<T: Apply> ProcessBlock for CounterBlock<T>
-where
-    OldBlockData: FromPass<T::Counter>,
-{
+impl<T: Apply> ProcessBlock for CounterBlock<T> {
     type Inputs = T;
     type Output = T::Counter;
     type Parameters = Parameters;
@@ -58,16 +50,10 @@ where
     }
 }
 
-impl<T: Apply> Default for CounterBlock<T>
-where
-    OldBlockData: FromPass<T::Counter>,
-{
+impl<T: Apply> Default for CounterBlock<T> {
     fn default() -> Self {
         let counter = T::Counter::default();
-        Self {
-            data: OldBlockData::from_pass(counter.as_by()),
-            counter,
-        }
+        Self { counter }
     }
 }
 

--- a/pictorus-blocks/src/core_blocks/cross_product_block.rs
+++ b/pictorus-blocks/src/core_blocks/cross_product_block.rs
@@ -1,5 +1,4 @@
 use crate::matrix_ext::MatrixNalgebraExt;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Context, Matrix, Pass, PassBy};
 
 pub struct Parameters {
@@ -23,18 +22,15 @@ pub struct CrossProductBlock<T>
 where
     T: Apply + Pass + Default,
 {
-    pub data: OldBlockData,
     buffer: T::Output,
 }
 
 impl<T> Default for CrossProductBlock<T>
 where
     T: Apply + Pass + Default,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
             buffer: T::Output::default(),
         }
     }
@@ -43,7 +39,6 @@ where
 impl<T> pictorus_traits::ProcessBlock for CrossProductBlock<T>
 where
     T: Pass + Apply + Default,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -56,7 +51,6 @@ where
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         let output = T::apply(&mut self.buffer, inputs);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 
@@ -109,7 +103,6 @@ float_matrix_impl!(f32);
 mod tests {
 
     use crate::testing::StubContext;
-    use pictorus_block_data::{BlockData, ToPass};
     use pictorus_traits::ProcessBlock;
 
     use super::*;
@@ -126,14 +119,15 @@ mod tests {
         let p = Parameters::new();
         let mut cross_block =
             CrossProductBlock::<(Matrix<1, 3, f64>, Matrix<1, 3, f64>)>::default();
-        let input1 = BlockData::new(1, 3, &[1.0, 0.0, 0.0]);
-        let input2 = BlockData::new(1, 3, &[0.0, 1.0, 0.0]);
-        cross_block.process(&p, &context, (&input1.to_pass(), &input2.to_pass()));
+        let input1: Matrix<1, 3, f64> = Matrix {
+            data: [[1.0], [0.0], [0.0]],
+        };
+        let input2: Matrix<1, 3, f64> = Matrix {
+            data: [[0.0], [1.0], [0.0]],
+        };
+        cross_block.process(&p, &context, (&input1, &input2));
 
-        assert_eq!(
-            cross_block.data,
-            BlockData::from_matrix(&[&[0.0, 0.0, 1.0]])
-        );
+        assert_eq!(cross_block.buffer().data, [[0.0], [0.0], [1.0]]);
     }
 
     #[test]
@@ -142,14 +136,15 @@ mod tests {
         let p = Parameters::new();
         let mut cross_block =
             CrossProductBlock::<(Matrix<3, 1, f64>, Matrix<3, 1, f64>)>::default();
-        let input1 = BlockData::new(3, 1, &[1.0, 0.0, 0.0]);
-        let input2 = BlockData::new(3, 1, &[0.0, 1.0, 0.0]);
-        cross_block.process(&p, &context, (&input1.to_pass(), &input2.to_pass()));
+        let input1: Matrix<3, 1, f64> = Matrix {
+            data: [[1.0, 0.0, 0.0]],
+        };
+        let input2: Matrix<3, 1, f64> = Matrix {
+            data: [[0.0, 1.0, 0.0]],
+        };
+        cross_block.process(&p, &context, (&input1, &input2));
 
-        assert_eq!(
-            cross_block.data,
-            BlockData::from_matrix(&[&[0.0], &[0.0], &[1.0]])
-        );
+        assert_eq!(cross_block.buffer().data, [[0.0, 0.0, 1.0]]);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/dac_block.rs
+++ b/pictorus-blocks/src/core_blocks/dac_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Context, Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::traits::Float;
@@ -21,18 +20,15 @@ impl Parameters {
 
 /// Buffer data to be sent to a DAC (Digital-to-Analog Converter).
 pub struct DacBlock<O: Pass> {
-    pub data: OldBlockData,
     buffer: O,
 }
 
 impl<O> Default for DacBlock<O>
 where
     O: Pass + Default,
-    OldBlockData: FromPass<O>,
 {
     fn default() -> Self {
         DacBlock {
-            data: <OldBlockData as FromPass<O>>::from_pass(<O>::default().as_by()),
             buffer: O::default(),
         }
     }
@@ -41,7 +37,6 @@ where
 impl<F> ProcessBlock for DacBlock<Matrix<1, 2, F>>
 where
     F: Float,
-    OldBlockData: FromPass<Matrix<1, 2, F>>,
 {
     type Parameters = Parameters;
     type Inputs = Matrix<1, 2, F>;
@@ -54,7 +49,6 @@ where
         input: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         self.buffer = *input;
-        self.data = OldBlockData::from_pass(&self.buffer);
         &self.buffer
     }
 

--- a/pictorus-blocks/src/core_blocks/delay_block.rs
+++ b/pictorus-blocks/src/core_blocks/delay_block.rs
@@ -1,24 +1,16 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{HasIc, Pass, PassBy, ProcessBlock};
 
 use crate::traits::CopyInto;
 
 /// Delays the input signal by N steps.
-pub struct DelayBlock<T: Pass + Default + Copy, const N: usize>
-where
-    pictorus_block_data::BlockData: FromPass<T>,
-{
+pub struct DelayBlock<T: Pass + Default + Copy, const N: usize> {
     samples: [T; N],
     sample_index: usize,
     initial_accumulation: bool,
     output: T,
-    pub data: OldBlockData,
 }
 
-impl<T: Pass + Default + Copy + CopyInto<T>, const N: usize> HasIc for DelayBlock<T, N>
-where
-    pictorus_block_data::BlockData: FromPass<T>,
-{
+impl<T: Pass + Default + Copy + CopyInto<T>, const N: usize> HasIc for DelayBlock<T, N> {
     /// Constructs a new DelayBlock with the initial conditions from the parameters so that its output will be in a valid state before its first call to process.
     fn new(parameters: &Self::Parameters) -> Self {
         Self {
@@ -26,15 +18,11 @@ where
             sample_index: 0,
             initial_accumulation: true,
             output: parameters.ic,
-            data: OldBlockData::from_pass(parameters.ic.as_by()),
         }
     }
 }
 
-impl<T: Pass + Default + Copy, const N: usize> Default for DelayBlock<T, N>
-where
-    pictorus_block_data::BlockData: FromPass<T>,
-{
+impl<T: Pass + Default + Copy, const N: usize> Default for DelayBlock<T, N> {
     fn default() -> Self {
         const {
             panic!(
@@ -45,10 +33,7 @@ where
     }
 }
 
-impl<T: Pass + Default + Copy + CopyInto<T>, const N: usize> ProcessBlock for DelayBlock<T, N>
-where
-    pictorus_block_data::BlockData: FromPass<T>,
-{
+impl<T: Pass + Default + Copy + CopyInto<T>, const N: usize> ProcessBlock for DelayBlock<T, N> {
     type Inputs = T;
     type Output = T;
     type Parameters = Parameters<T>;
@@ -92,7 +77,6 @@ where
             self.sample_index = 0;
         }
 
-        self.data = OldBlockData::from_pass(self.output.as_by());
         self.output.as_by()
     }
 

--- a/pictorus-blocks/src/core_blocks/delay_control_block.rs
+++ b/pictorus-blocks/src/core_blocks/delay_control_block.rs
@@ -1,6 +1,5 @@
 use crate::traits::Scalar;
 use core::time::Duration;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Context, Matrix, Pass, PassBy, ProcessBlock};
 
 /// Debounce or throttle an input signal.
@@ -11,29 +10,21 @@ use pictorus_traits::{Context, Matrix, Pass, PassBy, ProcessBlock};
 ///  - Debounce: Wait until the input signal stops being true for delay_time before emitting true.
 ///  - Throttle: Immediately emit true on first true input, but then wait delay_time before passing through a true input again.
 pub struct DelayControlBlock<T: Apply> {
-    pub data: OldBlockData,
     buffer: T::Output,
     /// This is the state of the block used for the debounce and throttle functionality
     state: T::State,
 }
 
-impl<T: Apply> Default for DelayControlBlock<T>
-where
-    OldBlockData: FromPass<T::Output>,
-{
+impl<T: Apply> Default for DelayControlBlock<T> {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
             buffer: T::Output::default(),
             state: T::init_state(),
         }
     }
 }
 
-impl<T: Apply> ProcessBlock for DelayControlBlock<T>
-where
-    OldBlockData: FromPass<T::Output>,
-{
+impl<T: Apply> ProcessBlock for DelayControlBlock<T> {
     type Inputs = T;
     type Output = T::Output;
     type Parameters = Parameters;
@@ -51,7 +42,6 @@ where
             parameters,
             context,
         );
-        self.data = <OldBlockData as FromPass<T::Output>>::from_pass(output);
         output
     }
 
@@ -245,33 +235,32 @@ mod tests {
 
         let output = block.process(&parameters, &runtime.context(), 0.0);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
         assert_eq!(block.buffer(), output);
 
         runtime.tick(); // Time is 100ms
         let output = block.process(&parameters, &runtime.context(), 0.5);
         assert!(output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(true));
+        assert_eq!(block.buffer(), 1.0);
 
         runtime.tick(); // Time is 200ms
         let output = block.process(&parameters, &runtime.context(), 1.0);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), 0.0);
 
         runtime.tick(); // Time is 300ms
         let output = block.process(&parameters, &runtime.context(), 1.5);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), 0.0);
 
         runtime.tick(); // Time is 400ms
         let output = block.process(&parameters, &runtime.context(), 2.0);
         assert!(output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(true));
+        assert_eq!(block.buffer(), 1.0);
 
         runtime.tick(); // Time is 500ms
         let output = block.process(&parameters, &runtime.context(), 2.5);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), 0.0);
     }
 
     #[test]
@@ -283,58 +272,58 @@ mod tests {
         // T= 0  we receive false
         let output = block.process(&parameters, &runtime.context(), 0.0);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), 0.0);
 
         runtime.tick(); // T = 0.1s we receive true but still expect false
         let output = block.process(&parameters, &runtime.context(), -2.0);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), 0.0);
 
         runtime.tick(); // T = 0.2s we receive false but still expect false until the delay cooldown is over
         let output = block.process(&parameters, &runtime.context(), 0.0);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), 0.0);
 
         runtime.tick(); // T = 0.3s we receive false but still expect false until the delay cooldown is over
         let output = block.process(&parameters, &runtime.context(), 0.0);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), 0.0);
 
         runtime.tick(); // T = 0.4s we receive false but expect true because delay cooldown is over
         let output = block.process(&parameters, &runtime.context(), 0.0);
         assert!(output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(true));
+        assert_eq!(block.buffer(), 1.0);
 
         runtime.tick(); // T = 0.5s we receive false and expect false since we already emitted true
         let output = block.process(&parameters, &runtime.context(), 0.0);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), 0.0);
 
         runtime.tick(); // T = 0.6s we receive false and expect false since we already emitted true
         let output = block.process(&parameters, &runtime.context(), 0.0);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), 0.0);
 
         // Show we can do it again
         runtime.tick(); // T = 0.7s we receive true but still expect false
         let output = block.process(&parameters, &runtime.context(), 1.0);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), 0.0);
 
         runtime.tick(); // T = 0.8s we receive false setting the debounce cooldown in motion
         let output = block.process(&parameters, &runtime.context(), 0.0);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), 0.0);
 
         // Fast forward to 0.3 seconds after the last true input
         runtime.context.time += Duration::from_secs_f64(0.3);
         let output = block.process(&parameters, &runtime.context(), 0.0);
         assert!(output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(true));
+        assert_eq!(block.buffer(), 1.0);
 
         runtime.tick();
         let output = block.process(&parameters, &runtime.context(), 0.0);
         assert!(!output.is_truthy());
-        assert_eq!(block.data, OldBlockData::scalar_from_bool(false));
+        assert_eq!(block.buffer(), 0.0);
     }
 }

--- a/pictorus-blocks/src/core_blocks/derivative_block.rs
+++ b/pictorus-blocks/src/core_blocks/derivative_block.rs
@@ -1,25 +1,17 @@
 use crate::matrix_ext::MatrixNalgebraExt;
 use num_traits::One;
 use paste::paste;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{HasIc, Matrix, Pass, ProcessBlock};
 
 /// Compute the discrete derivative of a signal using a sliding window of samples.
-pub struct DerivativeBlock<T: Pass + Default + Copy, const N: usize>
-where
-    pictorus_block_data::BlockData: FromPass<T>,
-{
+pub struct DerivativeBlock<T: Pass + Default + Copy, const N: usize> {
     samples: [T; N],
     sample_index: usize,
     initial_accumulation: bool,
     output: T,
-    pub data: OldBlockData,
 }
 
-impl<const N: usize, T: Pass + Default + Copy> Default for DerivativeBlock<T, N>
-where
-    pictorus_block_data::BlockData: FromPass<T>,
-{
+impl<const N: usize, T: Pass + Default + Copy> Default for DerivativeBlock<T, N> {
     fn default() -> Self {
         const {
             panic!(
@@ -61,7 +53,6 @@ macro_rules! impl_process {
                         / ((N as $type - $type::one()) * context.timestep().expect("timestep should never be None outside of Initial Accumulation phase").[<as_secs_ $type>]());
                 }
 
-                self.data = <OldBlockData as FromPass<$type>>::from_pass(self.output);
                 self.output.as_by()
             }
 
@@ -78,7 +69,6 @@ macro_rules! impl_process {
                     sample_index: 0,
                     initial_accumulation: true,
                     output: parameters.ic,
-                    data: <OldBlockData as FromPass<$type>>::from_pass(parameters.ic),
                 }
             }
         }
@@ -113,7 +103,6 @@ macro_rules! impl_process {
                     self.output.as_view_mut().copy_from(&output);
                 }
 
-                self.data = <OldBlockData as FromPass<Matrix<NROWS, NCOLS, $type>>>::from_pass(self.output.as_by());
                 &self.output
             }
 
@@ -130,7 +119,6 @@ macro_rules! impl_process {
                     sample_index: 0,
                     initial_accumulation: true,
                     output: parameters.ic,
-                    data: <OldBlockData as FromPass<Matrix<NROWS, NCOLS, $type>>>::from_pass(&parameters.ic),
                 }
             }
         }

--- a/pictorus-blocks/src/core_blocks/determinant_block.rs
+++ b/pictorus-blocks/src/core_blocks/determinant_block.rs
@@ -1,5 +1,4 @@
 use nalgebra::{ArrayStorage, Const, DimMin, SquareMatrix, ToTypenum};
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
 
 pub struct Parameters {}
@@ -18,7 +17,6 @@ impl Parameters {
 
 /// A block that calculates the determinant of a square matrix.
 pub struct DeterminantBlock<S: Scalar, T> {
-    pub data: OldBlockData,
     buffer: S,
     phantom_type: core::marker::PhantomData<T>,
 }
@@ -27,11 +25,9 @@ impl<S, T> Default for DeterminantBlock<S, T>
 where
     S: Default + Scalar + Pass,
     T: Pass,
-    OldBlockData: FromPass<S>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<S>>::from_pass(S::default().as_by()),
             buffer: S::default(),
             phantom_type: core::marker::PhantomData,
         }
@@ -43,7 +39,6 @@ macro_rules! impl_determinant_block {
         impl<const N: usize> ProcessBlock for DeterminantBlock<$type, Matrix<N, N, $type>>
         where
             Const<N>: ToTypenum + DimMin<Const<N>, Output = Const<N>>,
-            OldBlockData: FromPass<$type>,
         {
             type Inputs = Matrix<N, N, $type>;
             type Output = $type;
@@ -57,7 +52,6 @@ macro_rules! impl_determinant_block {
             ) -> PassBy<'b, Self::Output> {
                 self.buffer =
                     SquareMatrix::from_array_storage(ArrayStorage(inputs.data)).determinant();
-                self.data = OldBlockData::from_scalar(self.buffer.into());
                 self.buffer
             }
 
@@ -66,10 +60,7 @@ macro_rules! impl_determinant_block {
             }
         }
 
-        impl ProcessBlock for DeterminantBlock<$type, $type>
-        where
-            OldBlockData: FromPass<$type>,
-        {
+        impl ProcessBlock for DeterminantBlock<$type, $type> {
             type Inputs = $type;
             type Output = $type;
             type Parameters = Parameters;
@@ -81,7 +72,6 @@ macro_rules! impl_determinant_block {
                 inputs: PassBy<'_, Self::Inputs>,
             ) -> PassBy<'b, Self::Output> {
                 self.buffer = inputs;
-                self.data = OldBlockData::from_scalar(self.buffer.into());
                 self.buffer
             }
 
@@ -100,7 +90,6 @@ mod tests {
     use super::*;
     use crate::testing::StubContext;
     use paste::paste;
-    use pictorus_block_data::BlockDataType;
 
     #[test]
     fn test_determinant_default_buffer_no_panic() {
@@ -123,8 +112,6 @@ mod tests {
                     let output = det_block.process(&p, &c, &input);
 
                     assert!(output == -2.0);
-                    assert!(det_block.data.scalar() == -2.0);
-                    assert!(det_block.data.get_type() == BlockDataType::Scalar);
                     assert_eq!(det_block.buffer(), output);
 
                     let mut det_block_3x3 = DeterminantBlock::<$type, Matrix<3, 3, $type>>::default();
@@ -133,8 +120,7 @@ mod tests {
                     };
                     let output = det_block_3x3.process(&p, &c, &input_3x3);
                     assert!(output == -33.0);
-                    assert!(det_block_3x3.data.scalar() == -33.0);
-                    assert!(det_block_3x3.data.get_type() == BlockDataType::Scalar);
+                    assert_eq!(det_block_3x3.buffer(), output);
                 }
             }
         }

--- a/pictorus-blocks/src/core_blocks/dot_product_block.rs
+++ b/pictorus-blocks/src/core_blocks/dot_product_block.rs
@@ -2,23 +2,19 @@ use core::ops::{AddAssign, Mul, MulAssign};
 
 use crate::matrix_ext::MatrixNalgebraExt;
 use crate::traits::Scalar;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Calculate the dot product of two same-sized vectors.
 pub struct DotProductBlock<T: Apply> {
     buffer: T::Output,
-    pub data: OldBlockData,
 }
 
 impl<T> Default for DotProductBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
             buffer: T::Output::default(),
         }
     }
@@ -27,7 +23,6 @@ where
 impl<T> ProcessBlock for DotProductBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -40,7 +35,6 @@ where
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         let output = T::apply(&mut self.buffer, inputs);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 

--- a/pictorus-blocks/src/core_blocks/frequency_filter_block.rs
+++ b/pictorus-blocks/src/core_blocks/frequency_filter_block.rs
@@ -1,7 +1,6 @@
 use crate::traits::Float;
 use crate::traits::{MatrixOps, Scalar};
 use core::time::Duration;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{HasIc, Matrix, Pass, PassBy, ProcessBlock};
 
 /// Perform a frequency filter operation on a signal, either as a low pass or high pass filter.
@@ -13,7 +12,6 @@ use pictorus_traits::{HasIc, Matrix, Pass, PassBy, ProcessBlock};
 /// independently to each element of the matrix.
 #[derive(Debug)]
 pub struct FrequencyFilterBlock<T: Pass> {
-    pub data: OldBlockData,
     prev_data: Option<PreviousData<T>>,
     output: T,
 }
@@ -25,10 +23,7 @@ struct PreviousData<T: Pass> {
     prev_time: Duration,
 }
 
-impl<T: Pass + Default> Default for FrequencyFilterBlock<T>
-where
-    OldBlockData: FromPass<T>,
-{
+impl<T: Pass + Default> Default for FrequencyFilterBlock<T> {
     fn default() -> Self {
         const {
             panic!(
@@ -42,7 +37,6 @@ where
 impl<T> HasIc for FrequencyFilterBlock<T>
 where
     T: Pass + Default + Float,
-    OldBlockData: FromPass<T>,
 {
     fn new(parameters: &Self::Parameters) -> Self {
         FrequencyFilterBlock::<T> {
@@ -51,7 +45,6 @@ where
                 prev_output: parameters.ic,
                 prev_time: Duration::ZERO,
             }),
-            data: OldBlockData::from_pass(parameters.ic.as_by()),
             output: parameters.ic,
         }
     }
@@ -61,7 +54,6 @@ impl<T, const NROWS: usize, const NCOLS: usize> HasIc
     for FrequencyFilterBlock<Matrix<NROWS, NCOLS, T>>
 where
     T: Pass + Default + Float + Scalar,
-    OldBlockData: FromPass<Matrix<NROWS, NCOLS, T>>,
 {
     fn new(parameters: &Self::Parameters) -> Self {
         FrequencyFilterBlock::<pictorus_traits::Matrix<NROWS, NCOLS, T>> {
@@ -70,7 +62,6 @@ where
                 prev_output: parameters.ic,
                 prev_time: Duration::ZERO,
             }),
-            data: OldBlockData::from_pass(parameters.ic.as_by()),
             output: parameters.ic,
         }
     }
@@ -79,7 +70,6 @@ where
 impl<T> ProcessBlock for FrequencyFilterBlock<T>
 where
     T: Pass + Default + Float,
-    OldBlockData: FromPass<T>,
 {
     type Inputs = T;
     type Output = T;
@@ -110,7 +100,6 @@ where
             prev_output: self.output,
             prev_time: context.time(),
         });
-        self.data = OldBlockData::from_pass(self.output.as_by());
         self.output.as_by()
     }
 
@@ -123,7 +112,6 @@ impl<T, const NROWS: usize, const NCOLS: usize> ProcessBlock
     for FrequencyFilterBlock<Matrix<NROWS, NCOLS, T>>
 where
     T: Pass + Default + Float + Scalar,
-    OldBlockData: FromPass<Matrix<NROWS, NCOLS, T>>,
 {
     type Inputs = Matrix<NROWS, NCOLS, T>;
     type Output = Matrix<NROWS, NCOLS, T>;
@@ -156,7 +144,6 @@ where
             prev_output: self.output,
             prev_time: context.time(),
         });
-        self.data = OldBlockData::from_pass(self.output.as_by());
         self.output.as_by()
     }
 

--- a/pictorus-blocks/src/core_blocks/gpio_output_block.rs
+++ b/pictorus-blocks/src/core_blocks/gpio_output_block.rs
@@ -1,6 +1,5 @@
 use core::marker::PhantomData;
 
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, Context, Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::traits::Scalar;
@@ -10,7 +9,6 @@ use crate::traits::Scalar;
 /// The block itself just handles converting the input to a boolean.
 /// The hardware interaction happens downstream of this block.
 pub struct GpioOutputBlock<T: ToBool> {
-    pub data: OldBlockData,
     buffer: bool,
     _unused: PhantomData<T>,
 }
@@ -34,7 +32,6 @@ impl<T: ToBool> Default for GpioOutputBlock<T> {
         GpioOutputBlock {
             _unused: PhantomData,
             buffer: false,
-            data: OldBlockData::scalar_from_bool(false),
         }
     }
 }
@@ -52,7 +49,6 @@ impl<T: ToBool> ProcessBlock for GpioOutputBlock<T> {
     ) -> PassBy<'b, Self::Output> {
         let res = T::to_bool(input);
         self.buffer = res;
-        self.data.set_scalar_bool(res);
         res
     }
 

--- a/pictorus-blocks/src/core_blocks/i2c_input_block.rs
+++ b/pictorus-blocks/src/core_blocks/i2c_input_block.rs
@@ -1,6 +1,5 @@
 extern crate alloc;
 use alloc::vec::Vec;
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, Context, PassBy, ProcessBlock};
 
 use crate::{stale_tracker::StaleTracker, IsValid};
@@ -35,7 +34,6 @@ impl Parameters {
 
 /// I2C Input Block buffers data read from an I2C peripheral.
 pub struct I2cInputBlock {
-    pub data: OldBlockData,
     pub stale_check: StaleTracker,
     buffer: Vec<u8>,
     last_valid: bool,
@@ -45,7 +43,6 @@ pub struct I2cInputBlock {
 impl Default for I2cInputBlock {
     fn default() -> Self {
         Self {
-            data: OldBlockData::from_bytes(b""),
             stale_check: StaleTracker::from_ms(0.0),
             buffer: Vec::new(),
             last_valid: false,
@@ -55,7 +52,7 @@ impl Default for I2cInputBlock {
 }
 
 impl IsValid for I2cInputBlock {
-    fn is_valid(&self, app_time_s: f64) -> OldBlockData {
+    fn is_valid(&self, app_time_s: f64) -> f64 {
         self.stale_check.is_valid(app_time_s)
     }
 }
@@ -82,7 +79,6 @@ impl ProcessBlock for I2cInputBlock {
             self.buffer.clear();
             self.stale_check.mark_updated(context.time().as_secs_f64());
             self.buffer.extend_from_slice(inputs);
-            self.data.set_bytes(&self.buffer);
         }
 
         self.last_valid = self.stale_check.is_valid_bool(context.time().as_secs_f64());
@@ -120,12 +116,9 @@ mod tests {
             (data.to_vec(), valid)
         };
         assert_eq!(output.0, input_data);
-        assert_eq!(block.data.to_bytes(), input_data);
         assert_eq!(block.buffer(), (output.0.as_slice(), output.1));
-        let valid = block
-            .is_valid(runtime.context().time().as_secs_f64())
-            .clone();
-        assert_eq!(valid.scalar(), 1.0);
+        let valid = block.is_valid(runtime.context().time().as_secs_f64());
+        assert_eq!(valid, 1.0);
 
         runtime.set_time(Duration::from_secs(1));
 
@@ -134,6 +127,6 @@ mod tests {
         let output = block.process(&parameters, &runtime.context(), &[]);
         assert_eq!(output.0, input_data);
         let valid = block.is_valid(runtime.context().time().as_secs_f64());
-        assert_eq!(valid.scalar(), 0.0);
+        assert_eq!(valid, 0.0);
     }
 }

--- a/pictorus-blocks/src/core_blocks/i2c_input_block.rs
+++ b/pictorus-blocks/src/core_blocks/i2c_input_block.rs
@@ -52,7 +52,7 @@ impl Default for I2cInputBlock {
 }
 
 impl IsValid for I2cInputBlock {
-    fn is_valid(&self, app_time_s: f64) -> f64 {
+    fn is_valid(&self, app_time_s: f64) -> bool {
         self.stale_check.is_valid(app_time_s)
     }
 }
@@ -118,7 +118,7 @@ mod tests {
         assert_eq!(output.0, input_data);
         assert_eq!(block.buffer(), (output.0.as_slice(), output.1));
         let valid = block.is_valid(runtime.context().time().as_secs_f64());
-        assert_eq!(valid, 1.0);
+        assert!(valid);
 
         runtime.set_time(Duration::from_secs(1));
 
@@ -127,6 +127,6 @@ mod tests {
         let output = block.process(&parameters, &runtime.context(), &[]);
         assert_eq!(output.0, input_data);
         let valid = block.is_valid(runtime.context().time().as_secs_f64());
-        assert_eq!(valid, 0.0);
+        assert!(!valid);
     }
 }

--- a/pictorus-blocks/src/core_blocks/i2c_output_block.rs
+++ b/pictorus-blocks/src/core_blocks/i2c_output_block.rs
@@ -24,14 +24,9 @@ impl Parameters {
 }
 
 /// I2C Output Block buffers data to write to an I2C peripheral.
+#[derive(Default)]
 pub struct I2cOutputBlock {
     buffer: Vec<u8>,
-}
-
-impl Default for I2cOutputBlock {
-    fn default() -> Self {
-        Self { buffer: Vec::new() }
-    }
 }
 
 impl ProcessBlock for I2cOutputBlock {

--- a/pictorus-blocks/src/core_blocks/i2c_output_block.rs
+++ b/pictorus-blocks/src/core_blocks/i2c_output_block.rs
@@ -1,6 +1,5 @@
 extern crate alloc;
 use alloc::vec::Vec;
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, Context, PassBy, ProcessBlock};
 
 /// Parameters for I2C Output Block
@@ -26,16 +25,12 @@ impl Parameters {
 
 /// I2C Output Block buffers data to write to an I2C peripheral.
 pub struct I2cOutputBlock {
-    pub data: OldBlockData,
     buffer: Vec<u8>,
 }
 
 impl Default for I2cOutputBlock {
     fn default() -> Self {
-        Self {
-            data: OldBlockData::from_bytes(b""),
-            buffer: Vec::new(),
-        }
+        Self { buffer: Vec::new() }
     }
 }
 
@@ -52,7 +47,6 @@ impl ProcessBlock for I2cOutputBlock {
     ) -> PassBy<'b, Self::Output> {
         self.buffer.clear();
         self.buffer.extend_from_slice(inputs);
-        self.data.set_bytes(&self.buffer);
         &self.buffer
     }
 
@@ -83,7 +77,6 @@ mod tests {
         let output_signal = block.process(&params, &context, input_data);
 
         assert_eq!(output_signal, input_data);
-        assert_eq!(block.data.to_bytes(), input_data);
         assert_eq!(block.buffer(), input_data);
     }
 }

--- a/pictorus-blocks/src/core_blocks/iir_filter_block.rs
+++ b/pictorus-blocks/src/core_blocks/iir_filter_block.rs
@@ -1,22 +1,14 @@
 use crate::matrix_ext::MatrixNalgebraExt;
 use crate::traits::Float;
 use core::time::Duration;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{HasIc, Matrix, Pass, PassBy, ProcessBlock};
 
 /// Block for applying an Infinite Impulse Response (IIR) filter to an input signal.
-pub struct IirFilterBlock<T: Pass + Default>
-where
-    OldBlockData: FromPass<T>,
-{
-    pub data: OldBlockData,
+pub struct IirFilterBlock<T: Pass + Default> {
     buffer: T,
 }
 
-impl<T: Pass + Default> Default for IirFilterBlock<T>
-where
-    OldBlockData: FromPass<T>,
-{
+impl<T: Pass + Default> Default for IirFilterBlock<T> {
     fn default() -> Self {
         const {
             panic!(
@@ -27,14 +19,10 @@ where
     }
 }
 
-impl<T: Float> HasIc for IirFilterBlock<T>
-where
-    OldBlockData: FromPass<T>,
-{
+impl<T: Float> HasIc for IirFilterBlock<T> {
     fn new(parameters: &Self::Parameters) -> Self {
         IirFilterBlock::<T> {
             buffer: parameters.ic,
-            data: <OldBlockData as FromPass<T>>::from_pass(parameters.ic),
         }
     }
 }
@@ -42,12 +30,10 @@ where
 impl<T, const NROWS: usize, const NCOLS: usize> HasIc for IirFilterBlock<Matrix<NROWS, NCOLS, T>>
 where
     T: Float,
-    OldBlockData: FromPass<Matrix<NROWS, NCOLS, T>>,
 {
     fn new(parameters: &Self::Parameters) -> Self {
         IirFilterBlock::<pictorus_traits::Matrix<NROWS, NCOLS, T>> {
             buffer: parameters.ic,
-            data: <OldBlockData as FromPass<Matrix<NROWS, NCOLS, T>>>::from_pass(&parameters.ic),
         }
     }
 }
@@ -55,7 +41,6 @@ where
 impl<T> ProcessBlock for IirFilterBlock<T>
 where
     T: Float,
-    OldBlockData: FromPass<T>,
 {
     type Inputs = T;
     type Output = T;
@@ -70,7 +55,6 @@ where
         let alpha = timestep_s / (timestep_s + parameters.time_constant_s);
         let res = alpha * inputs + ((T::one() - alpha) * self.buffer);
         self.buffer = res;
-        self.data = <OldBlockData as FromPass<T>>::from_pass(res);
         res
     }
 
@@ -83,7 +67,6 @@ impl<T, const NROWS: usize, const NCOLS: usize> ProcessBlock
     for IirFilterBlock<Matrix<NROWS, NCOLS, T>>
 where
     T: Float,
-    OldBlockData: FromPass<Matrix<NROWS, NCOLS, T>>,
 {
     type Inputs = Matrix<NROWS, NCOLS, T>;
     type Output = Matrix<NROWS, NCOLS, T>;
@@ -100,7 +83,6 @@ where
         let input = inputs.as_view();
         let res = input * alpha + (self.buffer.as_view() * (T::one() - alpha));
         self.buffer = Self::Output::from_view(&res.as_view());
-        self.data = OldBlockData::from_pass(&self.buffer);
         &self.buffer
     }
 
@@ -153,7 +135,7 @@ mod tests {
         // roughly 50% of final data
         let res = block.process(&parameters, &ctxt, 1.0);
         assert_relative_eq!(res, 0.5, max_relative = 0.01);
-        assert_relative_eq!(block.data.scalar(), 0.5, max_relative = 0.01);
+        assert_relative_eq!(block.buffer(), 0.5, max_relative = 0.01);
     }
 
     #[test]
@@ -192,7 +174,7 @@ mod tests {
             max_relative = 0.01
         );
         assert_relative_eq!(
-            block.data.get_data().as_slice(),
+            block.buffer().data.as_flattened(),
             expected.as_flattened(),
             max_relative = 0.01
         );
@@ -217,14 +199,14 @@ mod tests {
         // roughly 50% of final data
         let res = block.process(&parameters, &ctxt, 1.0);
         assert_relative_eq!(res, 0.5, max_relative = 0.01);
-        assert_relative_eq!(block.data.scalar(), 0.5, max_relative = 0.01);
+        assert_relative_eq!(block.buffer(), 0.5, max_relative = 0.01);
 
         // Reset the block with a new initial condition
         let new_ic = 0.5;
         let parameters = Parameters::new(new_ic, time_constants_s);
         let res = block.process(&parameters, &ctxt, 1.0);
         assert_relative_eq!(res, 0.75, max_relative = 0.01);
-        assert_relative_eq!(block.data.scalar(), 0.75, max_relative = 0.01);
+        assert_relative_eq!(block.buffer(), 0.75, max_relative = 0.01);
     }
 
     #[test]
@@ -263,7 +245,7 @@ mod tests {
             max_relative = 0.01
         );
         assert_relative_eq!(
-            block.data.get_data().as_slice(),
+            block.buffer().data.as_flattened(),
             expected.as_flattened(),
             max_relative = 0.01
         );

--- a/pictorus-blocks/src/core_blocks/integral_block.rs
+++ b/pictorus-blocks/src/core_blocks/integral_block.rs
@@ -4,30 +4,22 @@ use crate::{
     traits::{Float, MatrixOps},
     Scalar,
 };
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{HasIc, Matrix, Pass, PassBy, ProcessBlock};
 
 /// Performs a discrete integration of the input signal.
 ///
 /// It can accept a scalar or a matrix input, for a matrix input it will do an
 /// element wise integration.
-pub struct IntegralBlock<T: Apply>
-where
-    OldBlockData: FromPass<T::Output>,
-{
+pub struct IntegralBlock<T: Apply> {
     ic: T::Output,
     previous_sample: Option<T::Output>,
     // This is still Option<T> because we use this to determine if a reset has occurred or
     // data has not been processed. .buffer needs to return something, so we need the .ic
     // field or re-think how this block handles the first run and resets.
     output: Option<T::Output>,
-    pub data: OldBlockData,
 }
 
-impl<T: Apply> Default for IntegralBlock<T>
-where
-    OldBlockData: FromPass<T::Output>,
-{
+impl<T: Apply> Default for IntegralBlock<T> {
     fn default() -> Self {
         const {
             panic!(
@@ -38,10 +30,7 @@ where
     }
 }
 
-impl<F: Float, R: Scalar> ProcessBlock for IntegralBlock<(F, R)>
-where
-    OldBlockData: FromPass<F>,
-{
+impl<F: Float, R: Scalar> ProcessBlock for IntegralBlock<(F, R)> {
     type Inputs = (F, R);
     type Output = F;
     type Parameters = Parameters<(F, R)>;
@@ -84,7 +73,6 @@ where
         }
         // This could be none if we were reset above
         let output = self.output.get_or_insert(parameters.ic);
-        self.data = OldBlockData::from_pass(output.as_by());
         output.as_by()
     }
 
@@ -94,24 +82,18 @@ where
     }
 }
 
-impl<F: Float, R: Scalar> HasIc for IntegralBlock<(F, R)>
-where
-    OldBlockData: FromPass<F>,
-{
+impl<F: Float, R: Scalar> HasIc for IntegralBlock<(F, R)> {
     fn new(parameters: &Self::Parameters) -> Self {
         IntegralBlock::<(F, R)> {
             ic: parameters.ic,
             previous_sample: None,
             output: Some(parameters.ic),
-            data: <OldBlockData as FromPass<F>>::from_pass(parameters.ic.as_by()),
         }
     }
 }
 
 impl<F: Float, const NROWS: usize, const NCOLS: usize, R: Scalar> ProcessBlock
     for IntegralBlock<(Matrix<NROWS, NCOLS, F>, R)>
-where
-    OldBlockData: FromPass<Matrix<NROWS, NCOLS, F>>,
 {
     type Inputs = (Matrix<NROWS, NCOLS, F>, R);
     type Output = Matrix<NROWS, NCOLS, F>;
@@ -150,7 +132,6 @@ where
             self.previous_sample = Some(*sample);
         }
         let output = self.output.get_or_insert(parameters.ic);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 
@@ -161,15 +142,12 @@ where
 
 impl<F: Float, const NROWS: usize, const NCOLS: usize, R: Scalar> HasIc
     for IntegralBlock<(Matrix<NROWS, NCOLS, F>, R)>
-where
-    OldBlockData: FromPass<Matrix<NROWS, NCOLS, F>>,
 {
     fn new(parameters: &Self::Parameters) -> Self {
         IntegralBlock::<(Matrix<NROWS, NCOLS, F>, R)> {
             ic: parameters.ic,
             previous_sample: None,
             output: Some(parameters.ic),
-            data: <OldBlockData as FromPass<Matrix<NROWS, NCOLS, F>>>::from_pass(&parameters.ic),
         }
     }
 }
@@ -311,7 +289,7 @@ mod tests {
         let parameters = Parameters::new(10.0, 50.0, "Rectangle");
         let mut block = IntegralBlock::<(f64, bool)>::new(&parameters);
         // Check the initial value is set
-        assert_eq!(block.data.scalar(), 10.0);
+        assert_eq!(block.buffer(), 10.0);
 
         let input = 25.0;
         let output = block.process(&parameters, &runtime.context(), (input, false).as_by());
@@ -343,10 +321,7 @@ mod tests {
         );
         let mut block = IntegralBlock::<(Matrix<1, 3, f64>, bool)>::new(&parameters);
         // Check the initial value is set
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            [[10.0], [10.0], [10.0]].as_flattened()
-        );
+        assert_eq!(block.buffer().data, [[10.0], [10.0], [10.0]]);
 
         let input = Matrix {
             data: [[1.0], [1.0], [25.0]],

--- a/pictorus-blocks/src/core_blocks/json_dump_block.rs
+++ b/pictorus-blocks/src/core_blocks/json_dump_block.rs
@@ -2,14 +2,12 @@ extern crate alloc;
 use crate::traits::serialize::{ByteSliceFormat, Serialize};
 use alloc::{string::String, vec::Vec};
 use miniserde::json::{self, Value};
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, Pass, PassBy, ProcessBlock};
 
 /// Serializes a set of input signals into a JSON blob.
 ///
 /// That object is then serialized into a byte slice to be returned
 pub struct JsonDumpBlock<T: Apply> {
-    pub data: OldBlockData,
     buffer: Vec<u8>,
     _phantom: core::marker::PhantomData<T>,
 }
@@ -17,7 +15,6 @@ pub struct JsonDumpBlock<T: Apply> {
 impl<T: Apply> Default for JsonDumpBlock<T> {
     fn default() -> Self {
         Self {
-            data: OldBlockData::from_bytes(b""),
             buffer: Vec::new(),
             _phantom: core::marker::PhantomData,
         }
@@ -36,7 +33,6 @@ impl<T: Apply> ProcessBlock for JsonDumpBlock<T> {
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         T::apply(&mut self.buffer, inputs, parameters);
-        self.data = OldBlockData::from_bytes(&self.buffer);
         &self.buffer
     }
 

--- a/pictorus-blocks/src/core_blocks/json_load_block.rs
+++ b/pictorus-blocks/src/core_blocks/json_load_block.rs
@@ -1,11 +1,10 @@
 extern crate alloc;
 
 use alloc::string::String;
-use alloc::vec;
 use alloc::vec::Vec;
 
 use miniserde::json::{self, Array, Number, Object, Value};
-use pictorus_block_data::{BlockData as OldBlockData, BlockDataType, FromPass};
+use pictorus_block_data::BlockDataType;
 use pictorus_traits::{ByteSliceSignal, Context, Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::{stale_tracker::StaleTracker, traits::DefaultStorage, IsValid};
@@ -17,7 +16,6 @@ use crate::{stale_tracker::StaleTracker, traits::DefaultStorage, IsValid};
 /// select_data is a key in the object. If select_data is not provided, we assume
 /// that the passed in bytes represent a single value (either scalar or matrix).
 pub struct JsonLoadBlock<T: Apply> {
-    pub data: Vec<OldBlockData>,
     buffer: T::Storage,
     stale_tracker: Option<StaleTracker>,
 }
@@ -25,9 +23,7 @@ pub struct JsonLoadBlock<T: Apply> {
 impl<T: Apply> Default for JsonLoadBlock<T> {
     fn default() -> Self {
         let buffer = T::default_storage();
-        let data = T::build_block_data(&buffer);
         JsonLoadBlock {
-            data,
             buffer,
             stale_tracker: None,
         }
@@ -47,7 +43,6 @@ impl<T: Apply> ProcessBlock for JsonLoadBlock<T> {
     ) -> PassBy<'b, Self::Output> {
         let success = T::apply(&mut self.buffer, inputs, parameters);
         if success.is_ok() {
-            self.data = T::build_block_data(&self.buffer);
             let tracker = self
                 .stale_tracker
                 .get_or_insert(StaleTracker::from_ms(parameters.stale_age_ms));
@@ -62,10 +57,10 @@ impl<T: Apply> ProcessBlock for JsonLoadBlock<T> {
 }
 
 impl<T: Apply> IsValid for JsonLoadBlock<T> {
-    fn is_valid(&self, app_time_s: f64) -> OldBlockData {
+    fn is_valid(&self, app_time_s: f64) -> f64 {
         match self.stale_tracker {
             Some(ref tracker) => tracker.is_valid(app_time_s),
-            None => OldBlockData::scalar_from_bool(false),
+            None => 0.0,
         }
     }
 }
@@ -211,7 +206,6 @@ pub trait Apply: Pass {
 
     fn default_storage() -> Self::Storage;
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output>;
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData>;
 }
 
 fn parse_number(num_val: &Number) -> f64 {
@@ -223,10 +217,7 @@ fn parse_number(num_val: &Number) -> f64 {
 }
 
 // Impl for single value
-impl<A: Deserialize> Apply for A
-where
-    OldBlockData: FromPass<A>,
-{
+impl<A: Deserialize> Apply for A {
     type Storage = (A::Storage, bool);
     type Output = (A, bool);
 
@@ -259,21 +250,13 @@ where
         (A::default_storage(), false)
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![OldBlockData::from_pass(A::from_storage(&storage.0))]
-    }
-
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (A::from_storage(&storage.0), storage.1)
     }
 }
 
 // Impl for tuple of two values
-impl<A: Deserialize, B: Deserialize> Apply for (A, B)
-where
-    OldBlockData: FromPass<A>,
-    OldBlockData: FromPass<B>,
-{
+impl<A: Deserialize, B: Deserialize> Apply for (A, B) {
     type Storage = (A::Storage, B::Storage, bool);
     type Output = (A, B, bool);
 
@@ -299,13 +282,6 @@ where
         (A::default_storage(), B::default_storage(), false)
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&storage.0)),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&storage.1)),
-        ]
-    }
-
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (
             A::from_storage(&storage.0),
@@ -316,12 +292,7 @@ where
 }
 
 // Impl for tuple of three values
-impl<A: Deserialize, B: Deserialize, C: Deserialize> Apply for (A, B, C)
-where
-    OldBlockData: FromPass<A>,
-    OldBlockData: FromPass<B>,
-    OldBlockData: FromPass<C>,
-{
+impl<A: Deserialize, B: Deserialize, C: Deserialize> Apply for (A, B, C) {
     type Storage = (A::Storage, B::Storage, C::Storage, bool);
     type Output = (A, B, C, bool);
 
@@ -353,14 +324,6 @@ where
         )
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&storage.0)),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&storage.1)),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&storage.2)),
-        ]
-    }
-
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (
             A::from_storage(&storage.0),
@@ -372,13 +335,7 @@ where
 }
 
 // Impl for tuple of four values
-impl<A: Deserialize, B: Deserialize, C: Deserialize, D: Deserialize> Apply for (A, B, C, D)
-where
-    OldBlockData: FromPass<A>,
-    OldBlockData: FromPass<B>,
-    OldBlockData: FromPass<C>,
-    OldBlockData: FromPass<D>,
-{
+impl<A: Deserialize, B: Deserialize, C: Deserialize, D: Deserialize> Apply for (A, B, C, D) {
     type Storage = (A::Storage, B::Storage, C::Storage, D::Storage, bool);
     type Output = (A, B, C, D, bool);
 
@@ -412,15 +369,6 @@ where
         )
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&storage.0)),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&storage.1)),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&storage.2)),
-            <OldBlockData as FromPass<D>>::from_pass(D::from_storage(&storage.3)),
-        ]
-    }
-
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (
             A::from_storage(&storage.0),
@@ -435,12 +383,6 @@ where
 // Impl for tuple of five values
 impl<A: Deserialize, B: Deserialize, C: Deserialize, D: Deserialize, E: Deserialize> Apply
     for (A, B, C, D, E)
-where
-    OldBlockData: FromPass<A>,
-    OldBlockData: FromPass<B>,
-    OldBlockData: FromPass<C>,
-    OldBlockData: FromPass<D>,
-    OldBlockData: FromPass<E>,
 {
     type Storage = (
         A::Storage,
@@ -484,15 +426,6 @@ where
         )
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&storage.0)),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&storage.1)),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&storage.2)),
-            <OldBlockData as FromPass<D>>::from_pass(D::from_storage(&storage.3)),
-            <OldBlockData as FromPass<E>>::from_pass(E::from_storage(&storage.4)),
-        ]
-    }
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (
             A::from_storage(&storage.0),
@@ -514,13 +447,6 @@ impl<
         E: Deserialize,
         F: Deserialize,
     > Apply for (A, B, C, D, E, F)
-where
-    OldBlockData: FromPass<A>,
-    OldBlockData: FromPass<B>,
-    OldBlockData: FromPass<C>,
-    OldBlockData: FromPass<D>,
-    OldBlockData: FromPass<E>,
-    OldBlockData: FromPass<F>,
 {
     type Storage = (
         A::Storage,
@@ -565,16 +491,6 @@ where
             false,
         )
     }
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&storage.0)),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&storage.1)),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&storage.2)),
-            <OldBlockData as FromPass<D>>::from_pass(D::from_storage(&storage.3)),
-            <OldBlockData as FromPass<E>>::from_pass(E::from_storage(&storage.4)),
-            <OldBlockData as FromPass<F>>::from_pass(F::from_storage(&storage.5)),
-        ]
-    }
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (
             A::from_storage(&storage.0),
@@ -598,14 +514,6 @@ impl<
         F: Deserialize,
         G: Deserialize,
     > Apply for (A, B, C, D, E, F, G)
-where
-    OldBlockData: FromPass<A>,
-    OldBlockData: FromPass<B>,
-    OldBlockData: FromPass<C>,
-    OldBlockData: FromPass<D>,
-    OldBlockData: FromPass<E>,
-    OldBlockData: FromPass<F>,
-    OldBlockData: FromPass<G>,
 {
     type Storage = (
         A::Storage,
@@ -657,18 +565,6 @@ where
         )
     }
 
-    fn build_block_data(storage: &Self::Storage) -> Vec<OldBlockData> {
-        vec![
-            <OldBlockData as FromPass<A>>::from_pass(A::from_storage(&storage.0)),
-            <OldBlockData as FromPass<B>>::from_pass(B::from_storage(&storage.1)),
-            <OldBlockData as FromPass<C>>::from_pass(C::from_storage(&storage.2)),
-            <OldBlockData as FromPass<D>>::from_pass(D::from_storage(&storage.3)),
-            <OldBlockData as FromPass<E>>::from_pass(E::from_storage(&storage.4)),
-            <OldBlockData as FromPass<F>>::from_pass(F::from_storage(&storage.5)),
-            <OldBlockData as FromPass<G>>::from_pass(G::from_storage(&storage.6)),
-        ]
-    }
-
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (
             A::from_storage(&storage.0),
@@ -703,8 +599,7 @@ mod tests {
         let mut block = JsonLoadBlock::<f64>::default();
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (1.2, true));
-        assert_eq!(block.data, vec![OldBlockData::from_scalar(1.2)]);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
         assert_eq!(block.buffer(), res);
     }
 
@@ -737,16 +632,8 @@ mod tests {
         );
 
         assert_eq!(res, expected);
-        assert_eq!(
-            block.data,
-            vec![
-                <OldBlockData as FromPass<f64>>::from_pass(expected.0),
-                <OldBlockData as FromPass<ByteSliceSignal>>::from_pass(expected.1),
-                <OldBlockData as FromPass<Matrix<2, 1, f64>>>::from_pass(expected.2),
-                <OldBlockData as FromPass<Matrix<2, 2, f64>>>::from_pass(expected.3),
-            ]
-        );
-        assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(block.buffer(), expected);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
     }
 
     #[test]
@@ -757,8 +644,8 @@ mod tests {
         let mut block = JsonLoadBlock::<f64>::default();
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (0.0, false));
-        assert_eq!(block.data, vec![OldBlockData::from_scalar(0.0)]);
-        assert!(!block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(block.buffer(), (0.0, false));
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) == 0.0);
     }
 
     #[test]
@@ -769,8 +656,8 @@ mod tests {
         let mut block = JsonLoadBlock::<f64>::default();
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (0.0, false));
-        assert_eq!(block.data, vec![OldBlockData::from_scalar(0.0)]);
-        assert!(!block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(block.buffer(), (0.0, false));
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) == 0.0);
     }
 
     #[test]
@@ -781,8 +668,8 @@ mod tests {
         let mut block = JsonLoadBlock::<f64>::default();
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (0.0, false));
-        assert_eq!(block.data, vec![OldBlockData::from_scalar(0.0)]);
-        assert!(!block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(block.buffer(), (0.0, false));
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) == 0.0);
     }
 
     #[test]
@@ -796,11 +683,8 @@ mod tests {
             data: [[1.0], [2.0], [3.0]],
         };
         assert_eq!(res, (expected, true));
-        assert_eq!(
-            block.data,
-            vec![OldBlockData::from_matrix(&[&[1.0, 2.0, 3.0]])]
-        );
-        assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(block.buffer(), (expected, true));
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
     }
 
     #[test]
@@ -812,8 +696,8 @@ mod tests {
         let res = block.process(&params, &ctxt, input);
         let expected = &Matrix { data: [[]] };
         assert_eq!(res, (expected, true));
-        assert_eq!(block.data, vec![OldBlockData::from_row_slice(0, 1, &[])]);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(block.buffer(), (expected, true));
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
     }
 
     #[test]
@@ -827,11 +711,8 @@ mod tests {
             data: [[1.0, 3.0], [2.0, 4.0]],
         };
         assert_eq!(res, (expected, true));
-        assert_eq!(
-            block.data,
-            vec![OldBlockData::from_matrix(&[&[1.0, 2.0], &[3.0, 4.0]])]
-        );
-        assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(block.buffer(), (expected, true));
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
     }
 
     #[test]
@@ -842,8 +723,8 @@ mod tests {
         let mut block = JsonLoadBlock::<f64>::default();
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (1.0, true));
-        assert_eq!(block.data, vec![OldBlockData::from_scalar(1.0)]);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(block.buffer(), (1.0, true));
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
     }
 
     #[test]
@@ -854,14 +735,8 @@ mod tests {
         let mut block = JsonLoadBlock::<(f64, ByteSliceSignal)>::default();
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (1.0, b"hello".as_slice(), true));
-        assert_eq!(
-            block.data,
-            vec![
-                OldBlockData::from_scalar(1.0),
-                OldBlockData::from_bytes(b"hello"),
-            ]
-        );
-        assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(block.buffer(), (1.0, b"hello".as_slice(), true));
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
     }
 
     #[test]
@@ -878,26 +753,17 @@ mod tests {
         );
         let mut block = JsonLoadBlock::<(f64, ByteSliceSignal, Matrix<1, 2, f64>)>::default();
         let res = block.process(&params, &ctxt, input);
-        assert_eq!(
-            res,
-            (
-                1.0,
-                b"hello".as_slice(),
-                &Matrix {
-                    data: [[1.0], [2.0]]
-                },
-                true
-            )
+        let expected = (
+            1.0,
+            b"hello".as_slice(),
+            &Matrix {
+                data: [[1.0], [2.0]],
+            },
+            true,
         );
-        assert_eq!(
-            block.data,
-            vec![
-                OldBlockData::from_scalar(1.0),
-                OldBlockData::from_bytes(b"hello"),
-                OldBlockData::from_matrix(&[&[1.0, 2.0]]),
-            ]
-        );
-        assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(res, expected);
+        assert_eq!(block.buffer(), expected);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
     }
 
     #[test]
@@ -918,30 +784,20 @@ mod tests {
             JsonLoadBlock::<(f64, ByteSliceSignal, Matrix<1, 2, f64>, Matrix<2, 2, f64>)>::default(
             );
         let res = block.process(&params, &ctxt, input);
-        assert_eq!(
-            res,
-            (
-                1.0,
-                b"hello".as_slice(),
-                &Matrix {
-                    data: [[1.0], [2.0]]
-                },
-                &Matrix {
-                    data: [[1.0, 0.0], [0.0, 1.0]]
-                },
-                true
-            )
+        let expected = (
+            1.0,
+            b"hello".as_slice(),
+            &Matrix {
+                data: [[1.0], [2.0]],
+            },
+            &Matrix {
+                data: [[1.0, 0.0], [0.0, 1.0]],
+            },
+            true,
         );
-        assert_eq!(
-            block.data,
-            vec![
-                OldBlockData::from_scalar(1.0),
-                OldBlockData::from_bytes(b"hello"),
-                OldBlockData::from_matrix(&[&[1.0, 2.0]]),
-                OldBlockData::from_matrix(&[&[1.0, 0.0], &[0.0, 1.0]]),
-            ]
-        );
-        assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(res, expected);
+        assert_eq!(block.buffer(), expected);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
     }
 
     #[test]
@@ -966,32 +822,21 @@ mod tests {
             Matrix<1, 1, f64>,
         )>::default();
         let res = block.process(&params, &ctxt, input);
-        assert_eq!(
-            res,
-            (
-                1.0,
-                b"hello".as_slice(),
-                &Matrix {
-                    data: [[1.0], [2.0]]
-                },
-                &Matrix {
-                    data: [[1.0, 0.0], [0.0, 1.0]]
-                },
-                &Matrix { data: [[1.0]] },
-                true
-            )
+        let expected = (
+            1.0,
+            b"hello".as_slice(),
+            &Matrix {
+                data: [[1.0], [2.0]],
+            },
+            &Matrix {
+                data: [[1.0, 0.0], [0.0, 1.0]],
+            },
+            &Matrix { data: [[1.0]] },
+            true,
         );
-        assert_eq!(
-            block.data,
-            vec![
-                OldBlockData::from_scalar(1.0),
-                OldBlockData::from_bytes(b"hello"),
-                OldBlockData::from_matrix(&[&[1.0, 2.0]]),
-                OldBlockData::from_matrix(&[&[1.0, 0.0], &[0.0, 1.0]]),
-                OldBlockData::from_matrix(&[&[1.0]]),
-            ]
-        );
-        assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(res, expected);
+        assert_eq!(block.buffer(), expected);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
     }
 
     #[test]
@@ -1018,34 +863,22 @@ mod tests {
             Matrix<1, 1, f64>,
         )>::default();
         let res = block.process(&params, &ctxt, input);
-        assert_eq!(
-            res,
-            (
-                1.0,
-                b"hello".as_slice(),
-                &Matrix {
-                    data: [[1.0], [2.0]]
-                },
-                &Matrix {
-                    data: [[1.0, 0.0], [0.0, 1.0]]
-                },
-                &Matrix { data: [[1.0]] },
-                &Matrix { data: [[2.0]] },
-                true
-            )
+        let expected = (
+            1.0,
+            b"hello".as_slice(),
+            &Matrix {
+                data: [[1.0], [2.0]],
+            },
+            &Matrix {
+                data: [[1.0, 0.0], [0.0, 1.0]],
+            },
+            &Matrix { data: [[1.0]] },
+            &Matrix { data: [[2.0]] },
+            true,
         );
-        assert_eq!(
-            block.data,
-            vec![
-                OldBlockData::from_scalar(1.0),
-                OldBlockData::from_bytes(b"hello"),
-                OldBlockData::from_matrix(&[&[1.0, 2.0]]),
-                OldBlockData::from_matrix(&[&[1.0, 0.0], &[0.0, 1.0]]),
-                OldBlockData::from_matrix(&[&[1.0]]),
-                OldBlockData::from_matrix(&[&[2.0]]),
-            ]
-        );
-        assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert_eq!(res, expected);
+        assert_eq!(block.buffer(), expected);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
     }
 
     #[test]
@@ -1104,20 +937,8 @@ mod tests {
         );
 
         assert_eq!(res, expected);
+        assert_eq!(block.buffer(), expected);
 
-        assert_eq!(
-            block.data,
-            vec![
-                OldBlockData::from_scalar(1.0),
-                OldBlockData::from_bytes(b"hello"),
-                OldBlockData::from_matrix(&[&[1.0, 2.0]]),
-                OldBlockData::from_matrix(&[&[1.0, 0.0], &[0.0, 1.0]]),
-                OldBlockData::from_matrix(&[&[1.0]]),
-                OldBlockData::from_matrix(&[&[2.0]]),
-                OldBlockData::from_matrix(&[&[3.0, 4.0], &[5.0, 6.0]]),
-            ]
-        );
-
-        assert!(block.is_valid(ctxt.time().as_secs_f64()).any());
+        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
     }
 }

--- a/pictorus-blocks/src/core_blocks/json_load_block.rs
+++ b/pictorus-blocks/src/core_blocks/json_load_block.rs
@@ -57,10 +57,10 @@ impl<T: Apply> ProcessBlock for JsonLoadBlock<T> {
 }
 
 impl<T: Apply> IsValid for JsonLoadBlock<T> {
-    fn is_valid(&self, app_time_s: f64) -> f64 {
+    fn is_valid(&self, app_time_s: f64) -> bool {
         match self.stale_tracker {
             Some(ref tracker) => tracker.is_valid(app_time_s),
-            None => 0.0,
+            None => false,
         }
     }
 }
@@ -599,7 +599,7 @@ mod tests {
         let mut block = JsonLoadBlock::<f64>::default();
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (1.2, true));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()));
         assert_eq!(block.buffer(), res);
     }
 
@@ -633,7 +633,7 @@ mod tests {
 
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -645,7 +645,7 @@ mod tests {
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (0.0, false));
         assert_eq!(block.buffer(), (0.0, false));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) == 0.0);
+        assert!(!block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -657,7 +657,7 @@ mod tests {
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (0.0, false));
         assert_eq!(block.buffer(), (0.0, false));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) == 0.0);
+        assert!(!block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -669,7 +669,7 @@ mod tests {
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (0.0, false));
         assert_eq!(block.buffer(), (0.0, false));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) == 0.0);
+        assert!(!block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -684,7 +684,7 @@ mod tests {
         };
         assert_eq!(res, (expected, true));
         assert_eq!(block.buffer(), (expected, true));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -697,7 +697,7 @@ mod tests {
         let expected = &Matrix { data: [[]] };
         assert_eq!(res, (expected, true));
         assert_eq!(block.buffer(), (expected, true));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -712,7 +712,7 @@ mod tests {
         };
         assert_eq!(res, (expected, true));
         assert_eq!(block.buffer(), (expected, true));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -724,7 +724,7 @@ mod tests {
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (1.0, true));
         assert_eq!(block.buffer(), (1.0, true));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -736,7 +736,7 @@ mod tests {
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (1.0, b"hello".as_slice(), true));
         assert_eq!(block.buffer(), (1.0, b"hello".as_slice(), true));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -763,7 +763,7 @@ mod tests {
         );
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -797,7 +797,7 @@ mod tests {
         );
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -836,7 +836,7 @@ mod tests {
         );
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -878,7 +878,7 @@ mod tests {
         );
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -939,6 +939,6 @@ mod tests {
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
 
-        assert!(block.is_valid(ctxt.time().as_secs_f64()) != 0.0);
+        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 }

--- a/pictorus-blocks/src/core_blocks/logical_block.rs
+++ b/pictorus-blocks/src/core_blocks/logical_block.rs
@@ -1,6 +1,5 @@
 use core::ops::Sub;
 use num_traits::One;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::traits::{Apply, ApplyInto, MatrixOps, Scalar};
@@ -16,22 +15,18 @@ pub struct LogicalBlock<T>
 where
     T: Apply<Parameters>,
     T::Output: Finalize,
-    OldBlockData: FromPass<<T as Apply<Parameters>>::Output>,
 {
     store: T::Output,
-    pub data: OldBlockData,
 }
 
 impl<T> Default for LogicalBlock<T>
 where
     T: Apply<Parameters>,
     T::Output: Finalize,
-    OldBlockData: FromPass<<T as Apply<Parameters>>::Output>,
 {
     fn default() -> Self {
         Self {
             store: T::Output::default(),
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
         }
     }
 }
@@ -40,7 +35,6 @@ impl<T> ProcessBlock for LogicalBlock<T>
 where
     T: Apply<Parameters>,
     T::Output: Finalize,
-    OldBlockData: FromPass<<T as Apply<Parameters>>::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -55,7 +49,6 @@ where
         T::apply(inputs, parameters, &mut tmp);
         T::Output::finalize(parameters.method, &mut tmp);
         self.store = tmp.expect("apply must initialize the buffer");
-        self.data = OldBlockData::from_pass(self.store.as_by());
         self.store.as_by()
     }
 
@@ -235,23 +228,22 @@ mod tests {
         // All zero aka false inputs = false output
         let res = block.process(&params, &ctxt, (0.0, 0.0, 0.0));
         assert_eq!(res, 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
         assert_eq!(block.buffer(), res);
 
         // Some zero inputs = false output
         let res = block.process(&params, &ctxt, (1.0, 0.0, 1.0));
         assert_eq!(res, 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
 
         // All non-zero inputs = true output
         let res = block.process(&params, &ctxt, (1.0, 1.0, 1.0));
         assert_eq!(res, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
 
         // Even floats and negative data!
         let res = block.process(&params, &ctxt, (1.0, -2.0, 3.5));
         assert_eq!(res, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
     }
 
     #[test]
@@ -263,22 +255,22 @@ mod tests {
         // All zero aka false inputs = false output
         let res = block.process(&params, &ctxt, (0.0, 0.0, 0.0));
         assert_eq!(res, 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
 
         // Some zero inputs = true output
         let res = block.process(&params, &ctxt, (1.0, 0.0, 1.0));
         assert_eq!(res, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
 
         // All non-zero inputs = true output
         let res = block.process(&params, &ctxt, (1.0, 1.0, 1.0));
         assert_eq!(res, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
 
         // Even floats and negative data!
         let res = block.process(&params, &ctxt, (1.0, -2.0, 3.5));
         assert_eq!(res, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
     }
 
     #[test]
@@ -292,23 +284,22 @@ mod tests {
         // All zero aka false inputs = true output
         let res = block.process(&params, &ctxt, (0.0, 0.0, 0.0));
         assert_eq!(res, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
 
         // Some zero inputs = false output
         let res = block.process(&params, &ctxt, (1.0, 0.0, 1.0));
         assert_eq!(res, 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
 
         // All non-zero inputs = false output
         let res = block.process(&params, &ctxt, (1.0, 1.0, 1.0));
         assert_eq!(res, 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
 
         // Even floats and negative data!
         let res = block.process(&params, &ctxt, (1.0, -2.0, 3.5));
         assert_eq!(res, 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
     }
 
     #[test]
@@ -322,22 +313,22 @@ mod tests {
         // All zero aka false inputs = true output
         let res = block.process(&params, &ctxt, (0.0, 0.0, 0.0));
         assert_eq!(res, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
 
         // Some zero inputs = true output
         let res = block.process(&params, &ctxt, (1.0, 0.0, 1.0));
         assert_eq!(res, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
 
         // All non-zero inputs = false output
         let res = block.process(&params, &ctxt, (1.0, 1.0, 1.0));
         assert_eq!(res, 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
 
         // Even floats and negative data!
         let res = block.process(&params, &ctxt, (1.0, -2.0, 3.5));
         assert_eq!(res, 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
     }
 
     #[test]
@@ -364,10 +355,7 @@ mod tests {
             data: [[0.0, 0.0], [0.0, 0.0]],
         };
         assert_eq!(res, &expected);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer(), &expected);
 
         params.method = LogicalMethod::Or;
         let res = block.process(&params, &ctxt, input);
@@ -375,10 +363,7 @@ mod tests {
             data: [[1.0, 1.0], [1.0, 1.0]],
         };
         assert_eq!(res, &expected);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer(), &expected);
 
         params.method = LogicalMethod::Nor;
         let res = block.process(&params, &ctxt, input);
@@ -386,10 +371,7 @@ mod tests {
             data: [[0.0, 0.0], [0.0, 0.0]],
         };
         assert_eq!(res, &expected);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer(), &expected);
 
         params.method = LogicalMethod::Nand;
         let res = block.process(&params, &ctxt, input);
@@ -397,10 +379,7 @@ mod tests {
             data: [[1.0, 1.0], [1.0, 1.0]],
         };
         assert_eq!(res, &expected);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer(), &expected);
     }
 
     #[test]
@@ -421,10 +400,7 @@ mod tests {
             data: [[1.0, 0.0], [0.0, 1.0]],
         };
         assert_eq!(res, &expected);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer(), &expected);
 
         params.method = LogicalMethod::Or;
         let res = block.process(&params, &ctxt, input);
@@ -432,10 +408,7 @@ mod tests {
             data: [[1.0, 1.0], [1.0, 1.0]],
         };
         assert_eq!(res, &expected);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer(), &expected);
 
         params.method = LogicalMethod::Nor;
         let res = block.process(&params, &ctxt, input);
@@ -443,10 +416,7 @@ mod tests {
             data: [[0.0, 0.0], [0.0, 0.0]],
         };
         assert_eq!(res, &expected);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer(), &expected);
 
         params.method = LogicalMethod::Nand;
         let res = block.process(&params, &ctxt, input);
@@ -454,9 +424,6 @@ mod tests {
             data: [[0.0, 1.0], [1.0, 0.0]],
         };
         assert_eq!(res, &expected);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer(), &expected);
     }
 }

--- a/pictorus-blocks/src/core_blocks/lookup_2d_block.rs
+++ b/pictorus-blocks/src/core_blocks/lookup_2d_block.rs
@@ -1,6 +1,5 @@
 use core::marker::PhantomData;
 
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::traits::Float;
@@ -15,15 +14,12 @@ where
     S: Float,
     T: Apply<NX, NY, S>,
 {
-    pub data: OldBlockData,
     buffer: T,
     _unused: PhantomData<S>,
 }
 
 impl<const NX: usize, const NY: usize, S: Float, T: Apply<NX, NY, S>> ProcessBlock
     for Lookup2DBlock<NX, NY, S, T>
-where
-    OldBlockData: FromPass<T>,
 {
     type Inputs = (T, T); // X and Y inputs
     type Output = T; // Output has same type/dimensions as inputs
@@ -36,7 +32,6 @@ where
         inputs: pictorus_traits::PassBy<'_, Self::Inputs>,
     ) -> pictorus_traits::PassBy<'b, Self::Output> {
         let output = T::apply(&mut self.buffer, inputs, parameters);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 
@@ -47,12 +42,9 @@ where
 
 impl<const NX: usize, const NY: usize, S: Float, T: Apply<NX, NY, S>> Default
     for Lookup2DBlock<NX, NY, S, T>
-where
-    OldBlockData: FromPass<T>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T>>::from_pass(T::default().as_by()),
             buffer: T::default(),
             _unused: PhantomData,
         }
@@ -277,7 +269,6 @@ fn nearest_interpolation<const NX: usize, const NY: usize, S: Float>(
 #[cfg(test)]
 mod tests {
     use crate::testing::StubContext;
-    use pictorus_block_data::ToPass;
 
     use super::*;
 
@@ -302,23 +293,16 @@ mod tests {
         let break_points_u1 = [0.0, 1.0, 2.0];
         let break_points_u2 = [0.0, 10.0, 20.0];
 
-        // Create data points as a flattened 3x3 array in row-major order
-        let data_points = OldBlockData::new(
-            3,
-            3,
-            &[
-                0.0, 10.0, 20.0, // First row: x=0
-                10.0, 20.0, 30.0, // Second row: x=1
-                20.0, 30.0, 40.0, // Third row: x=2
-            ],
-        );
+        // Create data points as a 3x3 matrix (column-major storage).
+        // This table is symmetric, so column-major == row-major:
+        //   row x=0: [0, 10, 20]
+        //   row x=1: [10, 20, 30]
+        //   row x=2: [20, 30, 40]
+        let data_points = Matrix {
+            data: [[0.0, 10.0, 20.0], [10.0, 20.0, 30.0], [20.0, 30.0, 40.0]],
+        };
 
-        let params = Parameters::new(
-            "Linear",
-            break_points_u1,
-            break_points_u2,
-            data_points.to_pass(),
-        );
+        let params = Parameters::new("Linear", break_points_u1, break_points_u2, data_points);
 
         let mut block = Lookup2DBlock::<3, 3, f64, f64>::default();
 
@@ -374,15 +358,11 @@ mod tests {
         let break_points_u1 = [0.0, 1.0, 2.0];
         let break_points_u2 = [0.0, 10.0, 20.0];
 
-        let data_points =
-            OldBlockData::new(3, 3, &[0.0, 10.0, 20.0, 10.0, 20.0, 30.0, 20.0, 30.0, 40.0]);
+        let data_points = Matrix {
+            data: [[0.0, 10.0, 20.0], [10.0, 20.0, 30.0], [20.0, 30.0, 40.0]],
+        };
 
-        let params = Parameters::new(
-            "Nearest",
-            break_points_u1,
-            break_points_u2,
-            data_points.to_pass(),
-        );
+        let params = Parameters::new("Nearest", break_points_u1, break_points_u2, data_points);
 
         let mut block = Lookup2DBlock::<3, 3, f64, f64>::default();
 
@@ -419,15 +399,11 @@ mod tests {
         let break_points_u1 = [0.0, 1.0, 2.0];
         let break_points_u2 = [0.0, 10.0, 20.0];
 
-        let data_points =
-            OldBlockData::new(3, 3, &[0.0, 10.0, 20.0, 10.0, 20.0, 30.0, 20.0, 30.0, 40.0]);
+        let data_points = Matrix {
+            data: [[0.0, 10.0, 20.0], [10.0, 20.0, 30.0], [20.0, 30.0, 40.0]],
+        };
 
-        let params = Parameters::new(
-            "Linear",
-            break_points_u1,
-            break_points_u2,
-            data_points.to_pass(),
-        );
+        let params = Parameters::new("Linear", break_points_u1, break_points_u2, data_points);
 
         let mut block = Lookup2DBlock::<3, 3, f64, Matrix<2, 2, f64>>::default();
 
@@ -452,10 +428,7 @@ mod tests {
         };
 
         assert_eq!(res.data, expected.data);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer().data, expected.data);
     }
 
     #[test]
@@ -466,15 +439,11 @@ mod tests {
         let break_points_u1 = [0.0, 1.0, 2.0];
         let break_points_u2 = [0.0, 10.0, 20.0];
 
-        let data_points =
-            OldBlockData::new(3, 3, &[0.0, 10.0, 20.0, 10.0, 20.0, 30.0, 20.0, 30.0, 40.0]);
+        let data_points = Matrix {
+            data: [[0.0, 10.0, 20.0], [10.0, 20.0, 30.0], [20.0, 30.0, 40.0]],
+        };
 
-        let params = Parameters::new(
-            "Nearest",
-            break_points_u1,
-            break_points_u2,
-            data_points.to_pass(),
-        );
+        let params = Parameters::new("Nearest", break_points_u1, break_points_u2, data_points);
 
         let mut block = Lookup2DBlock::<3, 3, f64, Matrix<2, 2, f64>>::default();
 
@@ -499,9 +468,6 @@ mod tests {
         };
 
         assert_eq!(res.data, expected.data);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer().data, expected.data);
     }
 }

--- a/pictorus-blocks/src/core_blocks/matrix_inverse_block.rs
+++ b/pictorus-blocks/src/core_blocks/matrix_inverse_block.rs
@@ -3,7 +3,6 @@ use nalgebra::{
     allocator::Allocator, ArrayStorage, Const, DefaultAllocator, DimDiff, DimMin, DimMinimum,
     DimSub, SMatrix, SquareMatrix, ToTypenum, SVD, U1,
 };
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::traits::{Float, Scalar};
@@ -40,7 +39,6 @@ impl Parameters {
 /// The output type of the block is a tuple of (<input_type>, bool), where the
 /// bool indicates whether the inversion was successful.
 pub struct MatrixInverseBlock<T: Apply<M>, M: Method> {
-    pub data: OldBlockData,
     store: T::Output,
     is_data_valid: bool,
 }
@@ -49,11 +47,9 @@ impl<T, M> Default for MatrixInverseBlock<T, M>
 where
     M: Method,
     T: Apply<M>,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
             store: <T::Output>::default(),
             is_data_valid: false,
         }
@@ -64,7 +60,6 @@ impl<T, M> ProcessBlock for MatrixInverseBlock<T, M>
 where
     M: Method,
     T: Apply<M>,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = (T::Output, bool);
@@ -87,7 +82,6 @@ where
             }
         }
         let output = self.store.as_by();
-        self.data = OldBlockData::from_pass(output);
         (output, self.is_data_valid)
     }
 
@@ -96,10 +90,9 @@ where
     }
 }
 
-// TODO: Remove when we remove BlockData
 impl<T: Apply<M>, M: Method> IsValid for MatrixInverseBlock<T, M> {
-    fn is_valid(&self, _: f64) -> OldBlockData {
-        OldBlockData::scalar_from_bool(self.is_data_valid)
+    fn is_valid(&self, _: f64) -> f64 {
+        f64::from(self.is_data_valid)
     }
 }
 
@@ -185,8 +178,7 @@ mod tests {
         let mut block = MatrixInverseBlock::<f64, Inverse>::default();
         let res = block.process(&params, &ctxt, 99.0);
         assert_eq!(res, (99.0, true));
-        assert_eq!(block.data.scalar(), 99.0);
-        assert!(block.is_valid(0.0).any());
+        assert!(block.is_valid(0.0) != 0.0);
         assert_eq!(block.buffer(), res);
     }
 
@@ -203,8 +195,8 @@ mod tests {
         assert_eq!(res.0.data, expected);
         assert!(res.1);
 
-        assert_eq!(block.data.get_data().as_slice(), expected.as_flattened());
-        assert!(block.is_valid(0.0).any());
+        assert_eq!(block.buffer().0.data, expected);
+        assert!(block.is_valid(0.0) != 0.0);
     }
 
     #[test]
@@ -222,11 +214,8 @@ mod tests {
         assert_eq!(res.0.data, expected,);
         assert!(!res.1);
 
-        assert_eq!(
-            invert_block.data.get_data().as_slice(),
-            expected.as_flattened()
-        );
-        assert!(!invert_block.is_valid(0.0).any());
+        assert_eq!(invert_block.buffer().0.data, expected);
+        assert!(invert_block.is_valid(0.0) == 0.0);
 
         // SVD-based pseudo-inverse method should be fine
         let mut svd_block = MatrixInverseBlock::<Matrix<3, 3, f64>, Svd>::default();
@@ -244,11 +233,11 @@ mod tests {
         assert!(res.1);
 
         assert_abs_diff_eq!(
-            svd_block.data.get_data().as_slice(),
+            svd_block.buffer().0.data.as_flattened(),
             expected.as_flattened(),
             epsilon = 1e-8
         );
-        assert!(svd_block.is_valid(0.0).any());
+        assert!(svd_block.is_valid(0.0) != 0.0);
     }
 
     #[test]
@@ -276,7 +265,7 @@ mod tests {
             epsilon = 1e-8
         );
         assert!(res.1);
-        assert!(block.is_valid(0.0).any());
+        assert!(block.is_valid(0.0) != 0.0);
     }
 
     #[test]
@@ -303,6 +292,6 @@ mod tests {
             epsilon = 1e-8
         );
         assert!(res.1);
-        assert!(block.is_valid(0.0).any());
+        assert!(block.is_valid(0.0) != 0.0);
     }
 }

--- a/pictorus-blocks/src/core_blocks/matrix_inverse_block.rs
+++ b/pictorus-blocks/src/core_blocks/matrix_inverse_block.rs
@@ -91,8 +91,8 @@ where
 }
 
 impl<T: Apply<M>, M: Method> IsValid for MatrixInverseBlock<T, M> {
-    fn is_valid(&self, _: f64) -> f64 {
-        f64::from(self.is_data_valid)
+    fn is_valid(&self, _: f64) -> bool {
+        self.is_data_valid
     }
 }
 
@@ -178,7 +178,7 @@ mod tests {
         let mut block = MatrixInverseBlock::<f64, Inverse>::default();
         let res = block.process(&params, &ctxt, 99.0);
         assert_eq!(res, (99.0, true));
-        assert!(block.is_valid(0.0) != 0.0);
+        assert!(block.is_valid(0.0));
         assert_eq!(block.buffer(), res);
     }
 
@@ -196,7 +196,7 @@ mod tests {
         assert!(res.1);
 
         assert_eq!(block.buffer().0.data, expected);
-        assert!(block.is_valid(0.0) != 0.0);
+        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -215,7 +215,7 @@ mod tests {
         assert!(!res.1);
 
         assert_eq!(invert_block.buffer().0.data, expected);
-        assert!(invert_block.is_valid(0.0) == 0.0);
+        assert!(!invert_block.is_valid(0.0));
 
         // SVD-based pseudo-inverse method should be fine
         let mut svd_block = MatrixInverseBlock::<Matrix<3, 3, f64>, Svd>::default();
@@ -237,7 +237,7 @@ mod tests {
             expected.as_flattened(),
             epsilon = 1e-8
         );
-        assert!(svd_block.is_valid(0.0) != 0.0);
+        assert!(svd_block.is_valid(0.0));
     }
 
     #[test]
@@ -265,7 +265,7 @@ mod tests {
             epsilon = 1e-8
         );
         assert!(res.1);
-        assert!(block.is_valid(0.0) != 0.0);
+        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -292,6 +292,6 @@ mod tests {
             epsilon = 1e-8
         );
         assert!(res.1);
-        assert!(block.is_valid(0.0) != 0.0);
+        assert!(block.is_valid(0.0));
     }
 }

--- a/pictorus-blocks/src/core_blocks/min_max_block.rs
+++ b/pictorus-blocks/src/core_blocks/min_max_block.rs
@@ -1,7 +1,6 @@
 use crate::matrix_ext::MatrixNalgebraExt;
 use crate::traits::{Apply, ApplyInto, MatrixOps, Scalar};
 use nalgebra::SMatrix;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 #[derive(strum::EnumString, Copy, Clone)]
@@ -30,30 +29,19 @@ impl Parameters {
 ///
 /// If inputs are all scalars, the output will be a scalar
 /// Otherwise the output will be the component-wise minimum or maximum of the inputs
-pub struct MinMaxBlock<T: Apply<Parameters>>
-where
-    OldBlockData: FromPass<<T as Apply<Parameters>>::Output>,
-{
-    pub data: OldBlockData,
+pub struct MinMaxBlock<T: Apply<Parameters>> {
     buffer: T::Output,
 }
 
-impl<T: Apply<Parameters>> Default for MinMaxBlock<T>
-where
-    OldBlockData: FromPass<<T as Apply<Parameters>>::Output>,
-{
+impl<T: Apply<Parameters>> Default for MinMaxBlock<T> {
     fn default() -> Self {
         MinMaxBlock {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
             buffer: T::Output::default(),
         }
     }
 }
 
-impl<T: Apply<Parameters>> ProcessBlock for MinMaxBlock<T>
-where
-    OldBlockData: FromPass<T::Output>,
-{
+impl<T: Apply<Parameters>> ProcessBlock for MinMaxBlock<T> {
     type Parameters = Parameters;
     type Inputs = T;
     type Output = T::Output;
@@ -67,7 +55,6 @@ where
         let mut tmp: Option<T::Output> = None;
         T::apply(inputs, parameters, &mut tmp);
         self.buffer = tmp.expect("apply must initialize the buffer");
-        self.data = OldBlockData::from_pass(self.buffer.as_by());
         self.buffer.as_by()
     }
 
@@ -186,13 +173,11 @@ mod tests {
         let input = 99.0;
         let res = block.process(&parameters, &ctxt, input);
         assert_eq!(res, 99.0);
-        assert_eq!(block.data.scalar(), 99.0);
         assert_eq!(block.buffer(), res);
 
         parameters.method = MinMaxMethod::Max;
         let res = block.process(&parameters, &ctxt, input.as_by());
         assert_eq!(res, 99.0);
-        assert_eq!(block.data.scalar(), 99.0);
     }
 
     #[test]
@@ -203,12 +188,12 @@ mod tests {
         let input = Matrix::<2, 2, f64>::from_element(99.0);
         let res = block.process(&parameters, &ctxt, &input);
         assert_eq!(res.data.as_flattened(), [99.0, 99.0, 99.0, 99.0]);
-        assert_eq!(block.data.get_data().as_slice(), [99.0, 99.0, 99.0, 99.0]);
+        assert_eq!(block.buffer().data.as_flattened(), [99.0, 99.0, 99.0, 99.0]);
 
         parameters.method = MinMaxMethod::Max;
         let res = block.process(&parameters, &ctxt, &input);
         assert_eq!(res.data.as_flattened(), [99.0, 99.0, 99.0, 99.0]);
-        assert_eq!(block.data.get_data().as_slice(), [99.0, 99.0, 99.0, 99.0]);
+        assert_eq!(block.buffer().data.as_flattened(), [99.0, 99.0, 99.0, 99.0]);
     }
 
     #[test]
@@ -221,12 +206,12 @@ mod tests {
         let input = (99.0, 100.0);
         let res = two_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 99.0);
-        assert_eq!(two_block.data.scalar(), 99.0);
+        assert_eq!(two_block.buffer(), 99.0);
 
         parameters.method = MinMaxMethod::Max;
         let res = two_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 100.0);
-        assert_eq!(two_block.data.scalar(), 100.0);
+        assert_eq!(two_block.buffer(), 100.0);
 
         // Three inputs
         parameters.method = MinMaxMethod::Min;
@@ -234,12 +219,12 @@ mod tests {
         let input = (99.0, 100.0, 101.0);
         let res = three_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 99.0);
-        assert_eq!(three_block.data.scalar(), 99.0);
+        assert_eq!(three_block.buffer(), 99.0);
 
         parameters.method = MinMaxMethod::Max;
         let res = three_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 101.0);
-        assert_eq!(three_block.data.scalar(), 101.0);
+        assert_eq!(three_block.buffer(), 101.0);
 
         // Four inputs
         parameters.method = MinMaxMethod::Min;
@@ -247,12 +232,12 @@ mod tests {
         let input = (99.0, 100.0, 101.0, 102.0);
         let res = four_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 99.0);
-        assert_eq!(four_block.data.scalar(), 99.0);
+        assert_eq!(four_block.buffer(), 99.0);
 
         parameters.method = MinMaxMethod::Max;
         let res = four_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 102.0);
-        assert_eq!(four_block.data.scalar(), 102.0);
+        assert_eq!(four_block.buffer(), 102.0);
 
         // Five inputs
         parameters.method = MinMaxMethod::Min;
@@ -260,12 +245,12 @@ mod tests {
         let input = (99.0, 100.0, 101.0, 102.0, 103.0);
         let res = five_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 99.0);
-        assert_eq!(five_block.data.scalar(), 99.0);
+        assert_eq!(five_block.buffer(), 99.0);
 
         parameters.method = MinMaxMethod::Max;
         let res = five_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 103.0);
-        assert_eq!(five_block.data.scalar(), 103.0);
+        assert_eq!(five_block.buffer(), 103.0);
 
         // Six inputs
         parameters.method = MinMaxMethod::Min;
@@ -273,12 +258,12 @@ mod tests {
         let input = (99.0, 100.0, 101.0, 102.0, 103.0, 104.0);
         let res = six_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 99.0);
-        assert_eq!(six_block.data.scalar(), 99.0);
+        assert_eq!(six_block.buffer(), 99.0);
 
         parameters.method = MinMaxMethod::Max;
         let res = six_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 104.0);
-        assert_eq!(six_block.data.scalar(), 104.0);
+        assert_eq!(six_block.buffer(), 104.0);
 
         // Seven inputs
         parameters.method = MinMaxMethod::Min;
@@ -286,12 +271,12 @@ mod tests {
         let input = (99.0, 100.0, 101.0, 102.0, 103.0, 104.0, 105.0);
         let res = seven_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 99.0);
-        assert_eq!(seven_block.data.scalar(), 99.0);
+        assert_eq!(seven_block.buffer(), 99.0);
 
         parameters.method = MinMaxMethod::Max;
         let res = seven_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 105.0);
-        assert_eq!(seven_block.data.scalar(), 105.0);
+        assert_eq!(seven_block.buffer(), 105.0);
 
         // Eight inputs
         parameters.method = MinMaxMethod::Min;
@@ -299,12 +284,12 @@ mod tests {
         let input = (99.0, 100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0);
         let res = eight_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 99.0);
-        assert_eq!(eight_block.data.scalar(), 99.0);
+        assert_eq!(eight_block.buffer(), 99.0);
 
         parameters.method = MinMaxMethod::Max;
         let res = eight_block.process(&parameters, &ctxt, input);
         assert_eq!(res, 106.0);
-        assert_eq!(eight_block.data.scalar(), 106.0);
+        assert_eq!(eight_block.buffer(), 106.0);
     }
 
     #[test]
@@ -324,12 +309,12 @@ mod tests {
         );
         let res = two_block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [1.0, 2.0, 3.0, 4.0]);
-        assert_eq!(two_block.data.get_data().as_slice(), [1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(two_block.buffer().data.as_flattened(), [1.0, 2.0, 3.0, 4.0]);
 
         parameters.method = MinMaxMethod::Max;
         let res = two_block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [5.0, 6.0, 7.0, 8.0]);
-        assert_eq!(two_block.data.get_data().as_slice(), [5.0, 6.0, 7.0, 8.0]);
+        assert_eq!(two_block.buffer().data.as_flattened(), [5.0, 6.0, 7.0, 8.0]);
 
         // Three inputs
         parameters.method = MinMaxMethod::Min;
@@ -348,13 +333,16 @@ mod tests {
         );
         let res = three_block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [1.0, 2.0, 3.0, 4.0]);
-        assert_eq!(three_block.data.get_data().as_slice(), [1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(
+            three_block.buffer().data.as_flattened(),
+            [1.0, 2.0, 3.0, 4.0]
+        );
 
         parameters.method = MinMaxMethod::Max;
         let res = three_block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [9.0, 10.0, 11.0, 12.0]);
         assert_eq!(
-            three_block.data.get_data().as_slice(),
+            three_block.buffer().data.as_flattened(),
             [9.0, 10.0, 11.0, 12.0]
         );
 
@@ -382,13 +370,16 @@ mod tests {
         );
         let res = four_block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [1.0, 2.0, 3.0, 4.0]);
-        assert_eq!(four_block.data.get_data().as_slice(), [1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(
+            four_block.buffer().data.as_flattened(),
+            [1.0, 2.0, 3.0, 4.0]
+        );
 
         parameters.method = MinMaxMethod::Max;
         let res = four_block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [13.0, 14.0, 15.0, 16.0]);
         assert_eq!(
-            four_block.data.get_data().as_slice(),
+            four_block.buffer().data.as_flattened(),
             [13.0, 14.0, 15.0, 16.0]
         );
     }
@@ -403,12 +394,12 @@ mod tests {
         let input = (99.0, &Matrix::from_element(1.0));
         let res = block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [1.0, 1.0, 1.0, 1.0]);
-        assert_eq!(block.data.get_data().as_slice(), [1.0, 1.0, 1.0, 1.0]);
+        assert_eq!(block.buffer().data.as_flattened(), [1.0, 1.0, 1.0, 1.0]);
 
         parameters.method = MinMaxMethod::Max;
         let res = block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [99.0, 99.0, 99.0, 99.0]);
-        assert_eq!(block.data.get_data().as_slice(), [99.0, 99.0, 99.0, 99.0]);
+        assert_eq!(block.buffer().data.as_flattened(), [99.0, 99.0, 99.0, 99.0]);
 
         // Matrix and scalar
         let mut block = MinMaxBlock::<(Matrix<2, 2, f64>, f64)>::default();
@@ -416,12 +407,12 @@ mod tests {
         let input = (&Matrix::from_element(1.0), 99.0);
         let res = block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [1.0, 1.0, 1.0, 1.0]);
-        assert_eq!(block.data.get_data().as_slice(), [1.0, 1.0, 1.0, 1.0]);
+        assert_eq!(block.buffer().data.as_flattened(), [1.0, 1.0, 1.0, 1.0]);
 
         parameters.method = MinMaxMethod::Max;
         let res = block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [99.0, 99.0, 99.0, 99.0]);
-        assert_eq!(block.data.get_data().as_slice(), [99.0, 99.0, 99.0, 99.0]);
+        assert_eq!(block.buffer().data.as_flattened(), [99.0, 99.0, 99.0, 99.0]);
 
         // (Scalar, matrix, scalar)
         let mut block = MinMaxBlock::<(f64, Matrix<2, 2, f64>, f64)>::default();
@@ -429,13 +420,13 @@ mod tests {
         let input = (99.0, &Matrix::from_element(1.0), 100.0);
         let res = block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [1.0, 1.0, 1.0, 1.0]);
-        assert_eq!(block.data.get_data().as_slice(), [1.0, 1.0, 1.0, 1.0]);
+        assert_eq!(block.buffer().data.as_flattened(), [1.0, 1.0, 1.0, 1.0]);
 
         parameters.method = MinMaxMethod::Max;
         let res = block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [100.0, 100.0, 100.0, 100.0]);
         assert_eq!(
-            block.data.get_data().as_slice(),
+            block.buffer().data.as_flattened(),
             [100.0, 100.0, 100.0, 100.0]
         );
 
@@ -445,11 +436,11 @@ mod tests {
         let input = (&Matrix::from_element(1.0), 99.0, &Matrix::from_element(2.0));
         let res = block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [1.0, 1.0, 1.0, 1.0]);
-        assert_eq!(block.data.get_data().as_slice(), [1.0, 1.0, 1.0, 1.0]);
+        assert_eq!(block.buffer().data.as_flattened(), [1.0, 1.0, 1.0, 1.0]);
 
         parameters.method = MinMaxMethod::Max;
         let res = block.process(&parameters, &ctxt, input);
         assert_eq!(res.data.as_flattened(), [99.0, 99.0, 99.0, 99.0]);
-        assert_eq!(block.data.get_data().as_slice(), [99.0, 99.0, 99.0, 99.0]);
+        assert_eq!(block.buffer().data.as_flattened(), [99.0, 99.0, 99.0, 99.0]);
     }
 }

--- a/pictorus-blocks/src/core_blocks/pid_block.rs
+++ b/pictorus-blocks/src/core_blocks/pid_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{HasIc, Matrix, Pass, PassBy, ProcessBlock};
 
 use super::derivative_block::Parameters as DerivativeParameters;
@@ -17,10 +16,8 @@ use crate::{DerivativeBlock, IntegralBlock, Scalar};
 /// integrator.
 pub struct PidBlock<T: ComponentOps, R: Scalar, const ND_SAMPLES: usize>
 where
-    OldBlockData: FromPass<T>,
     (T, R): IntegralApply<Output = T>,
 {
-    pub data: OldBlockData,
     buffer: T,
     integrator: IntegralBlock<(T, R)>,
     derivative: DerivativeBlock<T, ND_SAMPLES>,
@@ -28,7 +25,6 @@ where
 
 impl<T: ComponentOps, R: Scalar, const ND_SAMPLES: usize> Default for PidBlock<T, R, ND_SAMPLES>
 where
-    OldBlockData: FromPass<T>,
     (T, R): IntegralApply<Output = T>,
 {
     fn default() -> Self {
@@ -70,7 +66,6 @@ impl<T: IntegralApply> Parameters<T> {
 
 impl<T: ComponentOps, R: Scalar, const ND_SAMPLES: usize> PidBlock<T, R, ND_SAMPLES>
 where
-    OldBlockData: FromPass<T>,
     (T, R): IntegralApply<Output = T, Float = T::Float>,
 {
     fn integrator_params(parameters: &Parameters<(T, R)>) -> IntegralParameters<(T, R)> {
@@ -88,7 +83,6 @@ where
 impl<T: ComponentOps, R: Scalar, const ND_SAMPLES: usize> ProcessBlock
     for PidBlock<T, R, ND_SAMPLES>
 where
-    OldBlockData: FromPass<T>,
     DerivativeBlock<T, ND_SAMPLES>:
         ProcessBlock<Output = T, Inputs = T, Parameters = DerivativeParameters<T>>,
     IntegralBlock<(T, R)>:
@@ -127,7 +121,6 @@ where
         let d = T::component_mul(d_res, parameters.kd);
         self.buffer = T::component_add(p.as_by(), i, d.as_by());
 
-        self.data = OldBlockData::from_pass(self.buffer.as_by());
         self.buffer.as_by()
     }
 
@@ -146,7 +139,6 @@ impl<const ND_SAMPLES: usize, R: Scalar> HasIc for PidBlock<f64, R, ND_SAMPLES> 
         let integrator_params = Self::integrator_params(parameters);
         let derivative_params = Self::derivative_params(parameters);
         Self {
-            data: OldBlockData::from_scalar(parameters.ic),
             buffer: parameters.ic,
             integrator: IntegralBlock::new(&integrator_params),
             derivative: DerivativeBlock::new(&derivative_params),
@@ -156,14 +148,11 @@ impl<const ND_SAMPLES: usize, R: Scalar> HasIc for PidBlock<f64, R, ND_SAMPLES> 
 
 impl<const ND_SAMPLES: usize, const NROWS: usize, const NCOLS: usize, R: Scalar> HasIc
     for PidBlock<Matrix<NROWS, NCOLS, f64>, R, ND_SAMPLES>
-where
-    OldBlockData: FromPass<Matrix<NROWS, NCOLS, f64>>,
 {
     fn new(parameters: &Self::Parameters) -> Self {
         let integrator_params = Self::integrator_params(parameters);
         let derivative_params = Self::derivative_params(parameters);
         Self {
-            data: OldBlockData::from_pass(parameters.ic.as_by()),
             buffer: parameters.ic,
             integrator: IntegralBlock::new(&integrator_params),
             derivative: DerivativeBlock::new(&derivative_params),
@@ -231,13 +220,12 @@ mod tests {
         // Output should just be double the input
         let res = p_block.process(&params, &runtime.context(), (1.0, false));
         assert_eq!(res, 2.0);
-        assert_eq!(p_block.data.scalar(), 2.0);
         assert_eq!(p_block.buffer(), res);
         runtime.tick();
 
         let res = p_block.process(&params, &runtime.context(), (-2.0, false));
         assert_eq!(res, -4.0);
-        assert_eq!(p_block.data.scalar(), -4.0);
+        assert_eq!(p_block.buffer(), -4.0);
     }
 
     #[test]
@@ -253,31 +241,31 @@ mod tests {
 
         let res = i_block.process(&params, &runtime.context(), (0.0, false));
         assert_eq!(res, 0.0);
-        assert_eq!(i_block.data.scalar(), 0.0);
+        assert_eq!(i_block.buffer(), 0.0);
         runtime.tick();
 
         i_block.process(&params, &runtime.context(), (0.0, false));
         let res = i_block.process(&params, &runtime.context(), (1.0, false));
         assert_relative_eq!(res, 3.0, max_relative = 0.01);
-        assert_relative_eq!(i_block.data.scalar(), 3.0, max_relative = 0.01);
+        assert_relative_eq!(i_block.buffer(), 3.0, max_relative = 0.01);
         runtime.tick();
 
         // Make sure it actually integrates
         let res = i_block.process(&params, &runtime.context(), (1.0, false));
         assert_relative_eq!(res, 6.0, max_relative = 0.01);
-        assert_relative_eq!(i_block.data.scalar(), 6.0, max_relative = 0.01);
+        assert_relative_eq!(i_block.buffer(), 6.0, max_relative = 0.01);
         runtime.tick();
 
         // Check saturation
         let res = i_block.process(&params, &runtime.context(), (100.0, false));
         assert_relative_eq!(res, 10.0, max_relative = 0.01);
-        assert_relative_eq!(i_block.data.scalar(), 10.0, max_relative = 0.01);
+        assert_relative_eq!(i_block.buffer(), 10.0, max_relative = 0.01);
         runtime.tick();
 
         // Test reset
         let res = i_block.process(&params, &runtime.context(), (1.0, true));
         assert_relative_eq!(res, 0.0, max_relative = 0.01);
-        assert_relative_eq!(i_block.data.scalar(), 0.0, max_relative = 0.01);
+        assert_relative_eq!(i_block.buffer(), 0.0, max_relative = 0.01);
     }
 
     #[test]
@@ -295,7 +283,7 @@ mod tests {
 
         let res = d_block.process(&params, &runtime.context(), (100.0, false));
         assert_relative_eq!(res, 200.0, max_relative = 0.01);
-        assert_relative_eq!(d_block.data.scalar(), 200.0, max_relative = 0.01);
+        assert_relative_eq!(d_block.buffer(), 200.0, max_relative = 0.01);
     }
     #[test]
     fn test_pid_scalar() {
@@ -314,7 +302,7 @@ mod tests {
         // p: 2, i: 4, d: 6
         let res = block.process(&params, &runtime.context(), (2.0, false));
         assert_relative_eq!(res, 12.0, max_relative = 0.01);
-        assert_relative_eq!(block.data.scalar(), 12.0, max_relative = 0.01);
+        assert_relative_eq!(block.buffer(), 12.0, max_relative = 0.01);
     }
 
     #[test]
@@ -334,7 +322,7 @@ mod tests {
         // p: 2, i: 5 + 4 = 9, d: 6
         let res = block.process(&params, &runtime.context(), (2.0, false));
         assert_relative_eq!(res, 17.0, max_relative = 0.01);
-        assert_relative_eq!(block.data.scalar(), 17.0, max_relative = 0.01);
+        assert_relative_eq!(block.buffer(), 17.0, max_relative = 0.01);
     }
 
     #[test]
@@ -356,7 +344,7 @@ mod tests {
         };
         assert_eq!(res, &expected);
         assert_eq!(
-            p_block.data.get_data().as_slice(),
+            p_block.buffer().data.as_flattened(),
             expected.data.as_flattened()
         );
         runtime.tick();
@@ -370,7 +358,7 @@ mod tests {
         };
         assert_eq!(res, &expected);
         assert_eq!(
-            p_block.data.get_data().as_slice(),
+            p_block.buffer().data.as_flattened(),
             expected.data.as_flattened()
         );
     }
@@ -395,7 +383,7 @@ mod tests {
         };
         assert_eq!(res, &expected);
         assert_eq!(
-            i_block.data.get_data().as_slice(),
+            i_block.buffer().data.as_flattened(),
             expected.data.as_flattened()
         );
         runtime.tick();
@@ -409,7 +397,7 @@ mod tests {
         };
         assert_eq!(res, &expected);
         assert_eq!(
-            i_block.data.get_data().as_slice(),
+            i_block.buffer().data.as_flattened(),
             expected.data.as_flattened()
         );
         runtime.tick();
@@ -424,7 +412,7 @@ mod tests {
         };
         assert_eq!(res, &expected);
         assert_eq!(
-            i_block.data.get_data().as_slice(),
+            i_block.buffer().data.as_flattened(),
             expected.data.as_flattened()
         );
         runtime.tick();
@@ -439,7 +427,7 @@ mod tests {
         };
         assert_eq!(res, &expected);
         assert_eq!(
-            i_block.data.get_data().as_slice(),
+            i_block.buffer().data.as_flattened(),
             expected.data.as_flattened()
         );
         runtime.tick();
@@ -467,7 +455,7 @@ mod tests {
         };
         assert_eq!(res, &expected);
         assert_eq!(
-            d_block.data.get_data().as_slice(),
+            d_block.buffer().data.as_flattened(),
             expected.data.as_flattened()
         );
     }
@@ -491,7 +479,7 @@ mod tests {
         };
         assert_eq!(res, &expected);
         assert_eq!(
-            block.data.get_data().as_slice(),
+            block.buffer().data.as_flattened(),
             expected.data.as_flattened()
         );
         runtime.tick();
@@ -505,7 +493,7 @@ mod tests {
         };
         assert_eq!(res, &expected);
         assert_eq!(
-            block.data.get_data().as_slice(),
+            block.buffer().data.as_flattened(),
             expected.data.as_flattened()
         );
     }
@@ -532,7 +520,7 @@ mod tests {
         };
         assert_eq!(res, &expected);
         assert_eq!(
-            block.data.get_data().as_slice(),
+            block.buffer().data.as_flattened(),
             expected.data.as_flattened()
         );
         runtime.tick();
@@ -548,7 +536,7 @@ mod tests {
         };
         assert_eq!(res, &expected);
         assert_eq!(
-            block.data.get_data().as_slice(),
+            block.buffer().data.as_flattened(),
             expected.data.as_flattened()
         );
     }

--- a/pictorus-blocks/src/core_blocks/product_block.rs
+++ b/pictorus-blocks/src/core_blocks/product_block.rs
@@ -1,5 +1,4 @@
 use core::marker::PhantomData;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Pass, PassBy, ProcessBlock};
 
 // This Block is essentially two blocks hiding in a trench coat; Matrix Multiplication and Component Wise Multiplication.
@@ -17,26 +16,18 @@ use matrix::{ApplyMatMul, ParametersMatrixMult};
 pub struct ProductBlock<T: Apply<M>, M: ProductMethod> {
     _method: PhantomData<M>,
     store: T::Output,
-    pub data: OldBlockData,
 }
 
-impl<T: Apply<M>, M: ProductMethod> Default for ProductBlock<T, M>
-where
-    OldBlockData: FromPass<T::Output>,
-{
+impl<T: Apply<M>, M: ProductMethod> Default for ProductBlock<T, M> {
     fn default() -> Self {
         Self {
             _method: PhantomData,
             store: T::Output::default(),
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
         }
     }
 }
 
-impl<T: Apply<M>, M: ProductMethod> ProcessBlock for ProductBlock<T, M>
-where
-    OldBlockData: FromPass<T::Output>,
-{
+impl<T: Apply<M>, M: ProductMethod> ProcessBlock for ProductBlock<T, M> {
     type Inputs = T;
     type Output = T::Output;
     type Parameters = T::Parameters;
@@ -50,7 +41,6 @@ where
         let mut tmp: Option<T::Output> = None;
         T::apply(&mut tmp, parameters, inputs);
         self.store = tmp.expect("apply must initialize the buffer");
-        self.data = OldBlockData::from_pass(self.store.as_by());
         self.store.as_by()
     }
 
@@ -130,7 +120,6 @@ mod tests {
         let output = block.process(&parameters, &context, (11.0, 2.0));
 
         assert_eq!(output, 22.0);
-        assert_eq!(block.data.scalar(), 22.0);
         assert_eq!(block.buffer(), output);
 
         let mut block = ProductBlock::<(f32, f32, f32, f32, f32), ComponentWise>::default();
@@ -138,7 +127,6 @@ mod tests {
         let output = block.process(&parameters, &context, (11.0, 2.0, 3.0, 4.0, 5.0));
 
         assert_eq!(output, 82.5);
-        assert_eq!(block.data.scalar(), 82.5);
     }
     #[test]
     fn test_component_wise_scalar_matrix_mixed() {
@@ -163,10 +151,7 @@ mod tests {
         };
 
         assert_eq!(output, &expected);
-        assert_eq!(
-            block.data,
-            <OldBlockData as FromPass<Matrix<2, 2, f64>>>::from_pass(&expected)
-        );
+        assert_eq!(block.buffer(), &expected);
     }
 
     #[test]
@@ -195,10 +180,7 @@ mod tests {
         };
 
         assert_eq!(output, &expected);
-        assert_eq!(
-            block.data,
-            <OldBlockData as FromPass<Matrix<2, 2, f64>>>::from_pass(&expected)
-        );
+        assert_eq!(block.buffer(), &expected);
     }
 
     #[test]
@@ -225,10 +207,7 @@ mod tests {
         };
 
         assert_eq!(output, &expected);
-        assert_eq!(
-            block.data,
-            <OldBlockData as FromPass<Matrix<2, 2, f64>>>::from_pass(&expected)
-        );
+        assert_eq!(block.buffer(), &expected);
 
         let mut block = ProductBlock::<
             (Matrix<4, 2, f64>, Matrix<2, 3, f64>, Matrix<3, 2, f64>),
@@ -257,9 +236,6 @@ mod tests {
         };
 
         assert_eq!(output, &expected);
-        assert_eq!(
-            block.data,
-            <OldBlockData as FromPass<Matrix<4, 2, f64>>>::from_pass(&expected)
-        );
+        assert_eq!(block.buffer(), &expected);
     }
 }

--- a/pictorus-blocks/src/core_blocks/serial_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/serial_receive_block.rs
@@ -3,7 +3,6 @@ use alloc::vec::Vec;
 use core::{cmp::min, str};
 
 use log::debug;
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, Context, PassBy, ProcessBlock};
 
 use crate::{
@@ -66,7 +65,6 @@ impl Parameters {
 /// data is received before the specified expiration period elapses.
 /// The block caches data until a new message is received and parsed.
 pub struct SerialReceiveBlock {
-    pub data: OldBlockData,
     buffer: Vec<u8>,
     pub stale_check: StaleTracker,
     previous_stale_check_time_ms: f64,
@@ -77,7 +75,6 @@ pub struct SerialReceiveBlock {
 impl Default for SerialReceiveBlock {
     fn default() -> Self {
         SerialReceiveBlock {
-            data: OldBlockData::from_bytes(&[]),
             buffer: Vec::new(),
             stale_check: StaleTracker::from_ms(0.0),
             previous_stale_check_time_ms: 0.0,
@@ -88,7 +85,7 @@ impl Default for SerialReceiveBlock {
 }
 
 impl IsValid for SerialReceiveBlock {
-    fn is_valid(&self, app_time_s: f64) -> OldBlockData {
+    fn is_valid(&self, app_time_s: f64) -> f64 {
         self.stale_check.is_valid(app_time_s)
     }
 }
@@ -246,7 +243,6 @@ impl ProcessBlock for SerialReceiveBlock {
             if start_idx != 0 {
                 debug!("Discarding {start_idx} bytes");
             }
-            self.data.set_bytes(val);
             self.output = val.to_vec();
 
             // TODO: Drain is coming to heapless vec soon! - https://github.com/rust-embedded/heapless/pull/444
@@ -342,7 +338,7 @@ mod tests {
             block
                 .stale_check
                 .is_valid(runtime.context().time().as_secs_f64()),
-            OldBlockData::from_scalar(1.0)
+            1.0
         );
 
         for i in 1..11 {
@@ -354,7 +350,7 @@ mod tests {
                 block
                     .stale_check
                     .is_valid(runtime.context().time().as_secs_f64()),
-                OldBlockData::from_scalar(1.0)
+                1.0
             );
         }
 
@@ -366,7 +362,7 @@ mod tests {
             block
                 .stale_check
                 .is_valid(runtime.context().time().as_secs_f64()),
-            OldBlockData::from_scalar(0.0)
+            0.0
         );
     }
 }

--- a/pictorus-blocks/src/core_blocks/serial_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/serial_receive_block.rs
@@ -85,7 +85,7 @@ impl Default for SerialReceiveBlock {
 }
 
 impl IsValid for SerialReceiveBlock {
-    fn is_valid(&self, app_time_s: f64) -> f64 {
+    fn is_valid(&self, app_time_s: f64) -> bool {
         self.stale_check.is_valid(app_time_s)
     }
 }
@@ -334,35 +334,26 @@ mod tests {
         let input_data = b"$Hello World\r\n";
         let result = block.process(&parameters, &runtime.context(), input_data);
         assert!(result.1);
-        assert_eq!(
-            block
-                .stale_check
-                .is_valid(runtime.context().time().as_secs_f64()),
-            1.0
-        );
+        assert!(block
+            .stale_check
+            .is_valid(runtime.context().time().as_secs_f64()));
 
         for i in 1..11 {
             // 100ms to 1s
             runtime.set_time(Duration::from_millis(i * 100)); // 10 Hz runtime (100ms per tick)
             let result = block.process(&parameters, &runtime.context(), &[]);
             assert!(result.1);
-            assert_eq!(
-                block
-                    .stale_check
-                    .is_valid(runtime.context().time().as_secs_f64()),
-                1.0
-            );
+            assert!(block
+                .stale_check
+                .is_valid(runtime.context().time().as_secs_f64()));
         }
 
         // Stale
         runtime.set_time(Duration::from_millis(11 * 100)); // 1.1s
         let result = block.process(&parameters, &runtime.context(), &[]);
         assert!(!result.1);
-        assert_eq!(
-            block
-                .stale_check
-                .is_valid(runtime.context().time().as_secs_f64()),
-            0.0
-        );
+        assert!(!block
+            .stale_check
+            .is_valid(runtime.context().time().as_secs_f64()));
     }
 }

--- a/pictorus-blocks/src/core_blocks/serial_transmit_block.rs
+++ b/pictorus-blocks/src/core_blocks/serial_transmit_block.rs
@@ -1,7 +1,6 @@
 extern crate alloc;
 use alloc::vec::Vec;
 use log::debug;
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, Context, Pass, PassBy, ProcessBlock};
 
 use crate::byte_data::{parse_string_to_bytes, BUFF_SIZE_BYTES};
@@ -30,7 +29,6 @@ impl Parameters {
 ///
 /// Data is output as a ByteSliceSignal.
 pub struct SerialTransmitBlock<T: Serialize + Pass> {
-    pub data: OldBlockData,
     buffer: Vec<u8>,
     phantom: core::marker::PhantomData<T>,
 }
@@ -41,7 +39,6 @@ where
 {
     fn default() -> Self {
         SerialTransmitBlock {
-            data: OldBlockData::from_bytes(&[]),
             buffer: Vec::with_capacity(BUFF_SIZE_BYTES),
             phantom: core::marker::PhantomData,
         }
@@ -69,7 +66,6 @@ where
         ]
         .concat();
         debug!("Transmitting value: {:?}", &write_val);
-        self.data = OldBlockData::from_bytes(&write_val);
         self.buffer = write_val;
         &self.buffer
     }

--- a/pictorus-blocks/src/core_blocks/sliding_window_block.rs
+++ b/pictorus-blocks/src/core_blocks/sliding_window_block.rs
@@ -1,6 +1,5 @@
 use core::fmt::Debug;
 use heapless::Deque;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{HasIc, Matrix, Pass, PassBy, ProcessBlock, Scalar};
 
 /// Parameters for the SlidingWindowBlock consist of the initial condition of the output. This is only
@@ -44,7 +43,6 @@ impl<I> Parameters<I> {
 /// );
 /// ```
 pub struct SlidingWindowBlock<const N: usize, I, O> {
-    pub data: OldBlockData,
     memory: Deque<I, N>,
     buffer: O,
     _phantom: core::marker::PhantomData<I>,
@@ -53,7 +51,6 @@ pub struct SlidingWindowBlock<const N: usize, I, O> {
 impl<const N: usize, I, O> Default for SlidingWindowBlock<N, I, O>
 where
     O: Default + Pass,
-    OldBlockData: FromPass<O>,
 {
     fn default() -> Self {
         const {
@@ -68,13 +65,9 @@ where
 impl<const N: usize, I> HasIc for SlidingWindowBlock<N, I, Matrix<1, N, I>>
 where
     I: Scalar + Debug,
-    OldBlockData: FromPass<Matrix<1, N, I>>,
 {
     fn new(parameters: &Self::Parameters) -> Self {
         SlidingWindowBlock {
-            data: <OldBlockData as FromPass<Matrix<1, N, I>>>::from_pass(
-                parameters.initial_condition.as_by(),
-            ),
             memory: Deque::new(),
             buffer: parameters.initial_condition,
             _phantom: core::marker::PhantomData,
@@ -86,7 +79,6 @@ where
 impl<const N: usize, I> ProcessBlock for SlidingWindowBlock<N, I, Matrix<1, N, I>>
 where
     I: Scalar + Debug,
-    OldBlockData: FromPass<Matrix<1, N, I>>,
 {
     type Inputs = I;
     type Output = Matrix<1, N, I>;
@@ -114,8 +106,6 @@ where
             self.buffer.data.as_flattened_mut()[i] = *value;
         }
 
-        self.data = OldBlockData::from_pass(&self.buffer);
-
         if self.memory.len() == N {
             self.memory.pop_front();
         }
@@ -132,13 +122,9 @@ impl<const N: usize, const ROWS: usize, const ICOLS: usize, const OCOLS: usize, 
     for SlidingWindowBlock<N, Matrix<ROWS, ICOLS, I>, Matrix<ROWS, OCOLS, I>>
 where
     I: Scalar + Debug,
-    OldBlockData: FromPass<Matrix<ROWS, OCOLS, I>>,
 {
     fn new(parameters: &Self::Parameters) -> Self {
         SlidingWindowBlock {
-            data: <OldBlockData as FromPass<Matrix<ROWS, OCOLS, I>>>::from_pass(
-                parameters.initial_condition.as_by(),
-            ),
             memory: Deque::new(),
             buffer: parameters.initial_condition,
             _phantom: core::marker::PhantomData,
@@ -150,7 +136,6 @@ impl<const N: usize, const ROWS: usize, const ICOLS: usize, const OCOLS: usize, 
     for SlidingWindowBlock<N, Matrix<ROWS, ICOLS, I>, Matrix<ROWS, OCOLS, I>>
 where
     I: Scalar + Debug,
-    OldBlockData: FromPass<Matrix<ROWS, OCOLS, I>>,
 {
     type Inputs = Matrix<ROWS, ICOLS, I>;
     type Output = Matrix<ROWS, OCOLS, I>;
@@ -190,8 +175,6 @@ where
             }
         }
 
-        self.data = OldBlockData::from_pass(&self.buffer);
-
         if self.memory.len() == N {
             self.memory.pop_front();
         }
@@ -208,7 +191,6 @@ where
 mod tests {
     use super::*;
     use crate::testing::StubContext;
-    use pictorus_block_data::BlockData as OldBlockData;
     use pictorus_traits::{Matrix, ProcessBlock};
 
     #[test]
@@ -225,7 +207,6 @@ mod tests {
 
         let output = *block.process(&Parameters::new(initial_condition), &c, 1.0);
         assert_eq!(output.data.as_flattened(), [-1.0, -1.0, 1.0]);
-        assert_eq!(block.data, OldBlockData::from_matrix(&[&[-1.0, -1.0, 1.0]]));
         assert_eq!(block.buffer(), &output);
 
         let ic2 = Matrix {
@@ -235,15 +216,15 @@ mod tests {
         // Test that parameters with an IC are irrelevant after the first run
         let output = block.process(&Parameters::new(ic2), &c, 2.0);
         assert_eq!(output.data.as_flattened(), [-1.0, 1.0, 2.0]);
-        assert_eq!(block.data, OldBlockData::from_matrix(&[&[-1.0, 1.0, 2.0]]));
+        assert_eq!(block.buffer().data.as_flattened(), [-1.0, 1.0, 2.0]);
 
         let output = block.process(&Parameters::new(ic2), &c, 3.0);
         assert_eq!(output.data.as_flattened(), [1.0, 2.0, 3.0]);
-        assert_eq!(block.data, OldBlockData::from_matrix(&[&[1.0, 2.0, 3.0]]));
+        assert_eq!(block.buffer().data.as_flattened(), [1.0, 2.0, 3.0]);
 
         let output = block.process(&Parameters::new(ic2), &c, 4.0);
         assert_eq!(output.data.as_flattened(), [2.0, 3.0, 4.0]);
-        assert_eq!(block.data, OldBlockData::from_matrix(&[&[2.0, 3.0, 4.0]]));
+        assert_eq!(block.buffer().data.as_flattened(), [2.0, 3.0, 4.0]);
     }
 
     #[test]
@@ -274,26 +255,21 @@ mod tests {
                 data: [[1.0], [2.0], [3.0]],
             },
         );
-        assert_eq!(
-            output,
-            &Matrix {
-                data: [
-                    [-1.0],
-                    [-1.0],
-                    [-1.0],
-                    [-1.0],
-                    [-1.0],
-                    [-1.0],
-                    [1.0],
-                    [2.0],
-                    [3.0]
-                ]
-            }
-        );
-        assert_eq!(
-            block.data,
-            OldBlockData::from_matrix(&[&[-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 1.0, 2.0, 3.0]])
-        );
+        let expected = Matrix {
+            data: [
+                [-1.0],
+                [-1.0],
+                [-1.0],
+                [-1.0],
+                [-1.0],
+                [-1.0],
+                [1.0],
+                [2.0],
+                [3.0],
+            ],
+        };
+        assert_eq!(output, &expected);
+        assert_eq!(block.buffer(), &expected);
 
         let output = block.process(
             &p,
@@ -302,26 +278,21 @@ mod tests {
                 data: [[4.0], [5.0], [6.0]],
             },
         );
-        assert_eq!(
-            output,
-            &Matrix {
-                data: [
-                    [-1.0],
-                    [-1.0],
-                    [-1.0],
-                    [1.0],
-                    [2.0],
-                    [3.0],
-                    [4.0],
-                    [5.0],
-                    [6.0]
-                ]
-            }
-        );
-        assert_eq!(
-            block.data,
-            OldBlockData::from_matrix(&[&[-1.0, -1.0, -1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]])
-        );
+        let expected = Matrix {
+            data: [
+                [-1.0],
+                [-1.0],
+                [-1.0],
+                [1.0],
+                [2.0],
+                [3.0],
+                [4.0],
+                [5.0],
+                [6.0],
+            ],
+        };
+        assert_eq!(output, &expected);
+        assert_eq!(block.buffer(), &expected);
 
         let output = block.process(
             &p,
@@ -330,26 +301,21 @@ mod tests {
                 data: [[7.0], [8.0], [9.0]],
             },
         );
-        assert_eq!(
-            output,
-            &Matrix {
-                data: [
-                    [1.0],
-                    [2.0],
-                    [3.0],
-                    [4.0],
-                    [5.0],
-                    [6.0],
-                    [7.0],
-                    [8.0],
-                    [9.0]
-                ]
-            }
-        );
-        assert_eq!(
-            block.data,
-            OldBlockData::from_matrix(&[&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]])
-        );
+        let expected = Matrix {
+            data: [
+                [1.0],
+                [2.0],
+                [3.0],
+                [4.0],
+                [5.0],
+                [6.0],
+                [7.0],
+                [8.0],
+                [9.0],
+            ],
+        };
+        assert_eq!(output, &expected);
+        assert_eq!(block.buffer(), &expected);
 
         let output = block.process(
             &p,
@@ -358,26 +324,21 @@ mod tests {
                 data: [[10.0], [11.0], [12.0]],
             },
         );
-        assert_eq!(
-            output,
-            &Matrix {
-                data: [
-                    [4.0],
-                    [5.0],
-                    [6.0],
-                    [7.0],
-                    [8.0],
-                    [9.0],
-                    [10.0],
-                    [11.0],
-                    [12.0]
-                ]
-            }
-        );
-        assert_eq!(
-            block.data,
-            OldBlockData::from_matrix(&[&[4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0]])
-        );
+        let expected = Matrix {
+            data: [
+                [4.0],
+                [5.0],
+                [6.0],
+                [7.0],
+                [8.0],
+                [9.0],
+                [10.0],
+                [11.0],
+                [12.0],
+            ],
+        };
+        assert_eq!(output, &expected);
+        assert_eq!(block.buffer(), &expected);
     }
 
     #[test]
@@ -405,26 +366,18 @@ mod tests {
                 data: [[1.0, 2.0], [3.0, 4.0]],
             },
         );
-        assert_eq!(
-            output,
-            &Matrix {
-                data: [
-                    [0.0, 0.0],
-                    [0.0, 0.0],
-                    [0.0, 0.0],
-                    [0.0, 0.0],
-                    [1.0, 2.0],
-                    [3.0, 4.0],
-                ]
-            }
-        );
-        assert_eq!(
-            block.data,
-            OldBlockData::from_matrix(&[
-                &[0.0, 0.0, 0.0, 0.0, 1.0, 3.0],
-                &[0.0, 0.0, 0.0, 0.0, 2.0, 4.0]
-            ])
-        );
+        let expected = Matrix {
+            data: [
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [1.0, 2.0],
+                [3.0, 4.0],
+            ],
+        };
+        assert_eq!(output, &expected);
+        assert_eq!(block.buffer(), &expected);
 
         let output = block.process(
             &p,
@@ -433,26 +386,18 @@ mod tests {
                 data: [[5.0, 6.0], [7.0, 8.0]],
             },
         );
-        assert_eq!(
-            output,
-            &Matrix {
-                data: [
-                    [0.0, 0.0],
-                    [0.0, 0.0],
-                    [1.0, 2.0],
-                    [3.0, 4.0],
-                    [5.0, 6.0],
-                    [7.0, 8.0]
-                ]
-            }
-        );
-        assert_eq!(
-            block.data,
-            OldBlockData::from_matrix(&[
-                &[0.0, 0.0, 1.0, 3.0, 5.0, 7.0],
-                &[0.0, 0.0, 2.0, 4.0, 6.0, 8.0]
-            ])
-        );
+        let expected = Matrix {
+            data: [
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [1.0, 2.0],
+                [3.0, 4.0],
+                [5.0, 6.0],
+                [7.0, 8.0],
+            ],
+        };
+        assert_eq!(output, &expected);
+        assert_eq!(block.buffer(), &expected);
 
         let output = block.process(
             &p,
@@ -461,25 +406,17 @@ mod tests {
                 data: [[9.0, 10.0], [11.0, 12.0]],
             },
         );
-        assert_eq!(
-            output,
-            &Matrix {
-                data: [
-                    [1.0, 2.0],
-                    [3.0, 4.0],
-                    [5.0, 6.0],
-                    [7.0, 8.0],
-                    [9.0, 10.0],
-                    [11.0, 12.0]
-                ]
-            }
-        );
-        assert_eq!(
-            block.data,
-            OldBlockData::from_matrix(&[
-                &[1.0, 3.0, 5.0, 7.0, 9.0, 11.0],
-                &[2.0, 4.0, 6.0, 8.0, 10.0, 12.0]
-            ])
-        );
+        let expected = Matrix {
+            data: [
+                [1.0, 2.0],
+                [3.0, 4.0],
+                [5.0, 6.0],
+                [7.0, 8.0],
+                [9.0, 10.0],
+                [11.0, 12.0],
+            ],
+        };
+        assert_eq!(output, &expected);
+        assert_eq!(block.buffer(), &expected);
     }
 }

--- a/pictorus-blocks/src/core_blocks/spi_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/spi_receive_block.rs
@@ -78,7 +78,7 @@ impl ProcessBlock for SpiReceiveBlock {
 }
 
 impl IsValid for SpiReceiveBlock {
-    fn is_valid(&self, app_time_s: f64) -> f64 {
+    fn is_valid(&self, app_time_s: f64) -> bool {
         self.stale_check.is_valid(app_time_s)
     }
 }
@@ -114,7 +114,7 @@ mod tests {
         let is_valid = block
             .stale_check
             .is_valid(runtime.context().time().as_secs_f64());
-        assert_eq!(is_valid, 1.0);
+        assert!(is_valid);
 
         runtime.set_time(Duration::from_secs(1));
 
@@ -125,6 +125,6 @@ mod tests {
             .stale_check
             .is_valid(runtime.context().time().as_secs_f64());
         // However block should be invalid
-        assert_eq!(is_valid, 0.0);
+        assert!(!is_valid);
     }
 }

--- a/pictorus-blocks/src/core_blocks/spi_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/spi_receive_block.rs
@@ -1,6 +1,5 @@
 extern crate alloc;
 use alloc::vec::Vec;
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, Context, PassBy, ProcessBlock};
 
 use crate::{stale_tracker::StaleTracker, IsValid};
@@ -28,7 +27,6 @@ impl Parameters {
 /// If data is not received within the time indicated in the Parameters, the data is considered stale.
 /// The last valid data is kept in the buffer until new data arrives.
 pub struct SpiReceiveBlock {
-    pub data: OldBlockData,
     buffer: Vec<u8>,
     pub stale_check: StaleTracker,
     previous_stale_check_time_ms: f64,
@@ -38,7 +36,6 @@ pub struct SpiReceiveBlock {
 impl Default for SpiReceiveBlock {
     fn default() -> Self {
         Self {
-            data: OldBlockData::from_bytes(&[]),
             buffer: Vec::new(),
             stale_check: StaleTracker::from_ms(0.),
             previous_stale_check_time_ms: 0.0,
@@ -68,7 +65,6 @@ impl ProcessBlock for SpiReceiveBlock {
             // length check.
             self.buffer.clear();
             self.buffer.extend_from_slice(inputs);
-            self.data.set_bytes(&self.buffer);
             self.stale_check.mark_updated(context.time().as_secs_f64());
         }
 
@@ -82,7 +78,7 @@ impl ProcessBlock for SpiReceiveBlock {
 }
 
 impl IsValid for SpiReceiveBlock {
-    fn is_valid(&self, app_time_s: f64) -> OldBlockData {
+    fn is_valid(&self, app_time_s: f64) -> f64 {
         self.stale_check.is_valid(app_time_s)
     }
 }
@@ -114,22 +110,21 @@ mod tests {
             (data.to_vec(), valid)
         };
         assert_eq!(output.0, input_data);
-        assert_eq!(block.data.to_bytes(), input_data);
         assert_eq!(block.buffer(), (output.0.as_slice(), output.1));
         let is_valid = block
             .stale_check
             .is_valid(runtime.context().time().as_secs_f64());
-        assert_eq!(is_valid, OldBlockData::from_scalar(1.0));
+        assert_eq!(is_valid, 1.0);
 
         runtime.set_time(Duration::from_secs(1));
 
         let output = block.process(&parameters, &runtime.context(), &[]);
         assert_eq!(output.0, input_data);
-        assert_eq!(block.data.to_bytes(), input_data);
+        assert_eq!(block.buffer().0, input_data);
         let is_valid = block
             .stale_check
             .is_valid(runtime.context().time().as_secs_f64());
         // However block should be invalid
-        assert_eq!(is_valid, OldBlockData::from_scalar(0.0));
+        assert_eq!(is_valid, 0.0);
     }
 }

--- a/pictorus-blocks/src/core_blocks/sum_block.rs
+++ b/pictorus-blocks/src/core_blocks/sum_block.rs
@@ -1,24 +1,15 @@
 use crate::matrix_ext::MatrixNalgebraExt;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
 
 /// Sums (adds or subtracts) all inputs together.
-pub struct SumBlock<T: Summable>
-where
-    pictorus_block_data::BlockData: FromPass<<T as Summable>::Output>,
-{
+pub struct SumBlock<T: Summable> {
     store: T::Output,
-    pub data: OldBlockData,
 }
 
-impl<T: Summable> Default for SumBlock<T>
-where
-    pictorus_block_data::BlockData: FromPass<<T as Summable>::Output>,
-{
+impl<T: Summable> Default for SumBlock<T> {
     fn default() -> Self {
         Self {
             store: T::Output::default(),
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
         }
     }
 }
@@ -26,7 +17,6 @@ where
 impl<T> ProcessBlock for SumBlock<T>
 where
     T: Summable,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -41,7 +31,6 @@ where
         let mut tmp: Option<T::Output> = None;
         T::get_sum(input, *parameters, &mut tmp);
         self.store = tmp.expect("get_sum must initialize the buffer");
-        self.data = OldBlockData::from_pass(self.store.as_by());
         self.store.as_by()
     }
 

--- a/pictorus-blocks/src/core_blocks/switch_block.rs
+++ b/pictorus-blocks/src/core_blocks/switch_block.rs
@@ -1,6 +1,5 @@
 extern crate alloc;
 use alloc::vec::Vec;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{ByteSliceSignal, Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::traits::{CopyInto, DefaultStorage, Scalar};
@@ -50,22 +49,16 @@ use crate::traits::{CopyInto, DefaultStorage, Scalar};
 pub struct SwitchBlock<T: Apply>
 where
     T::Output: DefaultStorage,
-    OldBlockData: FromPass<T::Output>,
 {
-    pub data: OldBlockData,
     buffer: <T::Output as DefaultStorage>::Storage,
 }
 
 impl<T: Apply> Default for SwitchBlock<T>
 where
     T::Output: DefaultStorage,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::from_storage(
-                &T::Output::default_storage(),
-            )),
             buffer: T::Output::default_storage(),
         }
     }
@@ -74,7 +67,6 @@ where
 impl<T: Apply> ProcessBlock for SwitchBlock<T>
 where
     T::Output: DefaultStorage,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -87,9 +79,7 @@ where
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
         T::apply(inputs, parameters, &mut self.buffer);
-        let res = T::Output::from_storage(&self.buffer);
-        self.data = <OldBlockData as FromPass<T::Output>>::from_pass(res);
-        res
+        T::Output::from_storage(&self.buffer)
     }
 
     fn buffer(&self) -> PassBy<'_, Self::Output> {
@@ -332,7 +322,6 @@ mod tests {
         let input = (0.0, 1.0, 2.0);
         let output = block.process(&parameters, &ctxt, input);
         assert_eq!(output, 1.0);
-        assert_eq!(block.data.scalar(), 1.0);
         assert_eq!(block.buffer(), output);
     }
 
@@ -346,7 +335,7 @@ mod tests {
         let input = (6.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let output = block.process(&parameters, &ctxt, input);
         assert_eq!(output, 7.0);
-        assert_eq!(block.data.scalar(), 7.0);
+        assert_eq!(block.buffer(), 7.0);
     }
 
     #[test]
@@ -360,7 +349,7 @@ mod tests {
         let input = (1.2345, 1.0, 2.0);
         let output = block.process(&parameters, &ctxt, input);
         assert_eq!(output, 2.0);
-        assert_eq!(block.data.scalar(), 2.0);
+        assert_eq!(block.buffer(), 2.0);
     }
 
     #[test]
@@ -372,12 +361,9 @@ mod tests {
 
         let input = (0.0, &Matrix::from_element(1.0), &Matrix::from_element(2.0));
         let output = block.process(&parameters, &ctxt, input);
-        let expected = Matrix::from_element(1.0);
+        let expected: Matrix<3, 3, f64> = Matrix::from_element(1.0);
         assert_eq!(output, &expected);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer(), &expected);
     }
 
     #[test]
@@ -407,12 +393,9 @@ mod tests {
             &Matrix::from_element(7.0),
         );
         let output = block.process(&parameters, &ctxt, input);
-        let expected = Matrix::from_element(7.0);
+        let expected: Matrix<3, 3, f64> = Matrix::from_element(7.0);
         assert_eq!(output, &expected);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer(), &expected);
     }
 
     #[test]
@@ -429,12 +412,9 @@ mod tests {
             &Matrix::from_element(2.0),
         );
         let output = block.process(&parameters, &ctxt, input);
-        let expected = Matrix::from_element(2.0);
+        let expected: Matrix<3, 3, f64> = Matrix::from_element(2.0);
         assert_eq!(output, &expected);
-        assert_eq!(
-            block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(block.buffer(), &expected);
     }
 
     #[test]
@@ -447,7 +427,7 @@ mod tests {
         let input = (0.0, b"foo".as_slice(), b"bar".as_slice());
         let output = block.process(&parameters, &ctxt, input);
         assert_eq!(output, b"foo");
-        assert_eq!(block.data.raw_string().as_bytes(), b"foo".as_slice());
+        assert_eq!(block.buffer(), b"foo".as_slice());
     }
 
     #[test]
@@ -461,7 +441,7 @@ mod tests {
         let input = (1.2345, b"foo".as_slice(), b"bar".as_slice());
         let output = block.process(&parameters, &ctxt, input);
         assert_eq!(output, b"bar");
-        assert_eq!(block.data.raw_string().as_bytes(), b"bar".as_slice());
+        assert_eq!(block.buffer(), b"bar".as_slice());
     }
 
     #[test]
@@ -492,6 +472,6 @@ mod tests {
         );
         let output = block.process(&parameters, &ctxt, input);
         assert_eq!(output, b"grault");
-        assert_eq!(block.data.raw_string().as_bytes(), b"grault".as_slice());
+        assert_eq!(block.buffer(), b"grault".as_slice());
     }
 }

--- a/pictorus-blocks/src/core_blocks/timer_block.rs
+++ b/pictorus-blocks/src/core_blocks/timer_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{PassBy, ProcessBlock, Scalar};
 
 #[derive(strum::EnumString)]
@@ -37,7 +36,6 @@ impl Parameters {
 ///
 /// This block is useful for tracking how much time has passed since an event for logical conditions.
 pub struct TimerBlock<T> {
-    pub data: OldBlockData,
     buffer: T,
     timer_running: bool,
     start_time_s: T,
@@ -49,7 +47,6 @@ where
 {
     fn default() -> Self {
         Self {
-            data: OldBlockData::from_scalar(0.0),
             buffer: T::zero(),
             timer_running: false,
             start_time_s: T::zero(),
@@ -88,7 +85,6 @@ impl ProcessBlock for TimerBlock<f64> {
         let trigger_high = input > 0.0;
         // Early exit if not running and input trigger is false
         if !self.timer_running && !trigger_high {
-            self.data.set_scalar(self.buffer);
             return self.buffer;
         }
 
@@ -114,7 +110,6 @@ impl ProcessBlock for TimerBlock<f64> {
             }
         }
 
-        self.data.set_scalar(self.buffer);
         self.buffer
     }
 
@@ -143,34 +138,34 @@ mod tests {
         let mut block = TimerBlock::<f64>::default();
 
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
         assert_eq!(output, 0.0);
         assert_eq!(block.buffer(), output);
 
         runtime.set_time(time::Duration::from_secs_f64(1.0));
         let output = block.process(&p, &runtime.context(), 1.0);
-        assert_eq!(block.data.scalar(), 5.0);
+        assert_eq!(block.buffer(), 5.0);
         assert_eq!(output, 5.0);
 
         runtime.set_time(time::Duration::from_secs_f64(2.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 4.0);
+        assert_eq!(block.buffer(), 4.0);
         assert_eq!(output, 4.0);
 
         // Countdown not interrupted
         runtime.set_time(time::Duration::from_secs_f64(3.0));
         let output = block.process(&p, &runtime.context(), 1.0);
-        assert_eq!(block.data.scalar(), 3.0);
+        assert_eq!(block.buffer(), 3.0);
         assert_eq!(output, 3.0);
 
         runtime.set_time(time::Duration::from_secs_f64(10.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
         assert_eq!(output, 0.0);
 
         runtime.set_time(time::Duration::from_secs_f64(11.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
         assert_eq!(output, 0.0);
     }
 
@@ -183,36 +178,36 @@ mod tests {
         // Timer hasn't started
         runtime.set_time(time::Duration::from_secs_f64(1.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
         assert_eq!(output, 0.0);
 
         // Timer started, should be at countdown_time_s
         runtime.set_time(time::Duration::from_secs_f64(2.0));
         let output = block.process(&p, &runtime.context(), 1.0);
-        assert_eq!(block.data.scalar(), 5.0);
+        assert_eq!(block.buffer(), 5.0);
         assert_eq!(output, 5.0);
 
         runtime.set_time(time::Duration::from_secs_f64(3.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 4.0);
+        assert_eq!(block.buffer(), 4.0);
         assert_eq!(output, 4.0);
 
         // Countdown interrupted, resets
         runtime.set_time(time::Duration::from_secs_f64(4.0));
         let output = block.process(&p, &runtime.context(), 1.0);
-        assert_eq!(block.data.scalar(), 5.0);
+        assert_eq!(block.buffer(), 5.0);
         assert_eq!(output, 5.0);
 
         // Countdown interrupted, resets
         runtime.set_time(time::Duration::from_secs_f64(5.0));
         let output = block.process(&p, &runtime.context(), 1.0);
-        assert_eq!(block.data.scalar(), 5.0);
+        assert_eq!(block.buffer(), 5.0);
         assert_eq!(output, 5.0);
 
         // Countdown resumes
         runtime.set_time(time::Duration::from_secs_f64(6.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 4.0);
+        assert_eq!(block.buffer(), 4.0);
         assert_eq!(output, 4.0);
     }
 
@@ -225,34 +220,34 @@ mod tests {
         // Timer hasn't started
         runtime.set_time(time::Duration::from_secs_f64(1.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
         assert_eq!(output, 0.0);
 
         // Timer started, should be at time since start
         runtime.set_time(time::Duration::from_secs_f64(2.0));
         let output = block.process(&p, &runtime.context(), 1.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
         assert_eq!(output, 0.0);
 
         runtime.set_time(time::Duration::from_secs_f64(3.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
         assert_eq!(output, 1.0);
 
         // StopWatch not interrupted
         runtime.set_time(time::Duration::from_secs_f64(4.0));
         let output = block.process(&p, &runtime.context(), 1.0);
-        assert_eq!(block.data.scalar(), 2.0);
+        assert_eq!(block.buffer(), 2.0);
         assert_eq!(output, 2.0);
 
         runtime.set_time(time::Duration::from_secs_f64(10.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 8.0);
+        assert_eq!(block.buffer(), 8.0);
         assert_eq!(output, 8.0);
 
         runtime.set_time(time::Duration::from_secs_f64(100.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 98.0);
+        assert_eq!(block.buffer(), 98.0);
         assert_eq!(output, 98.0);
     }
 
@@ -265,35 +260,35 @@ mod tests {
         // Timer hasn't started
         runtime.set_time(time::Duration::from_secs_f64(1.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
         assert_eq!(output, 0.0);
 
         // Timer started, should be at time since start
         runtime.set_time(time::Duration::from_secs_f64(2.0));
         let output = block.process(&p, &runtime.context(), 1.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
         assert_eq!(output, 0.0);
 
         runtime.set_time(time::Duration::from_secs_f64(3.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 1.0);
+        assert_eq!(block.buffer(), 1.0);
         assert_eq!(output, 1.0);
 
         // StopWatch interrupted
         runtime.set_time(time::Duration::from_secs_f64(4.0));
         let output = block.process(&p, &runtime.context(), 1.0);
-        assert_eq!(block.data.scalar(), 0.0);
+        assert_eq!(block.buffer(), 0.0);
         assert_eq!(output, 0.0);
 
         // StopWatch resumes
         runtime.set_time(time::Duration::from_secs_f64(10.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 6.0);
+        assert_eq!(block.buffer(), 6.0);
         assert_eq!(output, 6.0);
 
         runtime.set_time(time::Duration::from_secs_f64(100.0));
         let output = block.process(&p, &runtime.context(), 0.0);
-        assert_eq!(block.data.scalar(), 96.0);
+        assert_eq!(block.buffer(), 96.0);
         assert_eq!(output, 96.0);
     }
 }

--- a/pictorus-blocks/src/core_blocks/transfer_function_block.rs
+++ b/pictorus-blocks/src/core_blocks/transfer_function_block.rs
@@ -1,7 +1,6 @@
 use crate::traits::{Float, MatrixOps};
 use heapless::Deque;
 use num_traits::Zero;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Parameters for the TransferFunctionBlock
@@ -55,7 +54,6 @@ pub struct TransferFunctionBlock<const NUM_SIZE: usize, const DEN_SIZE: usize, F
 where
     I: Default,
 {
-    pub data: OldBlockData,
     buffer: I,
     /// Stores input samples, typically denoted as x[n]
     input: Deque<I, NUM_SIZE>,
@@ -69,11 +67,9 @@ impl<const NUM_SIZE: usize, const DEN_SIZE: usize, F, I> Default
 where
     F: Float,
     I: Pass + Default,
-    OldBlockData: FromPass<I>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<I>>::from_pass(<I>::default().as_by()),
             buffer: I::default(),
             input: Deque::new(),
             output: Deque::new(),
@@ -86,8 +82,6 @@ macro_rules! impl_transfer_function {
     ($type:ty) => {
         impl<const NUM_SIZE: usize, const DEN_SIZE: usize> ProcessBlock
             for TransferFunctionBlock<NUM_SIZE, DEN_SIZE, $type, $type>
-        where
-            OldBlockData: FromPass<f64>,
         {
             type Inputs = $type;
             type Output = $type;
@@ -151,7 +145,6 @@ macro_rules! impl_transfer_function {
 
                 self.input.pop_back();
 
-                self.data = OldBlockData::from_scalar(self.buffer.into());
                 self.buffer
             }
 
@@ -169,7 +162,6 @@ macro_rules! impl_transfer_function {
             for TransferFunctionBlock<NUM_SIZE, DEN_SIZE, $type, Matrix<ROWS, COLS, $type>>
         where
             $type: Float,
-            OldBlockData: FromPass<Matrix<ROWS, COLS, $type>>,
         {
             type Inputs = Matrix<ROWS, COLS, $type>;
             type Output = Matrix<ROWS, COLS, $type>;
@@ -236,7 +228,6 @@ macro_rules! impl_transfer_function {
 
                 self.input.pop_back();
 
-                self.data = OldBlockData::from_pass(self.buffer.as_by());
                 &self.buffer
             }
 

--- a/pictorus-blocks/src/core_blocks/transpose_block.rs
+++ b/pictorus-blocks/src/core_blocks/transpose_block.rs
@@ -1,5 +1,4 @@
 use crate::matrix_ext::MatrixNalgebraExt;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::traits::Scalar;
@@ -21,26 +20,18 @@ impl Default for Parameters {
 ///
 /// For scalar inputs this is just a pass-through
 pub struct TransposeBlock<T: Apply> {
-    pub data: OldBlockData,
     store: T::Output,
 }
 
-impl<T: Apply> Default for TransposeBlock<T>
-where
-    OldBlockData: FromPass<T::Output>,
-{
+impl<T: Apply> Default for TransposeBlock<T> {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(<T::Output>::default().as_by()),
             store: T::Output::default(),
         }
     }
 }
 
-impl<T: Apply> ProcessBlock for TransposeBlock<T>
-where
-    OldBlockData: FromPass<T::Output>,
-{
+impl<T: Apply> ProcessBlock for TransposeBlock<T> {
     type Inputs = T;
     type Output = T::Output;
     type Parameters = Parameters;
@@ -51,9 +42,7 @@ where
         _context: &dyn pictorus_traits::Context,
         input: PassBy<Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
-        let output = T::apply(&mut self.store, input);
-        self.data = OldBlockData::from_pass(output);
-        output
+        T::apply(&mut self.store, input)
     }
 
     fn buffer(&self) -> PassBy<'_, Self::Output> {
@@ -110,12 +99,11 @@ mod tests {
 
         let output = transpose_block.process(&params, &ctxt, 1.0);
         assert_eq!(output, 1.0);
-        assert_eq!(transpose_block.data.scalar(), 1.0);
         assert_eq!(transpose_block.buffer(), output);
 
         let output = transpose_block.process(&params, &ctxt, 42.0);
         assert_eq!(output, 42.0);
-        assert_eq!(transpose_block.data.scalar(), 42.0);
+        assert_eq!(transpose_block.buffer(), 42.0);
     }
 
     #[test]
@@ -132,9 +120,6 @@ mod tests {
         };
         let output = transpose_block.process(&params, &ctxt, &input);
         assert_eq!(output.data, expected.data);
-        assert_eq!(
-            transpose_block.data.get_data().as_slice(),
-            expected.data.as_flattened()
-        );
+        assert_eq!(transpose_block.buffer().data, expected.data);
     }
 }

--- a/pictorus-blocks/src/core_blocks/udp_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/udp_receive_block.rs
@@ -43,7 +43,7 @@ impl Default for UdpReceiveBlock {
 }
 
 impl IsValid for UdpReceiveBlock {
-    fn is_valid(&self, app_time_s: f64) -> f64 {
+    fn is_valid(&self, app_time_s: f64) -> bool {
         self.stale_check.is_valid(app_time_s)
     }
 }

--- a/pictorus-blocks/src/core_blocks/udp_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/udp_receive_block.rs
@@ -1,6 +1,5 @@
 extern crate alloc;
 use alloc::vec::Vec;
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, PassBy, ProcessBlock};
 
 use crate::{stale_tracker::StaleTracker, IsValid};
@@ -26,7 +25,6 @@ impl Parameters {
 /// been received for a period of time longer than the `stale_age_ms` parameter, the block
 /// will return `false` for `is_valid()`.
 pub struct UdpReceiveBlock {
-    pub data: OldBlockData,
     pub stale_check: StaleTracker,
     buffer: Vec<u8>,
     previous_stale_check_time_ms: f64,
@@ -36,7 +34,6 @@ pub struct UdpReceiveBlock {
 impl Default for UdpReceiveBlock {
     fn default() -> Self {
         Self {
-            data: OldBlockData::from_bytes(b""),
             stale_check: StaleTracker::from_ms(0.0),
             buffer: Vec::new(),
             previous_stale_check_time_ms: 0.,
@@ -46,7 +43,7 @@ impl Default for UdpReceiveBlock {
 }
 
 impl IsValid for UdpReceiveBlock {
-    fn is_valid(&self, app_time_s: f64) -> OldBlockData {
+    fn is_valid(&self, app_time_s: f64) -> f64 {
         self.stale_check.is_valid(app_time_s)
     }
 }
@@ -72,7 +69,6 @@ impl ProcessBlock for UdpReceiveBlock {
         if !input.is_empty() {
             self.stale_check.mark_updated(context.time().as_secs_f64());
             self.buffer = input.to_vec();
-            self.data.set_bytes(&self.buffer);
         }
 
         self.last_valid = self.stale_check.is_valid_bool(context.time().as_secs_f64());

--- a/pictorus-blocks/src/core_blocks/udp_transmit_block.rs
+++ b/pictorus-blocks/src/core_blocks/udp_transmit_block.rs
@@ -3,6 +3,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
+use miniserde::de;
 use pictorus_traits::{ByteSliceSignal, PassBy, ProcessBlock};
 
 /// Parameters for UDP Transmit Block
@@ -30,14 +31,9 @@ impl Parameters {
 ///
 /// This block sends data to a Hardware specific UDP `OutputBlock` that is added
 /// by codegen
+#[derive(Default)]
 pub struct UdpTransmitBlock {
     buffer: Vec<u8>,
-}
-
-impl Default for UdpTransmitBlock {
-    fn default() -> Self {
-        Self { buffer: Vec::new() }
-    }
 }
 
 impl ProcessBlock for UdpTransmitBlock {

--- a/pictorus-blocks/src/core_blocks/udp_transmit_block.rs
+++ b/pictorus-blocks/src/core_blocks/udp_transmit_block.rs
@@ -3,7 +3,6 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{ByteSliceSignal, PassBy, ProcessBlock};
 
 /// Parameters for UDP Transmit Block
@@ -32,16 +31,12 @@ impl Parameters {
 /// This block sends data to a Hardware specific UDP `OutputBlock` that is added
 /// by codegen
 pub struct UdpTransmitBlock {
-    pub data: OldBlockData,
     buffer: Vec<u8>,
 }
 
 impl Default for UdpTransmitBlock {
     fn default() -> Self {
-        Self {
-            data: OldBlockData::from_bytes(b""),
-            buffer: Vec::new(),
-        }
+        Self { buffer: Vec::new() }
     }
 }
 
@@ -58,7 +53,6 @@ impl ProcessBlock for UdpTransmitBlock {
     ) -> PassBy<'b, Self::Output> {
         self.buffer.clear();
         self.buffer.extend_from_slice(inputs);
-        self.data.set_bytes(&self.buffer);
         &self.buffer
     }
 

--- a/pictorus-blocks/src/core_blocks/udp_transmit_block.rs
+++ b/pictorus-blocks/src/core_blocks/udp_transmit_block.rs
@@ -3,7 +3,6 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use miniserde::de;
 use pictorus_traits::{ByteSliceSignal, PassBy, ProcessBlock};
 
 /// Parameters for UDP Transmit Block

--- a/pictorus-blocks/src/core_blocks/vector_index_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_index_block.rs
@@ -1,5 +1,3 @@
-use alloc::{vec, vec::Vec};
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{
     tuple_array_interop::TupleEquivalent, Matrix, Pass, PassBy, ProcessBlock, Scalar,
 };
@@ -35,7 +33,6 @@ pub struct VectorIndexBlock<const N: usize, T: Scalar, I: Pass>
 where
     [T; N]: TupleEquivalent<T, N>,
 {
-    pub data: Vec<OldBlockData>,
     buffer: <[T; N] as TupleEquivalent<T, N>>::TupleEquivalent,
     _phantom: core::marker::PhantomData<I>,
 }
@@ -46,7 +43,6 @@ where
 {
     fn default() -> Self {
         VectorIndexBlock {
-            data: vec![OldBlockData::from_scalar(0.0); N],
             buffer: [T::default(); N].into_tuple(),
             _phantom: core::marker::PhantomData,
         }
@@ -77,12 +73,9 @@ where
             // Check if the matrix index is within the bounds of the matrix dimensions, out-of-bounds indexes will
             // be set to 0.
             if *x < flattened.len() {
-                let value = flattened[*x];
-                output[i] = value;
-                self.data[i] = OldBlockData::from_scalar(value.into());
+                output[i] = flattened[*x];
             } else {
                 output[i] = T::default();
-                self.data[i] = OldBlockData::from_scalar(T::default().into());
             }
         }
 
@@ -100,7 +93,6 @@ mod tests {
     use super::*;
     use crate::std::string::ToString;
     use crate::testing::StubContext;
-    use pictorus_block_data::BlockData;
     use pictorus_traits::{Matrix, ProcessBlock};
     use std::string::String;
     use std::vec;
@@ -167,10 +159,8 @@ mod tests {
         let output = index_block.process(&parameters, &c, &input);
         assert_eq!(output.0, 7.0);
         assert_eq!(output.1, 8.0);
-        assert_eq!(index_block.data[0].scalar(), 7.0);
-        assert_eq!(index_block.data[0], BlockData::from_scalar(7.0));
-        assert_eq!(index_block.data[1].scalar(), 8.0);
-        assert_eq!(index_block.data[1], BlockData::from_scalar(8.0));
+        assert_eq!(index_block.buffer().0, 7.0);
+        assert_eq!(index_block.buffer().1, 8.0);
     }
 
     #[test]
@@ -188,10 +178,8 @@ mod tests {
         let output = index_block.process(&parameters, &c, &input);
         assert_eq!(output.0, 7.0);
         assert_eq!(output.1, 0.0);
-        assert_eq!(index_block.data[0].scalar(), 7.0);
-        assert_eq!(index_block.data[0], BlockData::from_scalar(7.0));
-        assert_eq!(index_block.data[1].scalar(), 0.0);
-        assert_eq!(index_block.data[1], BlockData::from_scalar(0.0));
+        assert_eq!(index_block.buffer().0, 7.0);
+        assert_eq!(index_block.buffer().1, 0.0);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/vector_merge_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_merge_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::traits::Scalar;
@@ -31,7 +30,6 @@ pub struct VectorMergeBlock<O, I>
 where
     I: Pass + Mergeable<O>,
 {
-    pub data: OldBlockData,
     buffer: <I as Mergeable<O>>::Output,
     _phantom: core::marker::PhantomData<I>,
 }
@@ -40,13 +38,9 @@ impl<O, I> Default for VectorMergeBlock<O, I>
 where
     I: Pass + Mergeable<O>,
     O: Pass + Default,
-    OldBlockData: FromPass<<I as Mergeable<O>>::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<<I as Mergeable<O>>::Output>>::from_pass(
-                <I as Mergeable<O>>::Output::default().as_by(),
-            ),
             buffer: <I as Mergeable<O>>::Output::default(),
             _phantom: core::marker::PhantomData,
         }
@@ -57,7 +51,6 @@ impl<O, I> ProcessBlock for VectorMergeBlock<O, I>
 where
     I: Pass + Mergeable<O>,
     O: Pass + Default,
-    OldBlockData: FromPass<<I as Mergeable<O>>::Output>,
 {
     type Inputs = I;
     type Output = <I as Mergeable<O>>::Output;
@@ -73,9 +66,6 @@ where
         let mut tmp: Option<<I as Mergeable<O>>::Output> = None;
         I::get_merge(input, &mut offset, &mut tmp);
         self.buffer = tmp.expect("get_merge must initialize the buffer");
-        self.data = OldBlockData::from_pass(self.buffer.as_by());
-        self.data
-            .set_type(pictorus_block_data::BlockDataType::Vector);
         self.buffer.as_by()
     }
 
@@ -347,7 +337,6 @@ where
 mod tests {
     use super::*;
     use crate::testing::StubContext;
-    use pictorus_block_data::{BlockData as OldBlockData, BlockDataType, ToPass};
 
     #[test]
     fn test_vector_merge_default_buffer_no_panic() {
@@ -372,21 +361,19 @@ mod tests {
             data: [[2.], [3.], [4.]],
         };
 
-        let signal1 = OldBlockData::from_scalar(1.0);
-        let signal2 = OldBlockData::from_vector(&[2.0, 3.0, 4.0]);
-        let signal3 = OldBlockData::new(2, 2, &[5.0, 6.0, 7.0, 8.0]);
+        let signal1 = 1.0;
+        let signal2 = Matrix {
+            data: [[2.0], [3.0], [4.0]],
+        };
+        let signal3 = Matrix {
+            data: [[5.0, 6.0], [7.0, 8.0]],
+        };
 
-        let _output = block.process(
-            &parameters,
-            &stub_context,
-            (signal1.to_pass(), &signal2.to_pass(), &signal3.to_pass()),
-        );
-        assert_eq!(block.data.get_type(), BlockDataType::Vector);
+        let output = block.process(&parameters, &stub_context, (signal1, &signal2, &signal3));
 
-        // Note, the original test uses row-major order and Corelib uses column-major order, so 6 and 7 are swapped
-        // let original_expected = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
-        let expected = [1.0, 2.0, 3.0, 4.0, 5.0, 7.0, 6.0, 8.0];
-        assert!(block.data.vector().iter().eq(expected.iter()));
+        let expected = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        assert_eq!(output.data.as_flattened(), &expected);
+        assert_eq!(block.buffer().data.as_flattened(), &expected);
 
         let output = block.process(&parameters, &stub_context, (1.0, &input_v, &input_m));
         assert_eq!(

--- a/pictorus-blocks/src/core_blocks/vector_norm_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_norm_block.rs
@@ -1,5 +1,4 @@
 use crate::matrix_ext::MatrixNalgebraExt;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 pub struct Parameters {}
@@ -24,18 +23,15 @@ pub struct VectorNormBlock<T>
 where
     T: Apply,
 {
-    pub data: OldBlockData,
     buffer: T::Output,
 }
 
 impl<T> Default for VectorNormBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<T::Output>>::from_pass(T::Output::default().as_by()),
             buffer: T::Output::default(),
         }
     }
@@ -44,7 +40,6 @@ where
 impl<T> ProcessBlock for VectorNormBlock<T>
 where
     T: Apply,
-    OldBlockData: FromPass<T::Output>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -57,7 +52,6 @@ where
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
         let output = T::apply(&mut self.buffer, inputs);
-        self.data = OldBlockData::from_pass(output);
         output
     }
 
@@ -151,7 +145,6 @@ mod tests {
 
                     let output = block.process(&p, &c, &input);
                     assert_eq!(output, [<5 $type>].into());
-                    assert_eq!(block.data, OldBlockData::from_scalar([<5 $type>].into()));
                     assert_eq!(block.buffer(), output);
                 }
 
@@ -166,7 +159,7 @@ mod tests {
                     };
                     let output = block.process(&p, &c, &input);
                     assert_eq!(output, [<6 $type>].into());
-                    assert_eq!(block.data, OldBlockData::from_scalar([<6 $type>].into()));
+                    assert_eq!(block.buffer(), output);
                 }
             }
         };

--- a/pictorus-blocks/src/core_blocks/vector_reshape_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_reshape_block.rs
@@ -1,4 +1,3 @@
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Parameters for the VectorReshapeBlock
@@ -21,7 +20,6 @@ impl Parameters {
 /// If the input type is an (M, N) matrix, the output type MUST have dimensions such that M_in*N_in == M_out*N_out.
 /// Accepts a scalar input, T, if the output is a Matrix<1, 1, T>.
 pub struct VectorReshapeBlock<I, O> {
-    pub data: OldBlockData,
     buffer: O,
     _phantom: core::marker::PhantomData<I>,
 }
@@ -29,11 +27,9 @@ pub struct VectorReshapeBlock<I, O> {
 impl<I, O> Default for VectorReshapeBlock<I, O>
 where
     O: Default + Pass,
-    OldBlockData: FromPass<O>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<O>>::from_pass(O::default().as_by()),
             buffer: O::default(),
             _phantom: core::marker::PhantomData,
         }
@@ -67,7 +63,6 @@ where
             .data
             .as_flattened_mut()
             .copy_from_slice(input.data.as_flattened());
-        self.data = <OldBlockData as FromPass<Self::Output>>::from_pass(&self.buffer);
         &self.buffer
     }
 
@@ -91,7 +86,6 @@ where
         input: PassBy<Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
         self.buffer.data[0][0] = input;
-        self.data = <OldBlockData as FromPass<Self::Output>>::from_pass(&self.buffer);
         &self.buffer
     }
 

--- a/pictorus-blocks/src/core_blocks/vector_slice_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_slice_block.rs
@@ -1,6 +1,5 @@
 use crate::{traits::MatrixOps, Scalar};
 use num_traits::ToPrimitive;
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Parameters for the VectorSliceBlock
@@ -28,7 +27,6 @@ impl Parameters {
 
 /// Returns a fixed-size slice of the input matrix starting from the specified row and column.
 pub struct VectorSliceBlock<I, O> {
-    pub data: OldBlockData,
     buffer: O,
     _phantom: core::marker::PhantomData<I>,
 }
@@ -36,11 +34,9 @@ pub struct VectorSliceBlock<I, O> {
 impl<I, O> Default for VectorSliceBlock<I, O>
 where
     O: Default + Pass,
-    OldBlockData: FromPass<O>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<O>>::from_pass(O::default().as_by()),
             buffer: O::default(),
             _phantom: core::marker::PhantomData,
         }
@@ -84,7 +80,6 @@ impl<S: Scalar, const IROWS: usize, const ICOLS: usize, const OROWS: usize, cons
     ProcessBlock for VectorSliceBlock<Matrix<IROWS, ICOLS, S>, Matrix<OROWS, OCOLS, S>>
 where
     S: num_traits::Zero,
-    OldBlockData: FromPass<Matrix<OROWS, OCOLS, S>>,
 {
     type Inputs = Matrix<IROWS, ICOLS, S>;
     type Output = Matrix<OROWS, OCOLS, S>;
@@ -121,7 +116,6 @@ where
             }
         });
 
-        self.data = OldBlockData::from_pass(&self.buffer);
         &self.buffer
     }
 
@@ -134,7 +128,6 @@ impl<S: Scalar, const IROWS: usize, const ICOLS: usize> ProcessBlock
     for VectorSliceBlock<Matrix<IROWS, ICOLS, S>, S>
 where
     S: num_traits::Zero,
-    OldBlockData: FromPass<S>,
 {
     type Inputs = Matrix<IROWS, ICOLS, S>;
     type Output = S;
@@ -156,7 +149,6 @@ where
             .copied()
             .unwrap_or(S::zero());
 
-        self.data = OldBlockData::from_scalar(self.buffer.into());
         self.buffer
     }
 

--- a/pictorus-blocks/src/core_blocks/vector_sort_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_sort_block.rs
@@ -1,6 +1,5 @@
 use core::cmp::Ordering;
 
-use pictorus_block_data::{BlockData as OldBlockData, FromPass};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 #[derive(strum::EnumString, PartialEq)]
@@ -31,7 +30,6 @@ impl Parameters {
 ///
 /// This block also accepts scalars, though the output will always be the input.
 pub struct VectorSortBlock<I, O> {
-    pub data: OldBlockData,
     buffer: O,
     _phantom: core::marker::PhantomData<I>,
 }
@@ -39,11 +37,9 @@ pub struct VectorSortBlock<I, O> {
 impl<I, O> Default for VectorSortBlock<I, O>
 where
     O: Default + Pass,
-    OldBlockData: FromPass<O>,
 {
     fn default() -> Self {
         Self {
-            data: <OldBlockData as FromPass<O>>::from_pass(O::default().as_by()),
             buffer: O::default(),
             _phantom: core::marker::PhantomData,
         }
@@ -88,7 +84,6 @@ macro_rules! impl_vector_sort {
                     }
                 }
 
-                self.data = <OldBlockData as FromPass<Self::Output>>::from_pass(&self.buffer);
                 &self.buffer
             }
 
@@ -109,7 +104,6 @@ macro_rules! impl_vector_sort {
                 input: PassBy<Self::Inputs>,
             ) -> PassBy<'_, Self::Output> {
                 self.buffer = input;
-                self.data = OldBlockData::from_scalar(self.buffer.into());
                 self.buffer
             }
 

--- a/pictorus-blocks/src/lib.rs
+++ b/pictorus-blocks/src/lib.rs
@@ -15,7 +15,6 @@
 //! If you are implementing a custom block for a specific case, you can likely create a much simpler implementation
 //! by restricting the input/output types you need to support. We will be adding more examples of simple custom blocks in the future.
 #![no_std]
-use pictorus_block_data::BlockData;
 
 #[cfg(any(feature = "std", test))]
 extern crate std;
@@ -52,7 +51,6 @@ pub struct ParseEnumError;
 /// Blocks that implement this trait should output a false value for `is_valid`
 /// if the output is not in a valid state.
 pub trait IsValid {
-    // This still uses the deprecated BlockData type.
-    // Eventually we will need to update/replace this trait when BlockData is removed.
-    fn is_valid(&self, app_time_s: f64) -> BlockData;
+    /// Returns `1.0` if the block output is in a valid state, `0.0` otherwise.
+    fn is_valid(&self, app_time_s: f64) -> f64;
 }

--- a/pictorus-blocks/src/lib.rs
+++ b/pictorus-blocks/src/lib.rs
@@ -51,6 +51,6 @@ pub struct ParseEnumError;
 /// Blocks that implement this trait should output a false value for `is_valid`
 /// if the output is not in a valid state.
 pub trait IsValid {
-    /// Returns `1.0` if the block output is in a valid state, `0.0` otherwise.
-    fn is_valid(&self, app_time_s: f64) -> f64;
+    /// Returns `true` if the block output is in a valid state, `false` otherwise.
+    fn is_valid(&self, app_time_s: f64) -> bool;
 }

--- a/pictorus-blocks/src/stale_tracker.rs
+++ b/pictorus-blocks/src/stale_tracker.rs
@@ -1,5 +1,4 @@
 use embedded_time::{duration::*, fraction::Fraction, Clock, Instant};
-use pictorus_block_data::BlockData;
 
 struct GenericClock;
 impl Clock for GenericClock {
@@ -54,8 +53,8 @@ impl StaleTracker {
     }
 
     // TODO: Update with core::time::Duration when all blocks are updated
-    pub fn is_valid(&self, app_time_s: f64) -> BlockData {
-        BlockData::scalar_from_bool(self.is_valid_bool(app_time_s))
+    pub fn is_valid(&self, app_time_s: f64) -> f64 {
+        f64::from(self.is_valid_bool(app_time_s))
     }
 }
 
@@ -66,7 +65,7 @@ mod test {
     fn test_is_valid_not_updated() {
         let tracker = StaleTracker::from_ms(5000.0);
         let valid = tracker.is_valid(0.0);
-        assert!(!valid.all());
+        assert_eq!(valid, 0.0);
     }
 
     #[test]
@@ -74,7 +73,7 @@ mod test {
         let mut tracker = StaleTracker::from_ms(5000.0);
         tracker.mark_updated(0.0);
         let valid = tracker.is_valid(0.0);
-        assert!(valid.all());
+        assert_eq!(valid, 1.0);
     }
 
     #[test]
@@ -82,6 +81,6 @@ mod test {
         let mut tracker = StaleTracker::from_ms(1.0);
         tracker.mark_updated(0.0);
         let valid = tracker.is_valid(2.0);
-        assert!(!valid.all());
+        assert_eq!(valid, 0.0);
     }
 }

--- a/pictorus-blocks/src/stale_tracker.rs
+++ b/pictorus-blocks/src/stale_tracker.rs
@@ -53,8 +53,8 @@ impl StaleTracker {
     }
 
     // TODO: Update with core::time::Duration when all blocks are updated
-    pub fn is_valid(&self, app_time_s: f64) -> f64 {
-        f64::from(self.is_valid_bool(app_time_s))
+    pub fn is_valid(&self, app_time_s: f64) -> bool {
+        self.is_valid_bool(app_time_s)
     }
 }
 
@@ -65,7 +65,7 @@ mod test {
     fn test_is_valid_not_updated() {
         let tracker = StaleTracker::from_ms(5000.0);
         let valid = tracker.is_valid(0.0);
-        assert_eq!(valid, 0.0);
+        assert!(!valid);
     }
 
     #[test]
@@ -73,7 +73,7 @@ mod test {
         let mut tracker = StaleTracker::from_ms(5000.0);
         tracker.mark_updated(0.0);
         let valid = tracker.is_valid(0.0);
-        assert_eq!(valid, 1.0);
+        assert!(valid);
     }
 
     #[test]
@@ -81,6 +81,6 @@ mod test {
         let mut tracker = StaleTracker::from_ms(1.0);
         tracker.mark_updated(0.0);
         let valid = tracker.is_valid(2.0);
-        assert_eq!(valid, 0.0);
+        assert!(!valid);
     }
 }

--- a/pictorus-blocks/src/std_blocks/fmu_block.rs
+++ b/pictorus-blocks/src/std_blocks/fmu_block.rs
@@ -1,9 +1,7 @@
 use alloc::string::{String, ToString};
-use alloc::vec;
 use alloc::vec::Vec;
 
 use fmu_runner::{fmi2Type, model_description::ScalarVariable, Fmu, FmuInstance, FmuLibrary};
-use pictorus_block_data::BlockData as OldBlockData;
 use pictorus_traits::{Context, ProcessBlock};
 use std::collections::HashMap;
 
@@ -11,7 +9,6 @@ use std::collections::HashMap;
 /// It takes a set of parameters that define the FMU file, the input signals, and the output signals.
 /// Each time step, it will run the FMU for the given time step with the provided inputs and return the output signals.
 pub struct FmuBlock<const N_IN: usize, const N_OUT: usize> {
-    pub data: Vec<OldBlockData>,
     fm_cs: Option<FmuInstance<FmuLibrary>>,
     buffer: [f64; N_OUT],
 }
@@ -19,7 +16,6 @@ pub struct FmuBlock<const N_IN: usize, const N_OUT: usize> {
 impl<const N_IN: usize, const N_OUT: usize> Default for FmuBlock<N_IN, N_OUT> {
     fn default() -> Self {
         Self {
-            data: vec![OldBlockData::from_scalar(0.0); N_OUT],
             fm_cs: None,
             buffer: [0.0; N_OUT],
         }
@@ -155,12 +151,6 @@ impl<const N_IN: usize, const N_OUT: usize> ProcessBlock for FmuBlock<N_IN, N_OU
         inputs: pictorus_traits::PassBy<'_, Self::Inputs>,
     ) -> pictorus_traits::PassBy<'b, Self::Output> {
         self.buffer = self.run_time_step(parameters, context, inputs);
-        self.data.clear();
-        self.data = self
-            .buffer
-            .iter()
-            .map(|&x| OldBlockData::from_scalar(x))
-            .collect();
         &self.buffer
     }
 


### PR DESCRIPTION
- IsValid::is_valid trait function now returns a bool instead of BlockData
- Removed "pub data: OldBlockData" from the rest of the process blocks.
- Updated unit tests
