### PR TITLE
Pin socketcan to 3.5 release

### DIFF
--- a/pictorus-linux/Cargo.toml
+++ b/pictorus-linux/Cargo.toml
@@ -27,5 +27,5 @@ std-embedded-time = "0.1.0"
 linux-embedded-hal = "0.4.0"
 sysfs-pwm = "0.1.0"
 serialport = "4.3.0"
-socketcan = "3.3.0"
+socketcan = "=3.5.0" # Pinned until this issue is resolved: https://github.com/socketcan-rs/socketcan-rs/issues/100
 libc = "0.2.153"


### PR DESCRIPTION
It looks like an update to `socketcan` broke our packages on the "arm-unknown-linux-musleabi" target. I filed an issue with their repo which looks like it has pretty active development so hopefully it gets fixed sooner than later. Until then I am pining it to the working release

My issue with `socketcan` is here: https://github.com/socketcan-rs/socketcan-rs/issues/100