### PR TITLE
Make validity signal handling consistent

### DIFF
--- a/pictorus-blocks/Cargo.toml
+++ b/pictorus-blocks/Cargo.toml
@@ -27,7 +27,6 @@ paste = "1.0.15"
 log = "0.4.21"
 byteorder = { version = "1.5.0", default-features = false }
 seq-macro = "0.3.6"
-embedded-time = "0.12.1"
 
 # Std-only dependencies
 rustfft = { version = "6.2.0", default-features = false, optional = true }

--- a/pictorus-blocks/src/alloc_blocks/bytes_split_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/bytes_split_block.rs
@@ -1,6 +1,6 @@
 use crate::byte_data::{find_all_bytes_idx, parse_string_to_read_delimiter};
+use crate::stale_tracker::StaleTracker;
 use crate::traits::{DefaultStorage, Scalar};
-use crate::IsValid;
 use alloc::borrow::ToOwned;
 use alloc::{string::String, vec::Vec};
 use core::time::Duration;
@@ -17,7 +17,7 @@ use pictorus_traits::{ByteSliceSignal, Pass, PassBy, ProcessBlock};
 /// the block will output false for the "is_valid" output.
 pub struct BytesSplitBlock<T: Apply> {
     buffer: T::Storage,
-    last_valid_time: Option<Duration>,
+    stale_check: StaleTracker,
 }
 
 /// Parameters for the Bytes Split Block
@@ -61,7 +61,7 @@ impl<T: Apply> Default for BytesSplitBlock<T> {
     fn default() -> Self {
         Self {
             buffer: T::default_storage_value(),
-            last_valid_time: None,
+            stale_check: StaleTracker::default(),
         }
     }
 }
@@ -84,30 +84,25 @@ impl<T: Apply> ProcessBlock for BytesSplitBlock<T> {
         };
         let delim_idxs = find_all_bytes_idx(inputs, &parsed_deliminator.0, &parsed_deliminator.1);
 
-        let update_age = context.time() - self.last_valid_time.unwrap_or_default();
-
         let parse_success = T::apply(
             &mut self.buffer,
             inputs,
             parameters,
             &delim_idxs,
             parsed_deliminator.2,
-            update_age,
         );
         if parse_success {
-            self.last_valid_time = Some(context.time());
+            self.stale_check.mark_updated(context.time());
         }
+        let valid = self
+            .stale_check
+            .is_valid(context.time(), parameters.stale_age);
+        T::set_valid(&mut self.buffer, valid);
         <T as Apply>::storage_as_by(&self.buffer)
     }
 
     fn buffer(&self) -> PassBy<'_, Self::Output> {
         <T as Apply>::storage_as_by(&self.buffer)
-    }
-}
-
-impl<T: Apply> IsValid for BytesSplitBlock<T> {
-    fn is_valid(&self, _app_time_s: f64) -> bool {
-        T::is_valid(&self.buffer)
     }
 }
 
@@ -148,28 +143,28 @@ fn parse_bytes<T: FromBytes>(
 }
 
 pub trait Apply: Pass {
-    /// The type of the storage for the block. This will be the storage type for each of the outputs plus a bool all in a tuple
-    /// The bool is used for the always include `is_valid` output
+    /// The type of the storage for the block. This will be the storage type for each of the outputs plus a bool all in a tuple.
+    /// The bool slot is overwritten by the block from the `StaleTracker` on each tick.
     type Storage;
 
     type Output: Pass;
 
-    /// Handles parsing input into the storage type, also manages the is_valid output. Outputs `true` if it was able to parse the input
-    /// and `false` if it was not able to parse the input. This is used to update the `last_valid_time` field of the block.
+    /// Parses input into the storage type. Returns `true` if the parse succeeded so the
+    /// block can mark the [`StaleTracker`] as updated. The trailing bool slot of `dest`
+    /// is ignored here and updated separately by the `set_valid` call
     fn apply(
         dest: &mut Self::Storage,
         input_bytes: &[u8],
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
-        update_age: Duration,
     ) -> bool;
 
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output>;
 
     fn default_storage_value() -> Self::Storage;
 
-    fn is_valid(storage: &Self::Storage) -> bool;
+    fn set_valid(storage: &mut Self::Storage, valid: bool);
 }
 
 impl<A: FromBytes> Apply for A {
@@ -182,7 +177,6 @@ impl<A: FromBytes> Apply for A {
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
-        update_age: Duration,
     ) -> bool {
         let parsed_data = parse_bytes::<A>(
             input_bytes,
@@ -194,9 +188,6 @@ impl<A: FromBytes> Apply for A {
             *dest = (parsed_data, true);
             true
         } else {
-            if update_age > params.stale_age {
-                dest.1 = false;
-            }
             false
         }
     }
@@ -209,8 +200,8 @@ impl<A: FromBytes> Apply for A {
         (A::from_storage(&storage.0), storage.1)
     }
 
-    fn is_valid(storage: &Self::Storage) -> bool {
-        storage.1
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.1 = valid;
     }
 }
 
@@ -224,7 +215,6 @@ impl<A: FromBytes, B: FromBytes> Apply for (A, B) {
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
-        update_age: Duration,
     ) -> bool {
         let parsed_data_a = parse_bytes::<A>(
             input_bytes,
@@ -242,9 +232,6 @@ impl<A: FromBytes, B: FromBytes> Apply for (A, B) {
             *dest = (parsed_data_a, parsed_data_b, true);
             true
         } else {
-            if update_age > params.stale_age {
-                dest.2 = false;
-            }
             false
         }
     }
@@ -260,8 +247,9 @@ impl<A: FromBytes, B: FromBytes> Apply for (A, B) {
             storage.2,
         )
     }
-    fn is_valid(storage: &Self::Storage) -> bool {
-        storage.2
+
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.2 = valid;
     }
 }
 
@@ -275,7 +263,6 @@ impl<A: FromBytes, B: FromBytes, C: FromBytes> Apply for (A, B, C) {
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
-        update_age: Duration,
     ) -> bool {
         let parsed_data_a = parse_bytes::<A>(
             input_bytes,
@@ -301,9 +288,6 @@ impl<A: FromBytes, B: FromBytes, C: FromBytes> Apply for (A, B, C) {
             *dest = (parsed_data_a, parsed_data_b, parsed_data_c, true);
             true
         } else {
-            if update_age > params.stale_age {
-                dest.3 = false;
-            }
             false
         }
     }
@@ -325,8 +309,9 @@ impl<A: FromBytes, B: FromBytes, C: FromBytes> Apply for (A, B, C) {
             storage.3,
         )
     }
-    fn is_valid(storage: &Self::Storage) -> bool {
-        storage.3
+
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.3 = valid;
     }
 }
 
@@ -340,7 +325,6 @@ impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes> Apply for (A, B, C,
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
-        update_age: Duration,
     ) -> bool {
         let parsed_data_a = parse_bytes::<A>(
             input_bytes,
@@ -382,9 +366,6 @@ impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes> Apply for (A, B, C,
             );
             true
         } else {
-            if update_age > params.stale_age {
-                dest.4 = false;
-            }
             false
         }
     }
@@ -409,8 +390,8 @@ impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes> Apply for (A, B, C,
         )
     }
 
-    fn is_valid(storage: &Self::Storage) -> bool {
-        storage.4
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.4 = valid;
     }
 }
 
@@ -433,7 +414,6 @@ impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes, E: FromBytes> Apply
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
-        update_age: Duration,
     ) -> bool {
         let parsed_data_a = parse_bytes::<A>(
             input_bytes,
@@ -488,9 +468,6 @@ impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes, E: FromBytes> Apply
             );
             true
         } else {
-            if update_age > params.stale_age {
-                dest.5 = false;
-            }
             false
         }
     }
@@ -517,8 +494,8 @@ impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes, E: FromBytes> Apply
         )
     }
 
-    fn is_valid(storage: &Self::Storage) -> bool {
-        storage.5
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.5 = valid;
     }
 }
 
