### PR TITLE
Rework Renesas GPIO to match reworked HAL

### DIFF
--- a/pictorus-blocks/src/alloc_blocks/serial_receive_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/serial_receive_block.rs
@@ -138,10 +138,10 @@ impl SerialReceiveBlock {
         let end_idx;
 
         // Use anything in the overflow buffer plus new data
-        debug!("Received value: {:?}", &self.buffer);
+        debug!("Received value: {:?}", self.buffer);
         debug!(
             "Start delimiter: {:?}, End delimiter: {:?}",
-            &parameters.start_delimiter, &parameters.end_delimiter
+            parameters.start_delimiter, parameters.end_delimiter
         );
 
         if !parameters.start_delimiter.0.is_empty() {

--- a/pictorus-blocks/src/alloc_blocks/serial_transmit_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/serial_transmit_block.rs
@@ -64,7 +64,7 @@ where
             parameters.end_delimiter.as_slice(),
         ]
         .concat();
-        debug!("Transmitting value: {:?}", &write_val);
+        debug!("Transmitting value: {:?}", write_val);
         self.buffer = write_val;
         &self.buffer
     }

--- a/pictorus-renesas/Cargo.toml
+++ b/pictorus-renesas/Cargo.toml
@@ -19,7 +19,7 @@ embedded-io = "0.6.1"
 embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "68c8238" }
 heapless = "0.8.0"
 log = "0.4.21"
-ra4m2-hal = { git = "https://github.com/Pictorus-Labs/ra4m2-hal", rev = "76e158a" }
+ra4m2-hal = { git = "https://github.com/Pictorus-Labs/ra4m2-hal", rev = "7a09c10" }
 
 [features]
 # Enables protocols that allocate on the heap (i2c). Without it, only the alloc-free

--- a/pictorus-renesas/src/gpio_protocol.rs
+++ b/pictorus-renesas/src/gpio_protocol.rs
@@ -1,16 +1,15 @@
 use embedded_hal::digital::{InputPin, OutputPin};
 use pictorus_traits::{InputBlock, OutputBlock};
-use ra4m2_hal::gpio::{Input, Output, PullDown, PushPull};
 
-pub struct RenesasInputPin<const N: u8>(ra4m2_hal::gpio::port4::Pin<Input<PullDown>, N>);
+pub struct RenesasInputPin<P: InputPin>(P);
 
-impl<const N: u8> RenesasInputPin<N> {
-    pub fn new(inner: ra4m2_hal::gpio::port4::Pin<Input<PullDown>, N>) -> Self {
+impl<P: InputPin> RenesasInputPin<P> {
+    pub fn new(inner: P) -> Self {
         RenesasInputPin(inner)
     }
 }
 
-impl<const N: u8> InputBlock for RenesasInputPin<N> {
+impl<P: InputPin> InputBlock for RenesasInputPin<P> {
     type Output = f64;
     type Parameters = pictorus_blocks::GpioInputBlockParams;
 
@@ -23,15 +22,15 @@ impl<const N: u8> InputBlock for RenesasInputPin<N> {
     }
 }
 
-pub struct RenesasOutputPin<const N: u8>(ra4m2_hal::gpio::port4::Pin<Output<PushPull>, N>);
+pub struct RenesasOutputPin<P: OutputPin>(P);
 
-impl<const N: u8> RenesasOutputPin<N> {
-    pub fn new(inner: ra4m2_hal::gpio::port4::Pin<Output<PushPull>, N>) -> Self {
+impl<P: OutputPin> RenesasOutputPin<P> {
+    pub fn new(inner: P) -> Self {
         RenesasOutputPin(inner)
     }
 }
 
-impl<const N: u8> OutputBlock for RenesasOutputPin<N> {
+impl<P: OutputPin> OutputBlock for RenesasOutputPin<P> {
     type Inputs = bool;
     type Parameters = pictorus_blocks::GpioOutputBlockParams;
 


### PR DESCRIPTION
The HAL was reworked to allow GPIO for all valid ports / pins. The rework changed the generic to an OutputPin and InputPin instead of a pin number.

Changes:
- Reworked Renesas RA4M2 InputBlock and OutputBlock to work with the updated HAL.
- Updated HAL crate rev in Cargo.toml