### PR TITLE
Gate additional features behind alloc

### DIFF
--- a/pictorus-blocks/Cargo.toml
+++ b/pictorus-blocks/Cargo.toml
@@ -35,7 +35,7 @@ chrono = { version = "0.4.40", default-features = false, features = [
   "clock",
 ], optional = true }
 typenum = { version = "1.19.0", features = ["no_std", "const-generics"] }
-generic-array = { version = "1.2.0", features = ["alloc"] }
+generic-array = { version = "1.2.0", default-features = false }
 
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
@@ -49,8 +49,5 @@ byteorder = { version = "1.5.0", features = ["std"] }
 derive-new = { version = "0.7.0", default-features = false }
 
 [features]
-# TODO: `alloc` is a default feature for now to keep platform crates simple and to
-# match the current UI/codegen output. This should eventually be moved to opt-in.
-default = ["alloc"]
-alloc = []
+alloc = ["generic-array/alloc"]
 std = ["alloc", "dep:rustfft", "dep:chrono"]

--- a/pictorus-blocks/src/alloc_blocks/bytes_unpack_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/bytes_unpack_block.rs
@@ -29,6 +29,8 @@ impl<const N: usize> Default for BytesUnpackBlock<N> {
 }
 
 pub struct Parameters<N: ArrayLength> {
+    // TODO: I think we can use a [(DataType, ByteOrderSpec); N] once we ditch vectors
+    // for certain parameters. This would remove a dependency on generic-array (which uses alloc).
     pub pack_spec: GenericArray<(DataType, ByteOrderSpec), N>,
     pub stale_age: Duration,
 }

--- a/pictorus-internal/Cargo.toml
+++ b/pictorus-internal/Cargo.toml
@@ -27,7 +27,7 @@ chrono = { version = "0.4.40", optional = true }
 env_logger = { version = "0.11.8", optional = true }
 rtt-target = { git = "https://github.com/Pictorus-Labs/rtt-target", branch = "alignment-fix", optional = true }
 postcard = { version = "1.1.1" }
-serde = { version = "1.0.219", default-features = false, features = ["derive", "alloc"]}
+serde = { version = "1.0.219", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0", default-features = false, features = ["alloc", "preserve_order"], optional = true }
 heapless = { version = "0.7.0" }
 smashquote = { version = "0.1.2", optional = true }
@@ -38,5 +38,6 @@ temp-env = "0.3"
 cobs = "0.4.0"
 
 [features]
-std = ["serde/std", "dep:env_logger", "dep:chrono", "dep:serde_json", "dep:smashquote", "dep:serde-big-array"]
+std = ["serde/std", "dep:env_logger", "dep:chrono", "dep:serde_json", "dep:smashquote", "dep:serde-big-array", "alloc"]
 rtt = ["dep:rtt-target"]
+alloc = ["serde/alloc"]

--- a/pictorus-internal/src/encoders/postcard_encoder.rs
+++ b/pictorus-internal/src/encoders/postcard_encoder.rs
@@ -16,7 +16,7 @@ impl PostcardEncoderCOBS {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "alloc"))]
 mod tests {
     use super::*;
     use alloc::vec;

--- a/pictorus-internal/src/lib.rs
+++ b/pictorus-internal/src/lib.rs
@@ -4,7 +4,7 @@
 //! but rather as a dependency for the generated code.
 #![no_std]
 // TODO: We require alloc right now, but should be able to ditch this soon
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", test))]
 extern crate alloc;
 
 #[cfg(feature = "std")]

--- a/pictorus-internal/src/lib.rs
+++ b/pictorus-internal/src/lib.rs
@@ -4,6 +4,7 @@
 //! but rather as a dependency for the generated code.
 #![no_std]
 // TODO: We require alloc right now, but should be able to ditch this soon
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "std")]

--- a/pictorus-internal/src/utils.rs
+++ b/pictorus-internal/src/utils.rs
@@ -364,7 +364,7 @@ pub use std_utils::*;
 #[allow(clippy::approx_constant)]
 mod tests {
     use super::*;
-    use alloc::string::ToString;
+    use alloc::string::{String, ToString};
     use alloc::vec;
     use alloc::vec::Vec;
     use pictorus_traits::Matrix;

--- a/pictorus-internal/src/utils.rs
+++ b/pictorus-internal/src/utils.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "alloc")]
-use alloc::string::String;
-
 use core::str;
 use core::time::Duration;
 use num_traits::{AsPrimitive, Float};
@@ -11,14 +8,11 @@ use log::debug;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "alloc")]
-use core::convert::Infallible;
-
-#[cfg(feature = "alloc")]
 pub struct PictorusVars {
-    pub run_path: String,
+    pub run_path: alloc::string::String,
     pub data_log_rate_hz: f64,
     pub transmit_enabled: bool,
-    pub publish_socket: String,
+    pub publish_socket: alloc::string::String,
 }
 
 // TODO Can we create an error type for these functions? Could we use Option<> instead?