@@ -542,7 +519,6 @@ impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes, E: FromBytes, F: Fr
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
-        update_age: Duration,
     ) -> bool {
         let parsed_data_a = parse_bytes::<A>(
             input_bytes,
@@ -606,9 +582,6 @@ impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes, E: FromBytes, F: Fr
             );
             true
         } else {
-            if update_age > params.stale_age {
-                dest.6 = false;
-            }
             false
         }
     }
@@ -637,8 +610,8 @@ impl<A: FromBytes, B: FromBytes, C: FromBytes, D: FromBytes, E: FromBytes, F: Fr
         )
     }
 
-    fn is_valid(storage: &Self::Storage) -> bool {
-        storage.6
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.6 = valid;
     }
 }
 
@@ -670,7 +643,6 @@ impl<
         params: &Parameters,
         delim_idxs: &[usize],
         delim_len: usize,
-        update_age: Duration,
     ) -> bool {
         let parsed_data_a = parse_bytes::<A>(
             input_bytes,
@@ -743,9 +715,6 @@ impl<
             );
             true
         } else {
-            if update_age > params.stale_age {
-                dest.7 = false;
-            }
             false
         }
     }
@@ -776,8 +745,8 @@ impl<
         )
     }
 
-    fn is_valid(storage: &Self::Storage) -> bool {
-        storage.7
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.7 = valid;
     }
 }
 
@@ -797,20 +766,17 @@ mod tests {
         let output = block.process(&params, &context, input);
         assert_eq!(output, (123.0, 42.0, b"4.56".as_slice(), true));
         assert_eq!(block.buffer(), (123.0, 42.0, b"4.56".as_slice(), true));
-        assert!(block.is_valid(0.0));
 
         context.time += context.fundamental_timestep;
         let input = br#"123:4.56:78.9"#;
         let output = block.process(&params, &context, input);
         assert_eq!(output, (123.0, 42.0, b"4.56".as_slice(), true)); // stale time has not elapsed
         assert_eq!(block.buffer(), (123.0, 42.0, b"4.56".as_slice(), true));
-        assert!(block.is_valid(0.0));
 
         context.time = Duration::from_secs_f64(2.0);
         let output = block.process(&params, &context, input);
         assert_eq!(output, (123.0, 42.0, b"4.56".as_slice(), false)); // stale time has elapsed
         assert_eq!(block.buffer(), (123.0, 42.0, b"4.56".as_slice(), false));
-        assert!(!block.is_valid(0.0));
 
         // Now input is valid again
         context.time += context.fundamental_timestep;
@@ -818,7 +784,6 @@ mod tests {
         let output = block.process(&params, &context, input);
         assert_eq!(output, (1.03, 11.0, b"17".as_slice(), true));
         assert_eq!(block.buffer(), (1.03, 11.0, b"17".as_slice(), true));
-        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -832,7 +797,6 @@ mod tests {
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (b"\x00".as_ref(), b"\x02".as_ref(), true));
         assert_eq!(block.buffer(), (b"\x00".as_ref(), b"\x02".as_ref(), true));
-        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -845,7 +809,6 @@ mod tests {
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (42.0, true));
         assert_eq!(block.buffer(), (42.0, true));
-        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -858,7 +821,6 @@ mod tests {
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (123.0, b"42.0".as_slice(), true));
         assert_eq!(block.buffer(), (123.0, b"42.0".as_slice(), true));
-        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -871,7 +833,6 @@ mod tests {
         let output = block.process(&parameters, &context, input);
         assert_eq!(output, (123.0, 42.0, b"4.56".as_slice(), true));
         assert_eq!(block.buffer(), (123.0, 42.0, b"4.56".as_slice(), true));
-        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -891,7 +852,6 @@ mod tests {
             block.buffer(),
             (123.0, 42.0, 4.56, b"78.9".as_slice(), true)
         );
-        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -917,7 +877,6 @@ mod tests {
             block.buffer(),
             (123.0, 42.0, 4.56, 78.9, b"78.9".as_slice(), true)
         );
-        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -947,7 +906,6 @@ mod tests {
             block.buffer(),
             (123.0, 42.0, b"78.9".as_slice(), 4.56, 78.9, 4.56, true)
         );
-        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -1004,6 +962,5 @@ mod tests {
                 true
             )
         );
-        assert!(block.is_valid(0.0));
     }
 }

--- a/pictorus-blocks/src/alloc_blocks/bytes_split_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/bytes_split_block.rs
@@ -1,5 +1,5 @@
 use crate::byte_data::{find_all_bytes_idx, parse_string_to_read_delimiter};
-use crate::stale_tracker::StaleTracker;
+use crate::stale_tracker::{duration_from_ms_f64, StaleTracker};
 use crate::traits::{DefaultStorage, Scalar};
 use alloc::borrow::ToOwned;
 use alloc::{string::String, vec::Vec};
@@ -39,7 +39,7 @@ impl Parameters {
         Self {
             delimiter: delimiter.to_owned(),
             desired_output_idx,
-            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
+            stale_age: duration_from_ms_f64(stale_age_ms),
         }
     }
 

--- a/pictorus-blocks/src/alloc_blocks/bytes_unpack_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/bytes_unpack_block.rs
@@ -1,6 +1,9 @@
 use core::time::Duration;
 
-use crate::{stale_tracker::StaleTracker, traits::Scalar};
+use crate::{
+    stale_tracker::{duration_from_ms_f64, StaleTracker},
+    traits::Scalar,
+};
 use generic_array::{ArrayLength, GenericArray};
 use typenum::{Const, NonZero, Sub1, ToUInt, B1, U};
 
@@ -92,7 +95,7 @@ impl<N: ArrayLength> Parameters<N> {
             .expect("Bytes Data Spec is incorrectly sized for the number of inputs");
         Self {
             pack_spec,
-            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
+            stale_age: duration_from_ms_f64(stale_age_ms),
         }
     }
 }

--- a/pictorus-blocks/src/alloc_blocks/bytes_unpack_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/bytes_unpack_block.rs
@@ -1,6 +1,6 @@
 use core::time::Duration;
 
-use crate::{traits::Scalar, IsValid};
+use crate::{stale_tracker::StaleTracker, traits::Scalar};
 use generic_array::{ArrayLength, GenericArray};
 use typenum::{Const, NonZero, Sub1, ToUInt, B1, U};
 
@@ -8,17 +8,19 @@ use crate::byte_data::{parse_byte_data_spec, try_unpack_data, ByteOrderSpec, Dat
 use pictorus_traits::{ByteSliceSignal, PassBy, ProcessBlock};
 
 /// Unpacks a byte slice into a specified number of outputs based on the provided data types and byte order.
+///
+/// The output is `[f64; N]` where the last element is a `1.0`/`0.0` validity flag — true while
+/// the most recent successful unpack is still within the configured `stale_age`.
 pub struct BytesUnpackBlock<const N: usize> {
     buffer: [f64; N],
-    last_valid_time: Option<Duration>,
+    stale_check: StaleTracker,
 }
 
 impl<const N: usize> Default for BytesUnpackBlock<N> {
     fn default() -> Self {
-        let buffer = [0.0; N];
         BytesUnpackBlock {
-            buffer,
-            last_valid_time: None,
+            buffer: [0.0; N],
+            stale_check: StaleTracker::default(),
         }
     }
 }
@@ -46,16 +48,9 @@ where
         context: &dyn pictorus_traits::Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
-        let maybe_stale = if let Some(last_valid) = self.last_valid_time {
-            (context.time() - last_valid) > parameters.stale_age
-        } else {
-            // We've never had a valid time, so consider it stale if we don't get a valid read now
-            true
-        };
         let mut new_buffer = [0.0; N];
-        // Use Unpack::unpack N-1 times to fill the buffer
-        // if it fails at any point, keep the old buffer values
-        // the data at N is the `is_valid` flag
+        // Use Unpack::unpack N-1 times to fill the buffer; if it fails at any point,
+        // keep the old buffer values. The data at N-1 is the `is_valid` flag.
         let mut inputs = inputs;
         let mut unpack_success = true;
         for (i, elem) in new_buffer.iter_mut().enumerate().take(N - 1) {
@@ -70,24 +65,22 @@ where
             inputs = advanced_data;
         }
         if unpack_success {
-            new_buffer[N - 1] = 1.0; // last element is is_valid flag
             self.buffer = new_buffer;
-            self.last_valid_time = Some(context.time());
-        } else if maybe_stale {
-            // If we failed to unpack and it is stale, keep the old buffer but mark as invalid
-            self.buffer[N - 1] = 0.0; // last element is is_valid flag
+            self.stale_check.mark_updated(context.time());
         }
+        self.buffer[N - 1] = if self
+            .stale_check
+            .is_valid(context.time(), parameters.stale_age)
+        {
+            1.0
+        } else {
+            0.0
+        };
         &self.buffer
     }
 
     fn buffer(&self) -> PassBy<'_, Self::Output> {
         &self.buffer
