### PR TITLE
Patch custom fork of fmu-runner until insecure dep is upgraded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ homepage = "https://www.pictor.us/"
 repository = "https://github.com/Pictorus-Labs/pictorus-rs"
 keywords = ["embedded", "modeling", "simulation", "fmi"]
 categories = ["embedded", "hardware-support", "no-std"]
+
+[patch.crates-io]
+fmu-runner = { git = "https://github.com/jscatena88/fmu-runner-rs", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ keywords = ["embedded", "modeling", "simulation", "fmi"]
 categories = ["embedded", "hardware-support", "no-std"]
 
 [patch.crates-io]
-fmu-runner = { git = "https://github.com/jscatena88/fmu-runner-rs", branch = "main" }
+fmu-runner = { git = "https://github.com/Pictorus-Labs/fmu-runner-rs", branch = "main" }


### PR DESCRIPTION
I made a fork that upgrades to the secure version of the dep. I have a PR open with the project to get my upgrade merged in. We can remove this once that happens