@@ -37,20 +31,20 @@ pub fn string_to_scalar(val: &str) -> Result<f64, ()> {
 #[cfg(feature = "alloc")]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PictorusError {
-    pub err_type: String,
-    pub message: String,
+    pub err_type: alloc::string::String,
+    pub message: alloc::string::String,
 }
 
 #[cfg(feature = "alloc")]
 impl PictorusError {
-    pub fn new(err_type: String, message: String) -> Self {
+    pub fn new(err_type: alloc::string::String, message: alloc::string::String) -> Self {
         PictorusError { err_type, message }
     }
 }
 
 #[cfg(feature = "alloc")]
-impl From<Infallible> for PictorusError {
-    fn from(_: Infallible) -> Self {
+impl From<core::convert::Infallible> for PictorusError {
+    fn from(_: core::convert::Infallible) -> Self {
         unreachable!();
     }
 }

--- a/pictorus-internal/src/utils.rs
+++ b/pictorus-internal/src/utils.rs
@@ -1,12 +1,19 @@
-use alloc::str;
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 
-use core::{convert::Infallible, time::Duration};
+use core::str;
+use core::time::Duration;
 use num_traits::{AsPrimitive, Float};
 
 use log::debug;
+
+#[cfg(feature = "alloc")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "alloc")]
+use core::convert::Infallible;
+
+#[cfg(feature = "alloc")]
 pub struct PictorusVars {
     pub run_path: String,
     pub data_log_rate_hz: f64,
@@ -27,18 +34,21 @@ pub fn string_to_scalar(val: &str) -> Result<f64, ()> {
     val.trim().parse().or(Err(()))
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PictorusError {
     pub err_type: String,
     pub message: String,
 }
 
+#[cfg(feature = "alloc")]
 impl PictorusError {
     pub fn new(err_type: String, message: String) -> Self {
         PictorusError { err_type, message }
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<Infallible> for PictorusError {
     fn from(_: Infallible) -> Self {
         unreachable!();

--- a/pictorus-renesas/Cargo.toml
+++ b/pictorus-renesas/Cargo.toml
@@ -20,3 +20,8 @@ embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "68c82
 heapless = "0.8.0"
 log = "0.4.21"
 ra4m2-hal = { git = "https://github.com/Pictorus-Labs/ra4m2-hal", rev = "76e158a" }
+
+[features]
+# Enables protocols that allocate on the heap (i2c). Without it, only the alloc-free
+# protocols (clock, gpio) are compiled. 
+alloc = ["pictorus-blocks/alloc", "pictorus-internal/alloc"]

--- a/pictorus-renesas/src/lib.rs
+++ b/pictorus-renesas/src/lib.rs
@@ -1,10 +1,13 @@
 #![no_std]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 mod clock_protocols;
 pub use clock_protocols::*;
 
+#[cfg(feature = "alloc")]
 mod i2c_protocol;
+#[cfg(feature = "alloc")]
 pub use i2c_protocol::*;
 
 mod gpio_protocol;

--- a/pictorus-stm32/Cargo.toml
+++ b/pictorus-stm32/Cargo.toml
@@ -29,9 +29,15 @@ nb = { version = "1.1.0", optional = true }
 log = "0.4.21"
 
 [features]
-fdcan = ["dep:embedded-can", "dep:nb"]
-can = ["dep:embedded-can", "dep:nb"]
-spi = []
+# Enables protocols that allocate on the heap (i2c, serial, can). Without it, only the alloc-free
+# protocols (clock, pwm, spi, dac, adc, gpio) are compiled. Forwards alloc to the pictorus path
+# deps so they don't get re-enabled via their own defaults.
+alloc = ["pictorus-blocks/alloc", "pictorus-internal/alloc"]
+fdcan = ["alloc", "dep:embedded-can", "dep:nb"]
+can = ["alloc", "dep:embedded-can", "dep:nb"]
+# spi_protocol uses SpiReceiveBlockParams which lives in pictorus-blocks/alloc_blocks.
+# Once SpiReceiveBlock's Parameters struct is moved into core_blocks, "alloc" can be removed.
+spi = ["alloc"]
 dac = []
 adc = []
 interrupt-uart = []

--- a/pictorus-stm32/src/lib.rs
+++ b/pictorus-stm32/src/lib.rs
@@ -1,12 +1,15 @@
 //! This crate contains implementations of the various drivers needed to interact with I/O on STM32-based platforms.
 //! These are typically defined as `InputBlock` or `OutputBlock` interfaces as defined in the `pictorus-traits` crate.
 #![no_std]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 mod clock_protocol;
 pub use clock_protocol::*;
 
+#[cfg(feature = "alloc")]
 mod serial_protocol;
+#[cfg(feature = "alloc")]
 pub use serial_protocol::*;
 
 #[cfg(all(feature = "can", feature = "fdcan"))]
@@ -19,7 +22,9 @@ pub use can_protocol::*;
 mod pwm_protocol;
 pub use pwm_protocol::*;
 
+#[cfg(feature = "alloc")]
 mod i2c_protocol;
+#[cfg(feature = "alloc")]
 pub use i2c_protocol::*;
 
 #[cfg(feature = "dac")]


### PR DESCRIPTION
These changes are in parallel with codegen changes to ensure we can turn alloc on and off depending on codegen settings.

pictorus-blocks:
- Gate generic-array behind alloc
- Left note by the only instance of GenericArray to reconsider this import if we remove vec parsing from certain parameters (i.e. pass in an a static or stack allocated array)
- Removed default = ["alloc"], alloc feature should be set during codegen

pictorus-internal:
- Gate serde/alloc behind an alloc flag
- Gate PictorusVars and PictorusError behind alloc. These are used for Linux builds to communicate verbose errors and make parameters easier to parse from config files.
- Gate extern alloc crate behind alloc flag

Renesas / STM32 libraries:
- Add an opt-in `alloc` feature that forwards to pictorus-blocks/alloc and pictorus-internal/alloc.
- Gate `extern crate alloc` and alloc-using protocols (serial, i2c on stm32; i2c on renesas) behind the feature.
- Update `can`, `fdcan`, and `spi` features on stm32 to imply alloc, since the corresponding BlockParams types live in pictorus-blocks/alloc_blocks.