-    }
-}
-
-impl<const N: usize> IsValid for BytesUnpackBlock<N> {
-    fn is_valid(&self, _app_time_s: f64) -> bool {
-        self.buffer[N - 1] != 0.0
     }
 }
 

--- a/pictorus-blocks/src/alloc_blocks/i2c_input_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/i2c_input_block.rs
@@ -3,7 +3,7 @@ use core::time::Duration;
 use alloc::vec::Vec;
 use pictorus_traits::{ByteSliceSignal, Context, PassBy, ProcessBlock};
 
-use crate::stale_tracker::StaleTracker;
+use crate::stale_tracker::{duration_from_ms_f64, StaleTracker};
 
 /// Parameters for I2C Input Block
 #[doc(hidden)]
@@ -28,7 +28,7 @@ impl Parameters {
             address: addr_u8,
             command: command_u8,
             read_bytes: read_bytes_u8,
-            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
+            stale_age: duration_from_ms_f64(stale_age_ms),
         }
     }
 }

--- a/pictorus-blocks/src/alloc_blocks/i2c_input_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/i2c_input_block.rs
@@ -1,7 +1,9 @@
+use core::time::Duration;
+
 use alloc::vec::Vec;
 use pictorus_traits::{ByteSliceSignal, Context, PassBy, ProcessBlock};
 
-use crate::{stale_tracker::StaleTracker, IsValid};
+use crate::stale_tracker::StaleTracker;
 
 /// Parameters for I2C Input Block
 #[doc(hidden)]
@@ -12,8 +14,8 @@ pub struct Parameters {
     pub command: u8,
     /// Number of bytes to read from the I2C device
     pub read_bytes: usize,
-    /// Stale age in milliseconds
-    stale_age_ms: f64,
+    /// Stale age
+    stale_age: Duration,
 }
 
 impl Parameters {
@@ -26,34 +28,17 @@ impl Parameters {
             address: addr_u8,
             command: command_u8,
             read_bytes: read_bytes_u8,
-            stale_age_ms,
+            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
         }
     }
 }
 
 /// I2C Input Block buffers data read from an I2C peripheral.
+#[derive(Default)]
 pub struct I2cInputBlock {
-    pub stale_check: StaleTracker,
+    stale_check: StaleTracker,
     buffer: Vec<u8>,
     last_valid: bool,
-    previous_stale_check_time_ms: f64,
-}
-
-impl Default for I2cInputBlock {
-    fn default() -> Self {
-        Self {
-            stale_check: StaleTracker::from_ms(0.0),
-            buffer: Vec::new(),
-            last_valid: false,
-            previous_stale_check_time_ms: 0.,
-        }
-    }
-}
-
-impl IsValid for I2cInputBlock {
-    fn is_valid(&self, app_time_s: f64) -> bool {
-        self.stale_check.is_valid(app_time_s)
-    }
 }
 
 impl ProcessBlock for I2cInputBlock {
@@ -67,20 +52,17 @@ impl ProcessBlock for I2cInputBlock {
         context: &dyn Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
-        if self.previous_stale_check_time_ms != parameters.stale_age_ms {
-            self.stale_check = StaleTracker::from_ms(parameters.stale_age_ms);
-            self.previous_stale_check_time_ms = parameters.stale_age_ms;
-        }
-
         // Make sure the data is the correct size, if so, update the stale check, otherwise
         // something has gone wrong.
         if inputs.len() == parameters.read_bytes {
             self.buffer.clear();
-            self.stale_check.mark_updated(context.time().as_secs_f64());
+            self.stale_check.mark_updated(context.time());
             self.buffer.extend_from_slice(inputs);
         }
 
-        self.last_valid = self.stale_check.is_valid_bool(context.time().as_secs_f64());
+        self.last_valid = self
+            .stale_check
+            .is_valid(context.time(), parameters.stale_age);
         (&self.buffer, self.last_valid)
     }
 
@@ -115,17 +97,15 @@ mod tests {
             (data.to_vec(), valid)
         };
         assert_eq!(output.0, input_data);
+        assert!(output.1);
         assert_eq!(block.buffer(), (output.0.as_slice(), output.1));
-        let valid = block.is_valid(runtime.context().time().as_secs_f64());
-        assert!(valid);
 
         runtime.set_time(Duration::from_secs(1));
 
         // When the I2cWrapper has an error, the buffer is clear and the parameters.read_bytes is not
         // equal to the length of the empty buffer, however the previous value is buffered
-        let output = block.process(&parameters, &runtime.context(), &[]);
-        assert_eq!(output.0, input_data);
-        let valid = block.is_valid(runtime.context().time().as_secs_f64());
+        let (data, valid) = block.process(&parameters, &runtime.context(), &[]);
+        assert_eq!(data, input_data);
         assert!(!valid);
     }
 }

--- a/pictorus-blocks/src/alloc_blocks/json_load_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/json_load_block.rs
@@ -1,10 +1,11 @@
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::time::Duration;
 
 use miniserde::json::{self, Array, Number, Object, Value};
 use pictorus_traits::{ByteSliceSignal, Context, Matrix, Pass, PassBy, ProcessBlock};
 
-use crate::{stale_tracker::StaleTracker, traits::DefaultStorage, IsValid};
+use crate::{stale_tracker::StaleTracker, traits::DefaultStorage};
 
 /// Block-output data shape, parsed from the user-supplied select-data spec strings.
 ///
@@ -41,15 +42,14 @@ impl core::str::FromStr for BlockDataType {
 /// that the passed in bytes represent a single value (either scalar or matrix).
 pub struct JsonLoadBlock<T: Apply> {
     buffer: T::Storage,
-    stale_tracker: Option<StaleTracker>,
+    stale_check: StaleTracker,
 }
 
 impl<T: Apply> Default for JsonLoadBlock<T> {
     fn default() -> Self {
-        let buffer = T::default_storage();
         JsonLoadBlock {
-            buffer,
-            stale_tracker: None,
+            buffer: T::default_storage(),
+            stale_check: StaleTracker::default(),
         }
     }
 }
@@ -65,27 +65,18 @@ impl<T: Apply> ProcessBlock for JsonLoadBlock<T> {
         context: &dyn Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
-        let success = T::apply(&mut self.buffer, inputs, parameters);
-        if success.is_ok() {
-            let tracker = self
-                .stale_tracker
-                .get_or_insert(StaleTracker::from_ms(parameters.stale_age_ms));
-            tracker.mark_updated(context.time().as_secs_f64());
+        if T::apply(&mut self.buffer, inputs, parameters).is_ok() {
+            self.stale_check.mark_updated(context.time());
         }
+        let valid = self
+            .stale_check
+            .is_valid(context.time(), parameters.stale_age);
+        T::set_valid(&mut self.buffer, valid);
         T::storage_as_by(&self.buffer)
     }
 
     fn buffer(&self) -> PassBy<'_, Self::Output> {
         T::storage_as_by(&self.buffer)
-    }
-}
-
-impl<T: Apply> IsValid for JsonLoadBlock<T> {
-    fn is_valid(&self, app_time_s: f64) -> bool {
-        match self.stale_tracker {
-            Some(ref tracker) => tracker.is_valid(app_time_s),
-            None => false,
-        }
     }
 }
 
@@ -96,8 +87,8 @@ pub struct Parameters {
     /// Note: The data type is not actually used in code, but encoded into the
     /// generics of the block instance.
     pub select_data: Vec<(BlockDataType, String)>,
-    /// The age in milliseconds after which the data is considered stale
-    pub stale_age_ms: f64,
+    /// The age after which the data is considered stale
+    pub stale_age: Duration,
 }
 
 impl Parameters {
@@ -108,7 +99,7 @@ impl Parameters {
         let select_data = Self::parse_select_spec(select_data);
         Self {
             select_data,
-            stale_age_ms,
+            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
         }
     }
 
@@ -230,6 +221,9 @@ pub trait Apply: Pass {
 
     fn default_storage() -> Self::Storage;
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output>;
+    /// Overwrites the trailing validity bool in `storage`. The block sets this from its
+    /// [`StaleTracker`] after each call to [`apply`].
+    fn set_valid(storage: &mut Self::Storage, valid: bool);
 }
 
 fn parse_number(num_val: &Number) -> f64 {
@@ -265,7 +259,6 @@ impl<A: Deserialize> Apply for A {
             *dest = (v1, true);
             Ok(())
         } else {
-            dest.1 = false;
             Err(())
         }
     }
@@ -276,6 +269,10 @@ impl<A: Deserialize> Apply for A {
 
     fn storage_as_by(storage: &Self::Storage) -> PassBy<'_, Self::Output> {
         (A::from_storage(&storage.0), storage.1)
+    }
+
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.1 = valid;
     }
 }
 
@@ -297,7 +294,6 @@ impl<A: Deserialize, B: Deserialize> Apply for (A, B) {
             *dest = (v1, v2, true);
             Ok(())
         } else {
-            dest.2 = false;
             Err(())
         }
     }
@@ -312,6 +308,10 @@ impl<A: Deserialize, B: Deserialize> Apply for (A, B) {
             B::from_storage(&storage.1),
             storage.2,
         )
+    }
+
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.2 = valid;
     }
 }
 
@@ -334,7 +334,6 @@ impl<A: Deserialize, B: Deserialize, C: Deserialize> Apply for (A, B, C) {
             *dest = (v1, v2, v3, true);
             Ok(())
         } else {
-            dest.3 = false;
             Err(())
         }
     }
@@ -355,6 +354,10 @@ impl<A: Deserialize, B: Deserialize, C: Deserialize> Apply for (A, B, C) {
             C::from_storage(&storage.2),
             storage.3,
         )
+    }
+
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.3 = valid;
     }
 }
 
@@ -378,7 +381,6 @@ impl<A: Deserialize, B: Deserialize, C: Deserialize, D: Deserialize> Apply for (
             *dest = (v1, v2, v3, v4, true);
             Ok(())
         } else {
-            dest.4 = false;
             Err(())
         }
     }
@@ -401,6 +403,10 @@ impl<A: Deserialize, B: Deserialize, C: Deserialize, D: Deserialize> Apply for (
             D::from_storage(&storage.3),
             storage.4,
         )
+    }
+
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.4 = valid;
     }
 }
 
@@ -434,7 +440,6 @@ impl<A: Deserialize, B: Deserialize, C: Deserialize, D: Deserialize, E: Deserial
             *dest = (v1, v2, v3, v4, v5, true);
             Ok(())
         } else {
-            dest.5 = false;
             Err(())
         }
     }
@@ -459,6 +464,10 @@ impl<A: Deserialize, B: Deserialize, C: Deserialize, D: Deserialize, E: Deserial
             E::from_storage(&storage.4),
             storage.5,
         )
+    }
+
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.5 = valid;
     }
 }
 
@@ -500,7 +509,6 @@ impl<
             *dest = (v1, v2, v3, v4, v5, v6, true);
             Ok(())
         } else {
-            dest.6 = false;
             Err(())
         }
     }
@@ -525,6 +533,10 @@ impl<
             F::from_storage(&storage.5),
             storage.6,
         )
+    }
+
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.6 = valid;
     }
 }
 
@@ -571,7 +583,6 @@ impl<
             *dest = (v1, v2, v3, v4, v5, v6, v7, true);
             Ok(())
         } else {
-            dest.7 = false;
             Err(())
         }
     }
@@ -601,6 +612,10 @@ impl<
             storage.7,
         )
     }
+
+    fn set_valid(storage: &mut Self::Storage, valid: bool) {
+        storage.7 = valid;
+    }
 }
 
 #[cfg(test)]
@@ -623,7 +638,6 @@ mod tests {
         let mut block = JsonLoadBlock::<f64>::default();
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (1.2, true));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()));
         assert_eq!(block.buffer(), res);
     }
 
@@ -657,7 +671,6 @@ mod tests {
 
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -669,7 +682,6 @@ mod tests {
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (0.0, false));
         assert_eq!(block.buffer(), (0.0, false));
-        assert!(!block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -681,7 +693,6 @@ mod tests {
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (0.0, false));
         assert_eq!(block.buffer(), (0.0, false));
-        assert!(!block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -693,7 +704,6 @@ mod tests {
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (0.0, false));
         assert_eq!(block.buffer(), (0.0, false));
-        assert!(!block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -708,7 +718,6 @@ mod tests {
         };
         assert_eq!(res, (expected, true));
         assert_eq!(block.buffer(), (expected, true));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -721,7 +730,6 @@ mod tests {
         let expected = &Matrix { data: [[]] };
         assert_eq!(res, (expected, true));
         assert_eq!(block.buffer(), (expected, true));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -736,7 +744,6 @@ mod tests {
         };
         assert_eq!(res, (expected, true));
         assert_eq!(block.buffer(), (expected, true));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -748,7 +755,6 @@ mod tests {
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (1.0, true));
         assert_eq!(block.buffer(), (1.0, true));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -760,7 +766,6 @@ mod tests {
         let res = block.process(&params, &ctxt, input);
         assert_eq!(res, (1.0, b"hello".as_slice(), true));
         assert_eq!(block.buffer(), (1.0, b"hello".as_slice(), true));
-        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -787,7 +792,6 @@ mod tests {
         );
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -821,7 +825,6 @@ mod tests {
         );
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -860,7 +863,6 @@ mod tests {
         );
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -902,7 +904,6 @@ mod tests {
         );
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
-        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 
     #[test]
@@ -962,7 +963,5 @@ mod tests {
 
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
-
-        assert!(block.is_valid(ctxt.time().as_secs_f64()));
     }
 }

--- a/pictorus-blocks/src/alloc_blocks/json_load_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/json_load_block.rs
@@ -5,7 +5,10 @@ use core::time::Duration;
 use miniserde::json::{self, Array, Number, Object, Value};
 use pictorus_traits::{ByteSliceSignal, Context, Matrix, Pass, PassBy, ProcessBlock};
 
-use crate::{stale_tracker::StaleTracker, traits::DefaultStorage};
+use crate::{
+    stale_tracker::{duration_from_ms_f64, StaleTracker},
+    traits::DefaultStorage,
+};
 
 /// Block-output data shape, parsed from the user-supplied select-data spec strings.
 ///
@@ -99,7 +102,7 @@ impl Parameters {
         let select_data = Self::parse_select_spec(select_data);
         Self {
             select_data,
-            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
+            stale_age: duration_from_ms_f64(stale_age_ms),
         }
     }
 

--- a/pictorus-blocks/src/alloc_blocks/serial_receive_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/serial_receive_block.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use core::time::Duration;
 use core::{cmp::min, str};
 
 use log::debug;
@@ -10,7 +11,6 @@ use crate::{
         rfind_bytes_idx, ByteDataError, BUFF_SIZE_BYTES,
     },
     stale_tracker::StaleTracker,
-    IsValid,
 };
 
 /// Parameters for the Serial Receive Block
@@ -28,9 +28,9 @@ pub struct Parameters {
     end_delimiter: (Vec<u8>, Vec<usize>, usize),
     /// The number of bytes to read from the peripheral
     read_bytes: usize,
-    /// The age in milliseconds before the data is considered stale. Stale date is still
-    /// cached until new data comes in.
-    stale_age_ms: f64,
+    /// The age before the data is considered stale. Stale data is still cached until
+    /// new data comes in.
+    stale_age: Duration,
 }
 
 impl Parameters {
@@ -52,7 +52,7 @@ impl Parameters {
             start_delimiter,
             end_delimiter,
             read_bytes: read_bytes as usize,
-            stale_age_ms,
+            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
         }
     }
 }
@@ -63,30 +63,12 @@ impl Parameters {
 /// The `is_valid` signal will continue to emit true as long as new
 /// data is received before the specified expiration period elapses.
 /// The block caches data until a new message is received and parsed.
+#[derive(Default)]
 pub struct SerialReceiveBlock {
     buffer: Vec<u8>,
-    pub stale_check: StaleTracker,
-    previous_stale_check_time_ms: f64,
+    stale_check: StaleTracker,
     output: Vec<u8>,
     last_valid: bool,
-}
-
-impl Default for SerialReceiveBlock {
-    fn default() -> Self {
-        SerialReceiveBlock {
-            buffer: Vec::new(),
-            stale_check: StaleTracker::from_ms(0.0),
-            previous_stale_check_time_ms: 0.0,
-            output: Vec::new(),
-            last_valid: false,
-        }
-    }
-}
-
-impl IsValid for SerialReceiveBlock {
-    fn is_valid(&self, app_time_s: f64) -> bool {
-        self.stale_check.is_valid(app_time_s)
-    }
 }
 
 impl SerialReceiveBlock {
@@ -228,11 +210,6 @@ impl ProcessBlock for SerialReceiveBlock {
         context: &dyn Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
-        if self.previous_stale_check_time_ms != parameters.stale_age_ms {
-            self.stale_check = StaleTracker::from_ms(parameters.stale_age_ms);
-            self.previous_stale_check_time_ms = parameters.stale_age_ms;
-        }
-
         // Inputs is a Vec<u8> copying into a Vec<u8>
         self.buffer.extend_from_slice(inputs);
 
@@ -248,14 +225,16 @@ impl ProcessBlock for SerialReceiveBlock {
             self.buffer
                 .drain(..(min(end_idx + parameters.end_delimiter.2, self.buffer.len())));
 
-            self.stale_check.mark_updated(context.time().as_secs_f64());
+            self.stale_check.mark_updated(context.time());
         } else if self.buffer.len() >= BUFF_SIZE_BYTES * 2 {
             self.buffer.clear();
             self.buffer.extend_from_slice(inputs);
             debug!("Read too many bytes without a valid message. Clearing buffer",);
         }
 
-        self.last_valid = self.stale_check.is_valid_bool(context.time().as_secs_f64());
+        self.last_valid = self
+            .stale_check
+            .is_valid(context.time(), parameters.stale_age);
         (&self.output, self.last_valid)
     }
 
@@ -333,26 +312,17 @@ mod tests {
         let input_data = b"$Hello World\r\n";
         let result = block.process(&parameters, &runtime.context(), input_data);
         assert!(result.1);
-        assert!(block
-            .stale_check
-            .is_valid(runtime.context().time().as_secs_f64()));
 
         for i in 1..11 {
             // 100ms to 1s
             runtime.set_time(Duration::from_millis(i * 100)); // 10 Hz runtime (100ms per tick)
             let result = block.process(&parameters, &runtime.context(), &[]);
             assert!(result.1);
-            assert!(block
-                .stale_check
-                .is_valid(runtime.context().time().as_secs_f64()));
         }
 
         // Stale
         runtime.set_time(Duration::from_millis(11 * 100)); // 1.1s
         let result = block.process(&parameters, &runtime.context(), &[]);
         assert!(!result.1);
-        assert!(!block
-            .stale_check
-            .is_valid(runtime.context().time().as_secs_f64()));
     }
 }

--- a/pictorus-blocks/src/alloc_blocks/serial_receive_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/serial_receive_block.rs
@@ -10,7 +10,7 @@ use crate::{
         compare_bytes, find_bytes_idx, parse_string_to_read_delimiter, rfind_all_bytes_idx,
         rfind_bytes_idx, ByteDataError, BUFF_SIZE_BYTES,
     },
-    stale_tracker::StaleTracker,
+    stale_tracker::{duration_from_ms_f64, StaleTracker},
 };
 
 /// Parameters for the Serial Receive Block
@@ -52,7 +52,7 @@ impl Parameters {
             start_delimiter,
             end_delimiter,
             read_bytes: read_bytes as usize,
-            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
+            stale_age: duration_from_ms_f64(stale_age_ms),
         }
     }
 }

--- a/pictorus-blocks/src/alloc_blocks/spi_receive_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/spi_receive_block.rs
@@ -1,22 +1,23 @@
 use alloc::vec::Vec;
+use core::time::Duration;
 use pictorus_traits::{ByteSliceSignal, Context, PassBy, ProcessBlock};
 
-use crate::{stale_tracker::StaleTracker, IsValid};
+use crate::stale_tracker::StaleTracker;
 
 /// Parameters for the SPI receive block
 #[doc(hidden)]
 pub struct Parameters {
     /// Number of bytes to read from the SPI interface
     pub read_bytes: usize,
-    /// Time in milliseconds after which the data is considered stale
-    stale_age_ms: f64,
+    /// Time after which the data is considered stale
+    stale_age: Duration,
 }
 
 impl Parameters {
     pub fn new(read_bytes: f64, stale_age_ms: f64) -> Self {
         Self {
             read_bytes: read_bytes as usize,
-            stale_age_ms,
+            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
         }
     }
 }
@@ -25,22 +26,11 @@ impl Parameters {
 ///
 /// If data is not received within the time indicated in the Parameters, the data is considered stale.
 /// The last valid data is kept in the buffer until new data arrives.
+#[derive(Default)]
 pub struct SpiReceiveBlock {
     buffer: Vec<u8>,
-    pub stale_check: StaleTracker,
-    previous_stale_check_time_ms: f64,
+    stale_check: StaleTracker,
     last_valid: bool,
-}
-
-impl Default for SpiReceiveBlock {
-    fn default() -> Self {
-        Self {
-            buffer: Vec::new(),
-            stale_check: StaleTracker::from_ms(0.),
-            previous_stale_check_time_ms: 0.0,
-            last_valid: false,
-        }
-    }
 }
 
 impl ProcessBlock for SpiReceiveBlock {
@@ -54,31 +44,22 @@ impl ProcessBlock for SpiReceiveBlock {
         context: &dyn Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
-        if self.previous_stale_check_time_ms != parameters.stale_age_ms {
-            self.stale_check = StaleTracker::from_ms(parameters.stale_age_ms);
-            self.previous_stale_check_time_ms = parameters.stale_age_ms;
-        }
-
         if inputs.len() == parameters.read_bytes {
             // TODO: Error handling strategy for hardware SPI / I2C / etc. that isn't a simple buffer
             // length check.
             self.buffer.clear();
             self.buffer.extend_from_slice(inputs);
-            self.stale_check.mark_updated(context.time().as_secs_f64());
+            self.stale_check.mark_updated(context.time());
         }
 
-        self.last_valid = self.stale_check.is_valid_bool(context.time().as_secs_f64());
+        self.last_valid = self
+            .stale_check
+            .is_valid(context.time(), parameters.stale_age);
         (&self.buffer, self.last_valid)
     }
 
     fn buffer(&self) -> PassBy<'_, Self::Output> {
         (&self.buffer, self.last_valid)
-    }
-}
-
-impl IsValid for SpiReceiveBlock {
-    fn is_valid(&self, app_time_s: f64) -> bool {
-        self.stale_check.is_valid(app_time_s)
     }
 }
 
@@ -88,7 +69,6 @@ mod tests {
 
     use super::*;
     use crate::testing::StubRuntime;
-    use pictorus_traits::Context;
 
     #[test]
     fn test_spi_receive_default_buffer_no_panic() {
@@ -109,21 +89,14 @@ mod tests {
             (data.to_vec(), valid)
         };
         assert_eq!(output.0, input_data);
+        assert!(output.1);
         assert_eq!(block.buffer(), (output.0.as_slice(), output.1));
-        let is_valid = block
-            .stale_check
-            .is_valid(runtime.context().time().as_secs_f64());
-        assert!(is_valid);
 
         runtime.set_time(Duration::from_secs(1));
 
-        let output = block.process(&parameters, &runtime.context(), &[]);
-        assert_eq!(output.0, input_data);
-        assert_eq!(block.buffer().0, input_data);
-        let is_valid = block
-            .stale_check
-            .is_valid(runtime.context().time().as_secs_f64());
-        // However block should be invalid
-        assert!(!is_valid);
+        let (data, valid) = block.process(&parameters, &runtime.context(), &[]);
+        assert_eq!(data, input_data);
+        // Stale: buffered data is preserved, but `is_valid` flips to false
+        assert!(!valid);
     }
 }

--- a/pictorus-blocks/src/alloc_blocks/spi_receive_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/spi_receive_block.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::time::Duration;
 use pictorus_traits::{ByteSliceSignal, Context, PassBy, ProcessBlock};
 
-use crate::stale_tracker::StaleTracker;
+use crate::stale_tracker::{duration_from_ms_f64, StaleTracker};
 
 /// Parameters for the SPI receive block
 #[doc(hidden)]
@@ -17,7 +17,7 @@ impl Parameters {
     pub fn new(read_bytes: f64, stale_age_ms: f64) -> Self {
         Self {
             read_bytes: read_bytes as usize,
-            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
+            stale_age: duration_from_ms_f64(stale_age_ms),
         }
     }
 }

--- a/pictorus-blocks/src/core_blocks/can_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/can_receive_block.rs
@@ -2,7 +2,10 @@ use core::time::Duration;
 
 use pictorus_traits::{ByteSliceSignal, Pass, ProcessBlock};
 
-use crate::{stale_tracker::StaleTracker, traits::Float};
+use crate::{
+    stale_tracker::{duration_from_ms_f64, StaleTracker},
+    traits::Float,
+};
 
 type RxCallback<C, S> = fn(&C, &mut [S]);
 
@@ -21,7 +24,7 @@ impl Parameters {
         Self {
             frame_id,
             length,
-            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
+            stale_age: duration_from_ms_f64(stale_age_ms),
         }
     }
 }

--- a/pictorus-blocks/src/core_blocks/can_receive_block.rs
+++ b/pictorus-blocks/src/core_blocks/can_receive_block.rs
@@ -1,6 +1,8 @@
+use core::time::Duration;
+
 use pictorus_traits::{ByteSliceSignal, Pass, ProcessBlock};
 
-use crate::{stale_tracker::StaleTracker, traits::Float, IsValid};
+use crate::{stale_tracker::StaleTracker, traits::Float};
 
 type RxCallback<C, S> = fn(&C, &mut [S]);
 
@@ -10,8 +12,8 @@ pub struct Parameters {
     pub frame_id: embedded_can::Id,
     /// Number of bytes in the data frame
     length: usize,
-    /// Stale age in milliseconds
-    stale_age_ms: f64,
+    /// Stale age — after this elapses without a new frame, the output is marked invalid.
+    stale_age: Duration,
 }
 
 impl Parameters {
@@ -19,7 +21,7 @@ impl Parameters {
         Self {
             frame_id,
             length,
-            stale_age_ms,
+            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
         }
     }
 }
@@ -40,7 +42,6 @@ pub struct CanReceiveBlock<
     _phantom: core::marker::PhantomData<O>,
     output_buffer: O::Output,
     cache: [S; N],
-    previous_stale_check_time_ms: f64,
 }
 
 impl<const N: usize, S: Float, C, O: Pass + Default + ToTupleOutput<S>> Default
@@ -58,11 +59,10 @@ impl<const N: usize, S: Float, C, O: Pass + Default + ToTupleOutput<S>>
         let cache = [S::zero(); N];
         CanReceiveBlock {
             rx_cb,
-            stale_check: StaleTracker::from_ms(0.),
+            stale_check: StaleTracker::default(),
             _phantom: core::marker::PhantomData,
             output_buffer: O::Output::default(),
             cache,
-            previous_stale_check_time_ms: 0.0,
         }
     }
 }
@@ -85,37 +85,23 @@ where
         context: &dyn pictorus_traits::Context,
         inputs: pictorus_traits::PassBy<'_, Self::Inputs>,
     ) -> pictorus_traits::PassBy<'_, Self::Output> {
-        if self.previous_stale_check_time_ms != parameters.stale_age_ms {
-            self.stale_check = StaleTracker::from_ms(parameters.stale_age_ms);
-            self.previous_stale_check_time_ms = parameters.stale_age_ms;
-        }
-
         if inputs.len() == parameters.length {
             if let Some(can_decoder) = C::new(parameters.frame_id, inputs) {
                 (self.rx_cb)(&can_decoder, self.cache.as_mut_slice());
-                self.stale_check.mark_updated(context.time().as_secs_f64());
+                self.stale_check.mark_updated(context.time());
             }
         }
 
-        // Update buffer
-        self.output_buffer = O::to_tuple(
-            &self.cache,
-            self.stale_check.is_valid_bool(context.time().as_secs_f64()),
-        )
-        .expect("parameters.signal_count is shorter than output tuple type");
+        let valid = self
+            .stale_check
+            .is_valid(context.time(), parameters.stale_age);
+        self.output_buffer = O::to_tuple(&self.cache, valid)
+            .expect("parameters.signal_count is shorter than output tuple type");
         self.output_buffer.as_by()
     }
 
     fn buffer(&self) -> pictorus_traits::PassBy<'_, Self::Output> {
         self.output_buffer.as_by()
-    }
-}
-
-impl<const N: usize, S: Float, C, O: Pass + Default + ToTupleOutput<S>> IsValid
-    for CanReceiveBlock<N, S, C, O>
-{
-    fn is_valid(&self, app_time_s: f64) -> bool {
-        self.stale_check.is_valid(app_time_s)
     }
 }
 
@@ -282,15 +268,13 @@ mod tests {
             CanReceiveBlock::<1, f64, StubCanParser, f64>::new(stub_can_parser_callback);
 
         let output = block.process(&parameters, &runtime.context(), &[42, 0, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(output.0, 42.);
-        assert!(block.is_valid(runtime.context().time.as_secs_f64()));
+        assert_eq!(output, (42., true));
 
         runtime.set_time(Duration::from_secs(2));
 
         // Simulate a stale message
         let output = block.process(&parameters, &runtime.context(), &[]);
-        assert_eq!(output.0, 42.);
-        assert!(!block.is_valid(runtime.context().time.as_secs_f64()));
+        assert_eq!(output, (42., false));
     }
 
     #[test]
@@ -307,14 +291,12 @@ mod tests {
 
         let output = block.process(&parameters, &runtime.context(), &[42, 1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(output, (42., 1., 2., 3., 4., 5., 6., true));
-        assert!(block.is_valid(runtime.context().time.as_secs_f64()));
 
         // Simulate stale message
         runtime.set_time(Duration::from_secs(2));
 
         let output = block.process(&parameters, &runtime.context(), &[]);
         assert_eq!(output, (42., 1., 2., 3., 4., 5., 6., false));
-        assert!(!block.is_valid(runtime.context().time.as_secs_f64()));
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/matrix_inverse_block.rs
+++ b/pictorus-blocks/src/core_blocks/matrix_inverse_block.rs
@@ -1,4 +1,4 @@
-use crate::{matrix_ext::MatrixNalgebraExt, IsValid};
+use crate::matrix_ext::MatrixNalgebraExt;
 use nalgebra::{
     allocator::Allocator, ArrayStorage, Const, DefaultAllocator, DimDiff, DimMin, DimMinimum,
     DimSub, SMatrix, SquareMatrix, ToTypenum, SVD, U1,
@@ -90,12 +90,6 @@ where
     }
 }
 
-impl<T: Apply<M>, M: Method> IsValid for MatrixInverseBlock<T, M> {
-    fn is_valid(&self, _: f64) -> bool {
-        self.is_data_valid
-    }
-}
-
 pub trait Apply<M: Method>: Pass {
     type Output: Pass + Default;
 
@@ -178,7 +172,6 @@ mod tests {
         let mut block = MatrixInverseBlock::<f64, Inverse>::default();
         let res = block.process(&params, &ctxt, 99.0);
         assert_eq!(res, (99.0, true));
-        assert!(block.is_valid(0.0));
         assert_eq!(block.buffer(), res);
     }
 
@@ -196,7 +189,7 @@ mod tests {
         assert!(res.1);
 
         assert_eq!(block.buffer().0.data, expected);
-        assert!(block.is_valid(0.0));
+        assert!(block.buffer().1);
     }
 
     #[test]
@@ -215,7 +208,7 @@ mod tests {
         assert!(!res.1);
 
         assert_eq!(invert_block.buffer().0.data, expected);
-        assert!(!invert_block.is_valid(0.0));
+        assert!(!invert_block.buffer().1);
 
         // SVD-based pseudo-inverse method should be fine
         let mut svd_block = MatrixInverseBlock::<Matrix<3, 3, f64>, Svd>::default();
@@ -237,7 +230,7 @@ mod tests {
             expected.as_flattened(),
             epsilon = 1e-8
         );
-        assert!(svd_block.is_valid(0.0));
+        assert!(svd_block.buffer().1);
     }
 
     #[test]
@@ -265,7 +258,6 @@ mod tests {
             epsilon = 1e-8
         );
         assert!(res.1);
-        assert!(block.is_valid(0.0));
     }
 
     #[test]
@@ -292,6 +284,5 @@ mod tests {
             epsilon = 1e-8
         );
         assert!(res.1);
-        assert!(block.is_valid(0.0));
     }
 }

--- a/pictorus-blocks/src/lib.rs
+++ b/pictorus-blocks/src/lib.rs
@@ -56,12 +56,3 @@ mod testing;
 #[derive(Debug)]
 /// Error raised when parsing an enum from a string fails.
 pub struct ParseEnumError;
-
-/// Trait for blocks that can have stale/invalid ouput.
-///
-/// Blocks that implement this trait should output a false value for `is_valid`
-/// if the output is not in a valid state.
-pub trait IsValid {
-    /// Returns `true` if the block output is in a valid state, `false` otherwise.
-    fn is_valid(&self, app_time_s: f64) -> bool;
-}

--- a/pictorus-blocks/src/stale_tracker.rs
+++ b/pictorus-blocks/src/stale_tracker.rs
@@ -18,6 +18,19 @@ impl StaleTracker {
     }
 }
 
+/// Convert a millisecond duration supplied as an `f64` parameter into a `Duration`.
+///
+/// `Duration::from_secs_f64` panics on negative, NaN, or infinite inputs. Codegen-supplied
+/// stale-age parameters are not statically validated, so out-of-domain values fold to
+/// `Duration::ZERO` — i.e. the block is treated as immediately stale rather than panicking.
+pub fn duration_from_ms_f64(ms: f64) -> Duration {
+    if ms.is_finite() && ms >= 0.0 {
+        Duration::from_secs_f64(ms / 1000.0)
+    } else {
+        Duration::ZERO
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -40,5 +53,19 @@ mod test {
         let mut tracker = StaleTracker::default();
         tracker.mark_updated(Duration::ZERO);
         assert!(!tracker.is_valid(Duration::from_secs(2), Duration::from_millis(1)));
+    }
+
+    #[test]
+    fn test_duration_from_ms_f64_normal() {
+        assert_eq!(duration_from_ms_f64(1500.0), Duration::from_millis(1500));
+        assert_eq!(duration_from_ms_f64(0.0), Duration::ZERO);
+    }
+
+    #[test]
+    fn test_duration_from_ms_f64_invalid_inputs_fold_to_zero() {
+        assert_eq!(duration_from_ms_f64(-1.0), Duration::ZERO);
+        assert_eq!(duration_from_ms_f64(f64::NAN), Duration::ZERO);
+        assert_eq!(duration_from_ms_f64(f64::INFINITY), Duration::ZERO);
+        assert_eq!(duration_from_ms_f64(f64::NEG_INFINITY), Duration::ZERO);
     }
 }

--- a/pictorus-blocks/src/stale_tracker.rs
+++ b/pictorus-blocks/src/stale_tracker.rs
@@ -1,86 +1,44 @@
-use embedded_time::{duration::*, fraction::Fraction, Clock, Instant};
+use core::time::Duration;
 
-struct GenericClock;
-impl Clock for GenericClock {
-    type T = u64;
-
-    const SCALING_FACTOR: Fraction = Fraction::new(1, 1_000_000);
-
-    fn try_now(&self) -> Result<Instant<Self>, embedded_time::clock::Error> {
-        panic!(
-            "GenericClock is only used to calculate time elapsed. It cannot fetch the current time"
-        )
-    }
-}
-
+#[derive(Default)]
 pub struct StaleTracker {
-    stale_duration: Milliseconds<u64>,
-    last_updated: Option<Instant<GenericClock>>,
+    last_updated: Option<Duration>,
 }
 
-// TODO: Update with core::time::Duration when all blocks are updated
 impl StaleTracker {
-    pub fn from_ms(age_ms: f64) -> Self {
-        Self {
-            stale_duration: Milliseconds(age_ms as u64),
-            last_updated: None,
-        }
+    pub fn mark_updated(&mut self, app_time: Duration) {
+        self.last_updated = Some(app_time);
     }
 
-    fn seconds_to_instant(&self, app_time_s: f64) -> Instant<GenericClock> {
-        let app_time_ms = (1000.0 * app_time_s) as u64;
-        Instant::<GenericClock>::new(
-            app_time_ms * GenericClock::SCALING_FACTOR.recip() * Fraction::new(1, 1000),
-        )
-    }
-
-    // TODO: Update with core::time::Duration when all blocks are updated
-    pub fn mark_updated(&mut self, app_time_s: f64) {
-        let now = self.seconds_to_instant(app_time_s);
-        self.last_updated = Some(now);
-    }
-
-    pub fn is_valid_bool(&self, app_time_s: f64) -> bool {
-        match self.last_updated {
-            None => false,
-            Some(inst) => inst
-                .checked_duration_until(&self.seconds_to_instant(app_time_s))
-                .map(Milliseconds::<u64>::try_from)
-                .and_then(Result::ok)
-                .map(|dur| dur <= self.stale_duration)
-                .unwrap_or(false),
-        }
-    }
-
-    // TODO: Update with core::time::Duration when all blocks are updated
-    pub fn is_valid(&self, app_time_s: f64) -> bool {
-        self.is_valid_bool(app_time_s)
+    pub fn is_valid(&self, app_time: Duration, stale_duration: Duration) -> bool {
+        self.last_updated
+            .and_then(|inst| app_time.checked_sub(inst))
+            .map(|elapsed| elapsed <= stale_duration)
+            .unwrap_or(false)
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+
     #[test]
     fn test_is_valid_not_updated() {
-        let tracker = StaleTracker::from_ms(5000.0);
-        let valid = tracker.is_valid(0.0);
-        assert!(!valid);
+        let tracker = StaleTracker::default();
+        assert!(!tracker.is_valid(Duration::ZERO, Duration::from_secs(5)));
     }
 
     #[test]
     fn test_is_valid_updated_less_than_stale_duration() {
-        let mut tracker = StaleTracker::from_ms(5000.0);
-        tracker.mark_updated(0.0);
-        let valid = tracker.is_valid(0.0);
-        assert!(valid);
+        let mut tracker = StaleTracker::default();
+        tracker.mark_updated(Duration::ZERO);
+        assert!(tracker.is_valid(Duration::ZERO, Duration::from_secs(5)));
     }
 
     #[test]
     fn test_is_valid_updated_greater_than_stale_duration() {
-        let mut tracker = StaleTracker::from_ms(1.0);
-        tracker.mark_updated(0.0);
-        let valid = tracker.is_valid(2.0);
-        assert!(!valid);
+        let mut tracker = StaleTracker::default();
+        tracker.mark_updated(Duration::ZERO);
+        assert!(!tracker.is_valid(Duration::from_secs(2), Duration::from_millis(1)));
     }
 }

--- a/pictorus-blocks/src/stale_tracker.rs
+++ b/pictorus-blocks/src/stale_tracker.rs
@@ -18,17 +18,11 @@ impl StaleTracker {
     }
 }
 
-/// Convert a millisecond duration supplied as an `f64` parameter into a `Duration`.
+/// Convert a millisecond duration supplied as an `f64` into a `Duration`.
 ///
-/// `Duration::from_secs_f64` panics on negative, NaN, or infinite inputs. Codegen-supplied
-/// stale-age parameters are not statically validated, so out-of-domain values fold to
-/// `Duration::ZERO` — i.e. the block is treated as immediately stale rather than panicking.
+/// This will panic on negative, NaN, or infinite inputs.
 pub fn duration_from_ms_f64(ms: f64) -> Duration {
-    if ms.is_finite() && ms >= 0.0 {
-        Duration::from_secs_f64(ms / 1000.0)
-    } else {
-        Duration::ZERO
-    }
+    Duration::from_secs_f64(ms / 1000.0)
 }
 
 #[cfg(test)]
@@ -62,10 +56,26 @@ mod test {
     }
 
     #[test]
-    fn test_duration_from_ms_f64_invalid_inputs_fold_to_zero() {
-        assert_eq!(duration_from_ms_f64(-1.0), Duration::ZERO);
-        assert_eq!(duration_from_ms_f64(f64::NAN), Duration::ZERO);
-        assert_eq!(duration_from_ms_f64(f64::INFINITY), Duration::ZERO);
-        assert_eq!(duration_from_ms_f64(f64::NEG_INFINITY), Duration::ZERO);
+    #[should_panic]
+    fn test_duration_from_ms_f64_negative_input_panics() {
+        duration_from_ms_f64(-1.0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_duration_from_ms_f64_nan_input_panics() {
+        duration_from_ms_f64(f64::NAN);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_duration_from_ms_f64_infinite_input_panics() {
+        duration_from_ms_f64(f64::INFINITY);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_duration_from_ms_f64_neg_infinite_input_panics() {
+        duration_from_ms_f64(f64::NEG_INFINITY);
     }
 }

--- a/pictorus-blocks/src/std_blocks/udp_receive_block.rs
+++ b/pictorus-blocks/src/std_blocks/udp_receive_block.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::time::Duration;
 use pictorus_traits::{ByteSliceSignal, PassBy, ProcessBlock};
 
-use crate::stale_tracker::StaleTracker;
+use crate::stale_tracker::{duration_from_ms_f64, StaleTracker};
 
 /// Parameters for UDP Receive Block
 #[doc(hidden)]
@@ -13,7 +13,7 @@ pub struct Parameters {
 impl Parameters {
     pub fn new(stale_age_ms: f64) -> Self {
         Self {
-            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
+            stale_age: duration_from_ms_f64(stale_age_ms),
         }
     }
 }
@@ -24,8 +24,8 @@ impl Parameters {
 /// by codegen. It attempts to read data each timestep and if data is available, it
 /// will update its internal buffer making that data available to blocks connected to it
 /// in the graph. If no data is available the buffer will remain unchanged. If no data has
-/// been received for a period of time longer than the `stale_age_ms` parameter, the block
-/// will return `false` for `is_valid()`.
+/// been received for a period longer than the `stale_age` parameter, the block's trailing
+/// output bool flips to `false`.
 #[derive(Default)]
 pub struct UdpReceiveBlock {
     stale_check: StaleTracker,

--- a/pictorus-blocks/src/std_blocks/udp_receive_block.rs
+++ b/pictorus-blocks/src/std_blocks/udp_receive_block.rs
@@ -26,20 +26,11 @@ impl Parameters {
 /// in the graph. If no data is available the buffer will remain unchanged. If no data has
 /// been received for a period of time longer than the `stale_age_ms` parameter, the block
 /// will return `false` for `is_valid()`.
+#[derive(Default)]
 pub struct UdpReceiveBlock {
     stale_check: StaleTracker,
     buffer: Vec<u8>,
     last_valid: bool,
-}
-
-impl Default for UdpReceiveBlock {
-    fn default() -> Self {
-        Self {
-            stale_check: StaleTracker::default(),
-            buffer: Vec::new(),
-            last_valid: false,
-        }
-    }
 }
 
 impl ProcessBlock for UdpReceiveBlock {

--- a/pictorus-blocks/src/std_blocks/udp_receive_block.rs
+++ b/pictorus-blocks/src/std_blocks/udp_receive_block.rs
@@ -1,17 +1,20 @@
 use alloc::vec::Vec;
+use core::time::Duration;
 use pictorus_traits::{ByteSliceSignal, PassBy, ProcessBlock};
 
-use crate::{stale_tracker::StaleTracker, IsValid};
+use crate::stale_tracker::StaleTracker;
 
 /// Parameters for UDP Receive Block
 #[doc(hidden)]
 pub struct Parameters {
-    pub stale_age_ms: f64,
+    pub stale_age: Duration,
 }
 
 impl Parameters {
     pub fn new(stale_age_ms: f64) -> Self {
-        Self { stale_age_ms }
+        Self {
+            stale_age: Duration::from_secs_f64(stale_age_ms / 1000.0),
+        }
     }
 }
 
@@ -24,26 +27,18 @@ impl Parameters {
 /// been received for a period of time longer than the `stale_age_ms` parameter, the block
 /// will return `false` for `is_valid()`.
 pub struct UdpReceiveBlock {
-    pub stale_check: StaleTracker,
+    stale_check: StaleTracker,
     buffer: Vec<u8>,
-    previous_stale_check_time_ms: f64,
     last_valid: bool,
 }
 
 impl Default for UdpReceiveBlock {
     fn default() -> Self {
         Self {
-            stale_check: StaleTracker::from_ms(0.0),
+            stale_check: StaleTracker::default(),
             buffer: Vec::new(),
-            previous_stale_check_time_ms: 0.,
             last_valid: false,
         }
-    }
-}
-
-impl IsValid for UdpReceiveBlock {
-    fn is_valid(&self, app_time_s: f64) -> bool {
-        self.stale_check.is_valid(app_time_s)
     }
 }
 
@@ -58,19 +53,16 @@ impl ProcessBlock for UdpReceiveBlock {
         context: &dyn pictorus_traits::Context,
         input: PassBy<'_, Self::Inputs>,
     ) -> pictorus_traits::PassBy<'b, Self::Output> {
-        if self.previous_stale_check_time_ms != parameters.stale_age_ms {
-            self.stale_check = StaleTracker::from_ms(parameters.stale_age_ms);
-            self.previous_stale_check_time_ms = parameters.stale_age_ms;
-        }
-
         // Make sure the data is the correct size, if so, update the stale check, otherwise
         // something has gone wrong.
         if !input.is_empty() {
-            self.stale_check.mark_updated(context.time().as_secs_f64());
+            self.stale_check.mark_updated(context.time());
             self.buffer = input.to_vec();
         }
 
-        self.last_valid = self.stale_check.is_valid_bool(context.time().as_secs_f64());
+        self.last_valid = self
+            .stale_check
+            .is_valid(context.time(), parameters.stale_age);
         (&self.buffer, self.last_valid)
     }
 


### PR DESCRIPTION
This PR drops the `IsValid` trait entirely, in favor of the `bool` signals that were already being returned to indicate the signal validity. It also makes the returned bool consistent with the old `IsValid` handling by using the `StaleTracker` for checking validity as a function of staleness.