### PR TITLE
Add support for f32 default type

### DIFF
--- a/pictorus-blocks/src/alloc_blocks/bytes_pack_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/bytes_pack_block.rs
@@ -63,10 +63,27 @@ impl AppendBytes for f64 {
         let mut scratch = [0u8; 16]; // 16 bytes is the size of i128 which is the largest output spec we support
         let n = match data_spec.1 {
             ByteOrderSpec::BigEndian => {
-                try_pack_data::<byteorder::BigEndian>(&mut scratch, *self, data_spec.0)
+                try_pack_data::<f64, byteorder::BigEndian>(&mut scratch, *self, data_spec.0)
             }
             ByteOrderSpec::LittleEndian => {
-                try_pack_data::<byteorder::LittleEndian>(&mut scratch, *self, data_spec.0)
+                try_pack_data::<f64, byteorder::LittleEndian>(&mut scratch, *self, data_spec.0)
+            }
+        }
+        .expect("Scratch should always be big enough, which is the only way to produce an error");
+        buffer.extend_from_slice(scratch[..n].as_ref());
+        n
+    }
+}
+
+impl AppendBytes for f32 {
+    fn append_bytes(&self, data_spec: (DataType, ByteOrderSpec), buffer: &mut Vec<u8>) -> usize {
+        let mut scratch = [0u8; 16]; // 16 bytes is the size of i128 which is the largest output spec we support
+        let n = match data_spec.1 {
+            ByteOrderSpec::BigEndian => {
+                try_pack_data::<f32, byteorder::BigEndian>(&mut scratch, *self, data_spec.0)
+            }
+            ByteOrderSpec::LittleEndian => {
+                try_pack_data::<f32, byteorder::LittleEndian>(&mut scratch, *self, data_spec.0)
             }
         }
         .expect("Scratch should always be big enough, which is the only way to produce an error");
@@ -215,6 +232,24 @@ mod tests {
         let params = Parameters::new(&["I8:BigEndian"]);
         let mut block = BytesPackBlock::<f64>::default();
         let inputs = 255.0;
+
+        let expected = {
+            let mut expected = Vec::new();
+            expected.write_i8(inputs as i8).unwrap();
+            expected
+        };
+
+        let output = block.process(&params, &context, inputs);
+        assert_eq!(output, expected.as_slice());
+        assert_eq!(block.buffer(), expected.as_slice());
+    }
+
+    #[test]
+    fn test_bytes_pack_block_1_input_f32() {
+        let context = StubContext::default();
+        let params = Parameters::new(&["I8:BigEndian"]);
+        let mut block = BytesPackBlock::<f32>::default();
+        let inputs = 255.0f32;
 
         let expected = {
             let mut expected = Vec::new();

--- a/pictorus-blocks/src/alloc_blocks/bytes_pack_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/bytes_pack_block.rs
@@ -1,6 +1,7 @@
 use crate::byte_data::{parse_byte_data_spec, try_pack_data, ByteOrderSpec, DataType};
-use crate::traits::Scalar;
+use crate::traits::{Float, Scalar};
 use alloc::vec::Vec;
+use num_traits::AsPrimitive;
 use pictorus_traits::{ByteSliceSignal, Pass, PassBy, ProcessBlock};
 
 /// Packs scalar inputs into a byte buffer according to the provided data spec.
@@ -58,32 +59,30 @@ pub trait AppendBytes: Scalar {
     fn append_bytes(&self, data_spec: (DataType, ByteOrderSpec), buffer: &mut Vec<u8>) -> usize;
 }
 
-impl AppendBytes for f64 {
+impl<F> AppendBytes for F
+where
+    F: Float
+        + AsPrimitive<u8>
+        + AsPrimitive<i8>
+        + AsPrimitive<u16>
+        + AsPrimitive<i16>
+        + AsPrimitive<u32>
+        + AsPrimitive<i32>
+        + AsPrimitive<u64>
+        + AsPrimitive<i64>
+        + AsPrimitive<u128>
+        + AsPrimitive<i128>
+        + AsPrimitive<f32>
+        + AsPrimitive<f64>,
+{
     fn append_bytes(&self, data_spec: (DataType, ByteOrderSpec), buffer: &mut Vec<u8>) -> usize {
         let mut scratch = [0u8; 16]; // 16 bytes is the size of i128 which is the largest output spec we support
         let n = match data_spec.1 {
             ByteOrderSpec::BigEndian => {
-                try_pack_data::<f64, byteorder::BigEndian>(&mut scratch, *self, data_spec.0)
+                try_pack_data::<F, byteorder::BigEndian>(&mut scratch, *self, data_spec.0)
             }
             ByteOrderSpec::LittleEndian => {
-                try_pack_data::<f64, byteorder::LittleEndian>(&mut scratch, *self, data_spec.0)
-            }
-        }
-        .expect("Scratch should always be big enough, which is the only way to produce an error");
-        buffer.extend_from_slice(scratch[..n].as_ref());
-        n
-    }
-}
-
-impl AppendBytes for f32 {
-    fn append_bytes(&self, data_spec: (DataType, ByteOrderSpec), buffer: &mut Vec<u8>) -> usize {
-        let mut scratch = [0u8; 16]; // 16 bytes is the size of i128 which is the largest output spec we support
-        let n = match data_spec.1 {
-            ByteOrderSpec::BigEndian => {
-                try_pack_data::<f32, byteorder::BigEndian>(&mut scratch, *self, data_spec.0)
-            }
-            ByteOrderSpec::LittleEndian => {
-                try_pack_data::<f32, byteorder::LittleEndian>(&mut scratch, *self, data_spec.0)
+                try_pack_data::<F, byteorder::LittleEndian>(&mut scratch, *self, data_spec.0)
             }
         }
         .expect("Scratch should always be big enough, which is the only way to produce an error");

--- a/pictorus-blocks/src/alloc_blocks/bytes_unpack_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/bytes_unpack_block.rs
@@ -5,6 +5,7 @@ use crate::{
     traits::Float,
 };
 use generic_array::{ArrayLength, GenericArray};
+use num_traits::AsPrimitive;
 use typenum::{Const, NonZero, Sub1, ToUInt, B1, U};
 
 use crate::byte_data::{parse_byte_data_spec, try_unpack_data, ByteOrderSpec, DataType};
@@ -107,42 +108,31 @@ pub trait Unpack: Float {
         -> (Option<Self>, &[u8]);
 }
 
-impl Unpack for f64 {
+impl<F> Unpack for F
+where
+    F: Float,
+    u8: AsPrimitive<F>,
+    i8: AsPrimitive<F>,
+    u16: AsPrimitive<F>,
+    i16: AsPrimitive<F>,
+    u32: AsPrimitive<F>,
+    i32: AsPrimitive<F>,
+    u64: AsPrimitive<F>,
+    i64: AsPrimitive<F>,
+    u128: AsPrimitive<F>,
+    i128: AsPrimitive<F>,
+    f32: AsPrimitive<F>,
+    f64: AsPrimitive<F>,
+{
     fn unpack(
         data: &[u8],
         data_type: DataType,
         byte_order: ByteOrderSpec,
     ) -> (Option<Self>, &[u8]) {
         let val = match byte_order {
-            ByteOrderSpec::BigEndian => {
-                try_unpack_data::<f64, byteorder::BigEndian>(data, data_type)
-            }
+            ByteOrderSpec::BigEndian => try_unpack_data::<F, byteorder::BigEndian>(data, data_type),
             ByteOrderSpec::LittleEndian => {
-                try_unpack_data::<f64, byteorder::LittleEndian>(data, data_type)
-            }
-        }
-        .ok();
-        let advanced_data = if val.is_some() {
-            &data[data_type.byte_size()..]
-        } else {
-            data
-        };
-        (val, advanced_data)
-    }
-}
-
-impl Unpack for f32 {
-    fn unpack(
-        data: &[u8],
-        data_type: DataType,
-        byte_order: ByteOrderSpec,
-    ) -> (Option<Self>, &[u8]) {
-        let val = match byte_order {
-            ByteOrderSpec::BigEndian => {
-                try_unpack_data::<f32, byteorder::BigEndian>(data, data_type)
-            }
-            ByteOrderSpec::LittleEndian => {
-                try_unpack_data::<f32, byteorder::LittleEndian>(data, data_type)
+                try_unpack_data::<F, byteorder::LittleEndian>(data, data_type)
             }
         }
         .ok();

--- a/pictorus-blocks/src/alloc_blocks/bytes_unpack_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/bytes_unpack_block.rs
@@ -2,7 +2,7 @@ use core::time::Duration;
 
 use crate::{
     stale_tracker::{duration_from_ms_f64, StaleTracker},
-    traits::Scalar,
+    traits::Float,
 };
 use generic_array::{ArrayLength, GenericArray};
 use typenum::{Const, NonZero, Sub1, ToUInt, B1, U};
@@ -12,17 +12,17 @@ use pictorus_traits::{ByteSliceSignal, PassBy, ProcessBlock};
 
 /// Unpacks a byte slice into a specified number of outputs based on the provided data types and byte order.
 ///
-/// The output is `[f64; N]` where the last element is a `1.0`/`0.0` validity flag — true while
-/// the most recent successful unpack is still within the configured `stale_age`.
-pub struct BytesUnpackBlock<const N: usize> {
-    buffer: [f64; N],
+/// The output is `[O; N]` (`O` defaults for `f64` unless otherwise set) where the last element is a `1.0`/`0.0`
+/// validity flag — true while the most recent successful unpack is still within the configured `stale_age`.
+pub struct BytesUnpackBlock<const N: usize, O: Unpack = f64> {
+    buffer: [O; N],
     stale_check: StaleTracker,
 }
 
-impl<const N: usize> Default for BytesUnpackBlock<N> {
+impl<const N: usize, O: Unpack> Default for BytesUnpackBlock<N, O> {
     fn default() -> Self {
         BytesUnpackBlock {
-            buffer: [0.0; N],
+            buffer: [O::zero(); N],
             stale_check: StaleTracker::default(),
         }
     }
@@ -35,7 +35,7 @@ pub struct Parameters<N: ArrayLength> {
     pub stale_age: Duration,
 }
 
-impl<const N: usize> ProcessBlock for BytesUnpackBlock<N>
+impl<const N: usize, O: Unpack> ProcessBlock for BytesUnpackBlock<N, O>
 where
     // To be able to have parameters be of size N-1 we use typenum to express that at the type level
     Const<N>: ToUInt,                   // Ensure N can be converted to a typenum UInt
@@ -45,7 +45,7 @@ where
     type Parameters = Parameters<Sub1<U<N>>>;
 
     type Inputs = ByteSliceSignal;
-    type Output = [f64; N];
+    type Output = [O; N];
 
     fn process<'b>(
         &'b mut self,
@@ -53,14 +53,14 @@ where
         context: &dyn pictorus_traits::Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'b, Self::Output> {
-        let mut new_buffer = [0.0; N];
+        let mut new_buffer = [O::zero(); N];
         // Use Unpack::unpack N-1 times to fill the buffer; if it fails at any point,
         // keep the old buffer values. The data at N-1 is the `is_valid` flag.
         let mut inputs = inputs;
         let mut unpack_success = true;
         for (i, elem) in new_buffer.iter_mut().enumerate().take(N - 1) {
             let (val, advanced_data) =
-                f64::unpack(inputs, parameters.pack_spec[i].0, parameters.pack_spec[i].1);
+                O::unpack(inputs, parameters.pack_spec[i].0, parameters.pack_spec[i].1);
             if let Some(val) = val {
                 *elem = val;
             } else {
@@ -77,9 +77,9 @@ where
             .stale_check
             .is_valid(context.time(), parameters.stale_age)
         {
-            1.0
+            O::one()
         } else {
-            0.0
+            O::zero()
         };
         &self.buffer
     }
@@ -102,7 +102,7 @@ impl<N: ArrayLength> Parameters<N> {
     }
 }
 
-pub trait Unpack: Scalar {
+pub trait Unpack: Float {
     fn unpack(data: &[u8], data_type: DataType, byte_order: ByteOrderSpec)
         -> (Option<Self>, &[u8]);
 }
@@ -114,9 +114,35 @@ impl Unpack for f64 {
         byte_order: ByteOrderSpec,
     ) -> (Option<Self>, &[u8]) {
         let val = match byte_order {
-            ByteOrderSpec::BigEndian => try_unpack_data::<byteorder::BigEndian>(data, data_type),
+            ByteOrderSpec::BigEndian => {
+                try_unpack_data::<f64, byteorder::BigEndian>(data, data_type)
+            }
             ByteOrderSpec::LittleEndian => {
-                try_unpack_data::<byteorder::LittleEndian>(data, data_type)
+                try_unpack_data::<f64, byteorder::LittleEndian>(data, data_type)
+            }
+        }
+        .ok();
+        let advanced_data = if val.is_some() {
+            &data[data_type.byte_size()..]
+        } else {
+            data
+        };
+        (val, advanced_data)
+    }
+}
+
+impl Unpack for f32 {
+    fn unpack(
+        data: &[u8],
+        data_type: DataType,
+        byte_order: ByteOrderSpec,
+    ) -> (Option<Self>, &[u8]) {
+        let val = match byte_order {
+            ByteOrderSpec::BigEndian => {
+                try_unpack_data::<f32, byteorder::BigEndian>(data, data_type)
+            }
+            ByteOrderSpec::LittleEndian => {
+                try_unpack_data::<f32, byteorder::LittleEndian>(data, data_type)
             }
         }
         .ok();
@@ -175,6 +201,11 @@ mod tests {
         let test_data = (-23.0, 43.0);
         let expected = [-23.0, 43.0, 1.0];
         let packed = pack_block.process(&pack_parameters, &context, test_data);
+        let expected_packed: [u8; 2] = [
+            0b11101001, // -23 as i8
+            0b00101011,
+        ];
+        assert_eq!(&packed[..2], expected_packed.as_slice());
         let unpacked = block.process(&parameters, &context, packed);
         assert_eq!(unpacked, expected.as_slice());
 
@@ -294,5 +325,31 @@ mod tests {
         assert_relative_eq!(unpacked[10], 2.2250739e-308_f64);
         assert_relative_eq!(unpacked[11], -2147483648.0_f64);
         assert_relative_eq!(unpacked[12], 1.0_f64, epsilon = 0.001);
+    }
+
+    #[test]
+    fn test_bytes_unpack_3_output_f32() {
+        let mut context = StubContext::default();
+        let mut pack_block = BytesPackBlock::<(f32, f32)>::default();
+        let mut block = BytesUnpackBlock::<3, f32>::default();
+        let spec_strings = &["I8:BigEndian", "U64:LittleEndian"];
+        let pack_parameters = PackParameters::new(spec_strings);
+        let parameters = Parameters::new(spec_strings, 1000.0);
+
+        // Test happy path
+        let test_data = (-23.0, 43.0);
+        let expected = [-23.0, 43.0, 1.0];
+        let packed = pack_block.process(&pack_parameters, &context, test_data);
+        let unpacked = block.process(&parameters, &context, packed);
+        assert_eq!(unpacked, expected.as_slice());
+
+        // Test not-stale yet but invalid data
+        let unpacked: &[f32; 3] = block.process(&parameters, &context, &[]);
+        assert_eq!(unpacked, expected.as_slice());
+
+        // Now it is stale
+        context.time += Duration::from_secs_f64(1.1);
+        let unpacked = block.process(&parameters, &context, &[]);
+        assert_eq!(unpacked, [-23.0, 43.0, 0.0].as_slice());
     }
 }

--- a/pictorus-blocks/src/alloc_blocks/json_load_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/json_load_block.rs
@@ -1,13 +1,14 @@
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::time::Duration;
+use num_traits::AsPrimitive;
 
 use miniserde::json::{self, Array, Number, Object, Value};
 use pictorus_traits::{ByteSliceSignal, Context, Matrix, Pass, PassBy, ProcessBlock};
 
 use crate::{
     stale_tracker::{duration_from_ms_f64, StaleTracker},
-    traits::DefaultStorage,
+    traits::{DefaultStorage, Float},
 };
 
 /// Block-output data shape, parsed from the user-supplied select-data spec strings.
@@ -122,7 +123,12 @@ pub trait Deserialize: DefaultStorage {
     }
 }
 
-impl Deserialize for f64 {
+impl<T: Float> Deserialize for T
+where
+    i64: AsPrimitive<T>,
+    f64: AsPrimitive<T>,
+    u64: AsPrimitive<T>,
+{
     fn from_json_value(data: &Value) -> Result<Self::Storage, ()> {
         match data {
             Value::Number(n) => Ok(parse_number(n)),
@@ -140,10 +146,15 @@ impl Deserialize for ByteSliceSignal {
     }
 }
 
-fn parse_num_array<const NROWS: usize, const NCOLS: usize>(
+fn parse_num_array<const NROWS: usize, const NCOLS: usize, T: Float>(
     data: &Array,
-    res: &mut Matrix<NROWS, NCOLS, f64>,
-) -> Result<(), ()> {
+    res: &mut Matrix<NROWS, NCOLS, T>,
+) -> Result<(), ()>
+where
+    i64: AsPrimitive<T>,
+    f64: AsPrimitive<T>,
+    u64: AsPrimitive<T>,
+{
     // If ROWS * COLS is equal to the total number of elements in the matrix
     // then we can fill the matrix column-wise
     if data.len() != NROWS * NCOLS {
@@ -161,10 +172,15 @@ fn parse_num_array<const NROWS: usize, const NCOLS: usize>(
     Ok(())
 }
 
-fn parse_nested_array<const NROWS: usize, const NCOLS: usize>(
+fn parse_nested_array<const NROWS: usize, const NCOLS: usize, T: Float>(
     data: &Array,
-    res: &mut Matrix<NROWS, NCOLS, f64>,
-) -> Result<(), ()> {
+    res: &mut Matrix<NROWS, NCOLS, T>,
+) -> Result<(), ()>
+where
+    i64: AsPrimitive<T>,
+    f64: AsPrimitive<T>,
+    u64: AsPrimitive<T>,
+{
     let rows = data.len();
     if rows != NROWS {
         return Err(());
@@ -191,7 +207,12 @@ fn parse_nested_array<const NROWS: usize, const NCOLS: usize>(
     Ok(())
 }
 
-impl<const NROWS: usize, const NCOLS: usize> Deserialize for Matrix<NROWS, NCOLS, f64> {
+impl<const NROWS: usize, const NCOLS: usize, T: Float> Deserialize for Matrix<NROWS, NCOLS, T>
+where
+    i64: AsPrimitive<T>,
+    f64: AsPrimitive<T>,
+    u64: AsPrimitive<T>,
+{
     fn from_json_value(data: &Value) -> Result<Self::Storage, ()> {
         let mut res = Self::Storage::default();
         let val = match data {
@@ -229,11 +250,16 @@ pub trait Apply: Pass {
     fn set_valid(storage: &mut Self::Storage, valid: bool);
 }
 
-fn parse_number(num_val: &Number) -> f64 {
+fn parse_number<O: Float>(num_val: &Number) -> O
+where
+    i64: AsPrimitive<O>,
+    u64: AsPrimitive<O>,
+    f64: AsPrimitive<O>,
+{
     match num_val {
-        Number::F64(v) => *v,
-        Number::I64(v) => *v as f64,
-        Number::U64(v) => *v as f64,
+        Number::F64(v) => (*v).as_(),
+        Number::I64(v) => (*v).as_(),
+        Number::U64(v) => (*v).as_(),
     }
 }
 
@@ -966,5 +992,30 @@ mod tests {
 
         assert_eq!(res, expected);
         assert_eq!(block.buffer(), expected);
+    }
+
+    #[test]
+    fn test_load_f32_scalar() {
+        let ctxt = StubContext::default();
+        let input = br#"{"foo": 1.0}"#;
+        let params = Parameters::new(&["Scalar:foo".into()], 1000.0);
+        let mut block = JsonLoadBlock::<f32>::default();
+        let res = block.process(&params, &ctxt, input);
+        assert_eq!(res, (1.0_f32, true));
+        assert_eq!(block.buffer(), (1.0_f32, true));
+    }
+
+    #[test]
+    fn test_load_f32_matrix() {
+        let ctxt = StubContext::default();
+        let input = br#"[[1.0, 2.0], [3.0, 4.0]]"#;
+        let params = Parameters::new(&[], 1000.0);
+        let mut block = JsonLoadBlock::<Matrix<2, 2, f32>>::default();
+        let res = block.process(&params, &ctxt, input);
+        let expected = &Matrix {
+            data: [[1.0_f32, 3.0_f32], [2.0_f32, 4.0_f32]],
+        };
+        assert_eq!(res, (expected, true));
+        assert_eq!(block.buffer(), (expected, true));
     }
 }

--- a/pictorus-blocks/src/byte_data.rs
+++ b/pictorus-blocks/src/byte_data.rs
@@ -194,60 +194,92 @@ pub fn parse_string_to_read_delimiter(data: &str) -> (Vec<u8>, Vec<usize>) {
 pub const BUFF_SIZE_BYTES: usize = 1024;
 
 use byteorder::ByteOrder;
+use num_traits::AsPrimitive;
 
-pub fn try_unpack_data<Endian: ByteOrder>(
+use crate::traits::Float;
+
+pub fn try_unpack_data<T: Float, Endian: ByteOrder>(
     buf: &[u8],
     data_type: DataType,
-) -> Result<f64, ByteDataError> {
+) -> Result<T, ByteDataError>
+where
+    u8: AsPrimitive<T>,
+    i8: AsPrimitive<T>,
+    u16: AsPrimitive<T>,
+    i16: AsPrimitive<T>,
+    u32: AsPrimitive<T>,
+    i32: AsPrimitive<T>,
+    u64: AsPrimitive<T>,
+    i64: AsPrimitive<T>,
+    u128: AsPrimitive<T>,
+    i128: AsPrimitive<T>,
+    f32: AsPrimitive<T>,
+    f64: AsPrimitive<T>,
+{
     if buf.len() < data_type.byte_size() {
         return Err(ByteDataError::UnpackError);
     }
     let val = match data_type {
-        DataType::U8 => buf[0] as f64,
-        DataType::I8 => buf[0] as i8 as f64,
-        DataType::U16 => Endian::read_u16(buf) as f64,
-        DataType::I16 => Endian::read_i16(buf) as f64,
-        DataType::U24 => Endian::read_u24(buf) as f64,
-        DataType::I24 => Endian::read_i24(buf) as f64,
-        DataType::U32 => Endian::read_u32(buf) as f64,
-        DataType::I32 => Endian::read_i32(buf) as f64,
-        DataType::U48 => Endian::read_u48(buf) as f64,
-        DataType::I48 => Endian::read_i48(buf) as f64,
-        DataType::U64 => Endian::read_u64(buf) as f64,
-        DataType::I64 => Endian::read_i64(buf) as f64,
-        DataType::U128 => Endian::read_u128(buf) as f64,
-        DataType::I128 => Endian::read_i128(buf) as f64,
-        DataType::F32 => Endian::read_f32(buf) as f64,
-        DataType::F64 => Endian::read_f64(buf),
+        DataType::U8 => buf[0].as_(),
+        DataType::I8 => AsPrimitive::<i8>::as_(buf[0]).as_(),
+        DataType::U16 => Endian::read_u16(buf).as_(),
+        DataType::I16 => Endian::read_i16(buf).as_(),
+        DataType::U24 => Endian::read_u24(buf).as_(),
+        DataType::I24 => Endian::read_i24(buf).as_(),
+        DataType::U32 => Endian::read_u32(buf).as_(),
+        DataType::I32 => Endian::read_i32(buf).as_(),
+        DataType::U48 => Endian::read_u48(buf).as_(),
+        DataType::I48 => Endian::read_i48(buf).as_(),
+        DataType::U64 => Endian::read_u64(buf).as_(),
+        DataType::I64 => Endian::read_i64(buf).as_(),
+        DataType::U128 => Endian::read_u128(buf).as_(),
+        DataType::I128 => Endian::read_i128(buf).as_(),
+        DataType::F32 => Endian::read_f32(buf).as_(),
+        DataType::F64 => Endian::read_f64(buf).as_(),
     };
     Ok(val)
 }
 
-pub fn try_pack_data<Endian: ByteOrder>(
+pub fn try_pack_data<T, Endian: ByteOrder>(
     buf: &mut [u8],
-    value: f64,
+    value: T,
     data_type: DataType,
-) -> Result<usize, ByteDataError> {
+) -> Result<usize, ByteDataError>
+where
+    T: Float
+        + AsPrimitive<u8>
+        + AsPrimitive<i8>
+        + AsPrimitive<u16>
+        + AsPrimitive<i16>
+        + AsPrimitive<u32>
+        + AsPrimitive<i32>
+        + AsPrimitive<u64>
+        + AsPrimitive<i64>
+        + AsPrimitive<u128>
+        + AsPrimitive<i128>
+        + AsPrimitive<f32>
+        + AsPrimitive<f64>,
+{
     if buf.len() < data_type.byte_size() {
         return Err(ByteDataError::PackError);
     }
     match data_type {
-        DataType::U8 => buf[0] = value as u8,
-        DataType::I8 => buf[0] = value as i8 as u8,
-        DataType::U16 => Endian::write_u16(buf, value as u16),
-        DataType::I16 => Endian::write_i16(buf, value as i16),
-        DataType::U24 => Endian::write_u24(buf, value as u32),
-        DataType::I24 => Endian::write_i24(buf, value as i32),
-        DataType::U32 => Endian::write_u32(buf, value as u32),
-        DataType::I32 => Endian::write_i32(buf, value as i32),
-        DataType::U48 => Endian::write_u48(buf, value as u64),
-        DataType::I48 => Endian::write_i48(buf, value as i64),
-        DataType::U64 => Endian::write_u64(buf, value as u64),
-        DataType::I64 => Endian::write_i64(buf, value as i64),
-        DataType::U128 => Endian::write_u128(buf, value as u128),
-        DataType::I128 => Endian::write_i128(buf, value as i128),
-        DataType::F32 => Endian::write_f32(buf, value as f32),
-        DataType::F64 => Endian::write_f64(buf, value),
+        DataType::U8 => buf[0] = value.as_(),
+        DataType::I8 => buf[0] = AsPrimitive::<i8>::as_(value).as_(),
+        DataType::U16 => Endian::write_u16(buf, value.as_()),
+        DataType::I16 => Endian::write_i16(buf, value.as_()),
+        DataType::U24 => Endian::write_u24(buf, value.as_()),
+        DataType::I24 => Endian::write_i24(buf, value.as_()),
+        DataType::U32 => Endian::write_u32(buf, value.as_()),
+        DataType::I32 => Endian::write_i32(buf, value.as_()),
+        DataType::U48 => Endian::write_u48(buf, value.as_()),
+        DataType::I48 => Endian::write_i48(buf, value.as_()),
+        DataType::U64 => Endian::write_u64(buf, value.as_()),
+        DataType::I64 => Endian::write_i64(buf, value.as_()),
+        DataType::U128 => Endian::write_u128(buf, value.as_()),
+        DataType::I128 => Endian::write_i128(buf, value.as_()),
+        DataType::F32 => Endian::write_f32(buf, value.as_()),
+        DataType::F64 => Endian::write_f64(buf, value.as_()),
     };
     Ok(data_type.byte_size())
 }
@@ -382,13 +414,25 @@ mod tests {
     }
 
     #[test]
-    fn test_try_unpack_data_and_try_pack_data() {
+    fn test_try_unpack_data_and_try_pack_data_f64() {
         let input: f64 = 1234.5678;
         let dt = DataType::F64;
         let mut packed_data = vec![0; dt.byte_size()];
 
-        try_pack_data::<BigEndian>(&mut packed_data, input, dt).unwrap();
-        let unpacked_data = try_unpack_data::<BigEndian>(&packed_data, dt).unwrap();
+        try_pack_data::<f64, BigEndian>(&mut packed_data, input, dt).unwrap();
+        let unpacked_data = try_unpack_data::<f64, BigEndian>(&packed_data, dt).unwrap();
+
+        assert_eq!(input, unpacked_data);
+    }
+
+    #[test]
+    fn test_try_unpack_data_and_try_pack_data_f32() {
+        let input: f32 = 1234.5678;
+        let dt = DataType::F64;
+        let mut packed_data = vec![0; dt.byte_size()];
+
+        try_pack_data::<f32, BigEndian>(&mut packed_data, input, dt).unwrap();
+        let unpacked_data = try_unpack_data::<f32, BigEndian>(&packed_data, dt).unwrap();
 
         assert_eq!(input, unpacked_data);
     }

--- a/pictorus-blocks/src/core_blocks/change_detection_block.rs
+++ b/pictorus-blocks/src/core_blocks/change_detection_block.rs
@@ -1,4 +1,5 @@
-use pictorus_traits::{HasIc, Matrix, Pass, PassBy, ProcessBlock, Scalar};
+use crate::traits::Scalar;
+use pictorus_traits::{HasIc, Matrix, Pass, PassBy, ProcessBlock};
 use strum::EnumString;
 
 /// Detects whether the input value has changed.
@@ -15,14 +16,14 @@ use strum::EnumString;
 ///
 /// The first execution of this block has no value to compare with
 /// so it will always emit `false`
-pub struct ChangeDetectionBlock<T: Apply> {
+pub struct ChangeDetectionBlock<T: Apply<O>, O: Scalar = f64> {
     buffer: T::Output,
     last_input: Option<T>,
 }
 
-impl<T> Default for ChangeDetectionBlock<T>
+impl<T, O: Scalar> Default for ChangeDetectionBlock<T, O>
 where
-    T: Apply,
+    T: Apply<O>,
 {
     fn default() -> Self {
         const {
@@ -34,21 +35,21 @@ where
     }
 }
 
-impl<T> HasIc for ChangeDetectionBlock<T>
+impl<T, O: Scalar> HasIc for ChangeDetectionBlock<T, O>
 where
-    T: Apply,
+    T: Apply<O>,
 {
     fn new(parameters: &Self::Parameters) -> Self {
-        ChangeDetectionBlock::<T> {
+        ChangeDetectionBlock::<T, O> {
             buffer: T::Output::default(),
             last_input: Some(parameters.ic),
         }
     }
 }
 
-impl<T> ProcessBlock for ChangeDetectionBlock<T>
+impl<T, O: Scalar> ProcessBlock for ChangeDetectionBlock<T, O>
 where
-    T: Apply,
+    T: Apply<O>,
 {
     type Inputs = T;
     type Output = T::Output;
@@ -69,7 +70,7 @@ where
     }
 }
 
-pub trait Apply: Pass + Sized + Copy {
+pub trait Apply<O>: Pass + Sized + Copy {
     type Output: Pass + Default;
 
     fn apply<'s>(
@@ -80,8 +81,8 @@ pub trait Apply: Pass + Sized + Copy {
     ) -> PassBy<'s, Self::Output>;
 }
 
-impl<C: ChangeDetect> Apply for C {
-    type Output = f64;
+impl<C: ChangeDetect, O: Scalar> Apply<O> for C {
+    type Output = O;
 
     fn apply<'s>(
         store: &'s mut Self::Output,
@@ -93,13 +94,15 @@ impl<C: ChangeDetect> Apply for C {
         let old_last_input = last_input.replace(input);
         let old_last_input = old_last_input.unwrap_or(params.ic);
         let res = Self::change_detect(input, old_last_input, params.change_mode);
-        *store = res;
-        res.as_by()
+        *store = O::from_bool(res);
+        store.as_by()
     }
 }
 
-impl<const NROWS: usize, const NCOLS: usize, C: ChangeDetect> Apply for Matrix<NROWS, NCOLS, C> {
-    type Output = Matrix<NROWS, NCOLS, f64>;
+impl<const NROWS: usize, const NCOLS: usize, C: ChangeDetect, O: Scalar> Apply<O>
+    for Matrix<NROWS, NCOLS, C>
+{
+    type Output = Matrix<NROWS, NCOLS, O>;
 
     fn apply<'s>(
         store: &'s mut Self::Output,
@@ -127,23 +130,18 @@ impl<const NROWS: usize, const NCOLS: usize, C: ChangeDetect> Apply for Matrix<N
             .iter_mut()
             .zip(inputs)
             .for_each(|(output, (lh, rh))| {
-                *output = C::change_detect(*lh, *rh, params.change_mode)
+                *output = O::from_bool(C::change_detect(*lh, *rh, params.change_mode));
             });
         store
     }
 }
 
 trait ChangeDetect: Scalar + for<'a> Pass<By<'a> = Self> + PartialEq + PartialOrd {
-    fn change_detect(left_hand: PassBy<Self>, right_hand: PassBy<Self>, mode: ChangeMode) -> f64 {
-        let bool_output = match mode {
+    fn change_detect(left_hand: PassBy<Self>, right_hand: PassBy<Self>, mode: ChangeMode) -> bool {
+        match mode {
             ChangeMode::Any => left_hand != right_hand,
             ChangeMode::Rising => left_hand > right_hand,
             ChangeMode::Falling => left_hand < right_hand,
-        };
-        if bool_output {
-            1.0
-        } else {
-            0.0
         }
     }
 }
@@ -185,7 +183,6 @@ impl<T> Parameters<T> {
 mod tests {
     use super::*;
     use crate::testing::StubContext;
-    use crate::traits::Scalar as _;
     use paste::paste;
 
     macro_rules! test_scalars {
@@ -477,5 +474,46 @@ mod tests {
         //Rising all values
         let output = block.process(&params, &context, true);
         assert!(!output.is_truthy());
+    }
+
+    #[test]
+    fn test_f32_output_type_scalar() {
+        let context = StubContext::default();
+        let params = Parameters::new(1.0f64, "Any");
+        let mut block: ChangeDetectionBlock<_, f32> = ChangeDetectionBlock::new(&params);
+
+        // No change
+        let output = block.process(&params, &context, 1.0);
+        assert_eq!(output, 0.0f32);
+
+        // Falling for all values
+        let output = block.process(&params, &context, 0.0);
+        assert_eq!(output, 1.0f32);
+
+        //Rising all values
+        let output = block.process(&params, &context, 2.0);
+        assert_eq!(output, 1.0f32);
+    }
+
+    #[test]
+    fn test_f32_output_type_matrix() {
+        let context = StubContext::default();
+        let params = Parameters::new(
+            Matrix {
+                data: [[1u8; 2]; 2],
+            },
+            "Any",
+        );
+        // Accepts a Matrix<2,2, u8> as input and outputs a Matrix<2,2,f32>
+        let mut block: ChangeDetectionBlock<_, f32> = ChangeDetectionBlock::new(&params);
+
+        // No change
+        let output = block.process(&params, &context, &Matrix { data: [[1; 2]; 2] });
+        assert_eq!(
+            output,
+            &Matrix {
+                data: [[0.0f32; 2]; 2]
+            }
+        );
     }
 }

--- a/pictorus-blocks/src/core_blocks/constant_block.rs
+++ b/pictorus-blocks/src/core_blocks/constant_block.rs
@@ -1,4 +1,5 @@
-use pictorus_traits::{GeneratorBlock, Matrix, Pass, PassBy, Scalar};
+use crate::traits::Scalar;
+use pictorus_traits::{GeneratorBlock, Matrix, Pass, PassBy};
 
 pub struct Parameters<T> {
     pub constant: T,
@@ -58,8 +59,8 @@ pub trait Apply: Pass + Sized {
     ) -> PassBy<'s, Self::Output>;
 }
 
-impl Apply for f64 {
-    type Output = f64;
+impl<T: Scalar> Apply for T {
+    type Output = T;
 
     fn apply<'s>(
         store: &'s mut Self::Output,
@@ -143,5 +144,35 @@ mod tests {
         assert_eq!(block.buffer().data[1][0], 2.0);
         assert_eq!(block.buffer().data[0][1], 3.0);
         assert_eq!(block.buffer().data[1][1], 4.0);
+    }
+
+    #[test]
+    fn test_constant_scalar_f32() {
+        let mut block = ConstantBlock::<f32>::default();
+        let parameters = Parameters::new(3.0_f32);
+        let context = StubContext::default();
+
+        let output = block.generate(&parameters, &context);
+        assert_eq!(output, 3.0_f32);
+        assert_eq!(block.buffer(), output);
+    }
+
+    #[test]
+    fn test_constant_matrix_f32() {
+        let mut block = ConstantBlock::<Matrix<2, 2, f32>>::default();
+        let parameters = Parameters::new(Matrix {
+            data: [[1.0_f32, 3.0_f32], [2.0_f32, 4.0_f32]],
+        });
+        let context = StubContext::default();
+
+        let output = block.generate(&parameters, &context);
+        assert_eq!(output.data[0][0], 1.0_f32);
+        assert_eq!(output.data[1][0], 2.0_f32);
+        assert_eq!(output.data[0][1], 3.0_f32);
+        assert_eq!(output.data[1][1], 4.0_f32);
+        assert_eq!(block.buffer().data[0][0], 1.0_f32);
+        assert_eq!(block.buffer().data[1][0], 2.0_f32);
+        assert_eq!(block.buffer().data[0][1], 3.0_f32);
+        assert_eq!(block.buffer().data[1][1], 4.0_f32);
     }
 }

--- a/pictorus-blocks/src/core_blocks/counter_block.rs
+++ b/pictorus-blocks/src/core_blocks/counter_block.rs
@@ -27,11 +27,13 @@ impl Parameters {
 /// or a matrix of scalars. However they are interpreted as bools or matrices of bools, where true or
 /// false is determined by whether the value is non-zero or zero respectively. See the [`Scalar::is_truthy`]
 /// function for more details.
-pub struct CounterBlock<T: Apply> {
+pub struct CounterBlock<T: Apply<O>, O: Scalar + num_traits::Zero + num_traits::One = f64> {
     counter: T::Counter,
 }
 
-impl<T: Apply> ProcessBlock for CounterBlock<T> {
+impl<T: Apply<O>, O: Scalar + num_traits::Zero + num_traits::One> ProcessBlock
+    for CounterBlock<T, O>
+{
     type Inputs = T;
     type Output = T::Counter;
     type Parameters = Parameters;
@@ -50,41 +52,46 @@ impl<T: Apply> ProcessBlock for CounterBlock<T> {
     }
 }
 
-impl<T: Apply> Default for CounterBlock<T> {
+impl<T: Apply<O>, O: Scalar + num_traits::Zero + num_traits::One> Default for CounterBlock<T, O> {
     fn default() -> Self {
         let counter = T::Counter::default();
         Self { counter }
     }
 }
 
-pub trait Apply: Pass {
+pub trait Apply<O>: Pass {
     type Counter: Default + Pass;
     fn apply<'a>(count: &'a mut Self::Counter, input: PassBy<Self>) -> PassBy<'a, Self::Counter>;
 }
 
-impl<I: Scalar, R: Scalar> Apply for (I, R) {
-    type Counter = f64;
+impl<I: Scalar, O: Scalar + num_traits::Zero + num_traits::One, R: Scalar> Apply<O> for (I, R) {
+    type Counter = O;
     fn apply<'a>(count: &'a mut Self::Counter, input: PassBy<Self>) -> PassBy<'a, Self::Counter> {
         if input.1.is_truthy() {
-            *count = 0.0;
+            *count = O::zero();
         } else if input.0.is_truthy() {
-            *count += 1.0;
+            *count = *count + O::one();
         }
         count.as_by()
     }
 }
 
-impl<I: Scalar, R: Scalar, const NROWS: usize, const NCOLS: usize> Apply
-    for (Matrix<NROWS, NCOLS, I>, R)
+impl<
+        O: Scalar + num_traits::Zero + num_traits::One,
+        I: Scalar,
+        R: Scalar,
+        const NROWS: usize,
+        const NCOLS: usize,
+    > Apply<O> for (Matrix<NROWS, NCOLS, I>, R)
 {
-    type Counter = Matrix<NROWS, NCOLS, f64>;
+    type Counter = Matrix<NROWS, NCOLS, O>;
     fn apply<'a>(count: &'a mut Self::Counter, input: PassBy<Self>) -> PassBy<'a, Self::Counter> {
         for i in 0..NROWS {
             for j in 0..NCOLS {
                 if input.1.is_truthy() {
-                    count.data[j][i] = 0.0;
+                    count.data[j][i] = O::zero();
                 } else if input.0.data[j][i].is_truthy() {
-                    count.data[j][i] += 1.0;
+                    count.data[j][i] = count.data[j][i] + O::one();
                 }
             }
         }
@@ -92,17 +99,22 @@ impl<I: Scalar, R: Scalar, const NROWS: usize, const NCOLS: usize> Apply
     }
 }
 
-impl<I: Scalar, R: Scalar, const NROWS: usize, const NCOLS: usize> Apply
-    for (Matrix<NROWS, NCOLS, I>, Matrix<NROWS, NCOLS, R>)
+impl<
+        I: Scalar,
+        O: Scalar + num_traits::Zero + num_traits::One,
+        R: Scalar,
+        const NROWS: usize,
+        const NCOLS: usize,
+    > Apply<O> for (Matrix<NROWS, NCOLS, I>, Matrix<NROWS, NCOLS, R>)
 {
-    type Counter = Matrix<NROWS, NCOLS, f64>;
+    type Counter = Matrix<NROWS, NCOLS, O>;
     fn apply<'a>(count: &'a mut Self::Counter, input: PassBy<Self>) -> PassBy<'a, Self::Counter> {
         for i in 0..NROWS {
             for j in 0..NCOLS {
                 if input.1.data[j][i].is_truthy() {
-                    count.data[j][i] = 0.0;
+                    count.data[j][i] = O::zero();
                 } else if input.0.data[j][i].is_truthy() {
-                    count.data[j][i] += 1.0;
+                    count.data[j][i] = count.data[j][i] + O::one();
                 }
             }
         }
@@ -118,7 +130,7 @@ mod tests {
 
     #[test]
     fn test_counter_default_buffer_no_panic() {
-        let block = CounterBlock::<(Matrix<1, 1, bool>, Matrix<1, 1, bool>)>::default();
+        let block = CounterBlock::<(Matrix<1, 1, f64>, Matrix<1, 1, bool>), f64>::default();
         assert_eq!(block.buffer(), &Matrix::<1, 1, f64>::zeroed());
     }
 
@@ -149,7 +161,7 @@ mod tests {
     #[test]
     fn test_counter_block_1x2_f64() {
         let p = Parameters::new();
-        let mut block = CounterBlock::<(Matrix<1, 2, bool>, Matrix<1, 2, bool>)>::default();
+        let mut block = CounterBlock::<(Matrix<1, 2, bool>, Matrix<1, 2, bool>), f64>::default();
         let c = StubContext::default();
 
         let mut increment = Matrix::<1, 2, bool>::zeroed();
@@ -175,7 +187,7 @@ mod tests {
     #[test]
     fn test_counter_block_2x2_f64() {
         let p = Parameters::new();
-        let mut block = CounterBlock::<(Matrix<2, 2, f64>, Matrix<2, 2, bool>)>::default();
+        let mut block = CounterBlock::<(Matrix<2, 2, f64>, Matrix<2, 2, bool>), f64>::default();
         let c = StubContext::default();
 
         let mut increment = Matrix::<2, 2, f64>::zeroed();
@@ -226,7 +238,7 @@ mod tests {
     #[test]
     fn test_counter_block_2x2_single_reset_f64() {
         let p = Parameters::new();
-        let mut block = CounterBlock::<(Matrix<2, 2, f64>, bool)>::default();
+        let mut block = CounterBlock::<(Matrix<2, 2, f64>, bool), f64>::default();
         let c = StubContext::default();
 
         let mut increment = Matrix::<2, 2, f64>::zeroed();
@@ -273,7 +285,7 @@ mod tests {
     #[test]
     fn test_counter_block_2x2_u8() {
         let p = Parameters::new();
-        let mut block = CounterBlock::<(Matrix<2, 2, u8>, Matrix<2, 2, bool>)>::default();
+        let mut block = CounterBlock::<(Matrix<2, 2, u8>, Matrix<2, 2, bool>), f32>::default();
         let c = StubContext::default();
 
         let mut increment = Matrix::<2, 2, u8>::zeroed();

--- a/pictorus-blocks/src/core_blocks/delay_control_block.rs
+++ b/pictorus-blocks/src/core_blocks/delay_control_block.rs
@@ -9,13 +9,13 @@ use pictorus_traits::{Context, Matrix, Pass, PassBy, ProcessBlock};
 /// The block has two modes: Debounce and Throttle
 ///  - Debounce: Wait until the input signal stops being true for delay_time before emitting true.
 ///  - Throttle: Immediately emit true on first true input, but then wait delay_time before passing through a true input again.
-pub struct DelayControlBlock<T: Apply> {
+pub struct DelayControlBlock<T: Apply<O>, O: Scalar = f64> {
     buffer: T::Output,
     /// This is the state of the block used for the debounce and throttle functionality
     state: T::State,
 }
 
-impl<T: Apply> Default for DelayControlBlock<T> {
+impl<T: Apply<O>, O: Scalar> Default for DelayControlBlock<T, O> {
     fn default() -> Self {
         Self {
             buffer: T::Output::default(),
@@ -24,7 +24,7 @@ impl<T: Apply> Default for DelayControlBlock<T> {
     }
 }
 
-impl<T: Apply> ProcessBlock for DelayControlBlock<T> {
+impl<T: Apply<O>, O: Scalar> ProcessBlock for DelayControlBlock<T, O> {
     type Inputs = T;
     type Output = T::Output;
     type Parameters = Parameters;
@@ -50,7 +50,7 @@ impl<T: Apply> ProcessBlock for DelayControlBlock<T> {
     }
 }
 
-pub trait Apply: Pass {
+pub trait Apply<O>: Pass {
     type State;
     type Output: Pass + Default;
 
@@ -65,9 +65,9 @@ pub trait Apply: Pass {
     ) -> PassBy<'s, Self::Output>;
 }
 
-impl<S: Scalar> Apply for S {
+impl<S: Scalar, O: Scalar> Apply<O> for S {
     type State = Option<Duration>;
-    type Output = f64;
+    type Output = O;
 
     fn init_state() -> Self::State {
         None
@@ -83,19 +83,21 @@ impl<S: Scalar> Apply for S {
         let is_true = input.is_truthy();
         match parameters.method {
             DelayControlMethod::Debounce => {
-                *store = debounce(is_true, state, parameters.delay, context.time());
+                *store = O::from_bool(debounce(is_true, state, parameters.delay, context.time()));
             }
 
             DelayControlMethod::Throttle => {
-                *store = throttle(is_true, state, parameters.delay, context.time());
+                *store = O::from_bool(throttle(is_true, state, parameters.delay, context.time()));
             }
         }
         store.as_by()
     }
 }
 
-impl<S: Scalar, const NROWS: usize, const NCOLS: usize> Apply for Matrix<NROWS, NCOLS, S> {
-    type Output = Matrix<NROWS, NCOLS, f64>;
+impl<S: Scalar, const NROWS: usize, const NCOLS: usize, O: Scalar> Apply<O>
+    for Matrix<NROWS, NCOLS, S>
+{
+    type Output = Matrix<NROWS, NCOLS, O>;
     type State = [[Option<Duration>; NROWS]; NCOLS];
 
     fn init_state() -> Self::State {
@@ -116,21 +118,21 @@ impl<S: Scalar, const NROWS: usize, const NCOLS: usize> Apply for Matrix<NROWS, 
             let is_true = input_flat[i].is_truthy();
             match parameters.method {
                 DelayControlMethod::Debounce => {
-                    store_flat[i] = debounce(
+                    store_flat[i] = O::from_bool(debounce(
                         is_true,
                         &mut state_flat[i],
                         parameters.delay,
                         context.time(),
-                    );
+                    ));
                 }
 
                 DelayControlMethod::Throttle => {
-                    store_flat[i] = throttle(
+                    store_flat[i] = O::from_bool(throttle(
                         is_true,
                         &mut state_flat[i],
                         parameters.delay,
                         context.time(),
-                    );
+                    ));
                 }
             }
         }
@@ -146,7 +148,7 @@ fn debounce(
     state: &mut Option<Duration>,
     delay: Duration,
     curr_time: Duration,
-) -> f64 {
+) -> bool {
     let mut output = false;
     if input {
         *state = Some(curr_time);
@@ -156,11 +158,7 @@ fn debounce(
             *state = None;
         }
     }
-    if output {
-        1.0
-    } else {
-        0.0
-    }
+    output
 }
 
 /// If state is Some(d) and current_time - d >= delay then set state to None
@@ -171,7 +169,7 @@ fn throttle(
     state: &mut Option<Duration>,
     delay: Duration,
     curr_time: Duration,
-) -> f64 {
+) -> bool {
     let mut output = false;
     if let Some(d) = state {
         if curr_time - *d >= delay {
@@ -182,11 +180,7 @@ fn throttle(
         output = true;
         *state = Some(curr_time);
     }
-    if output {
-        1.0
-    } else {
-        0.0
-    }
+    output
 }
 
 #[derive(strum::EnumString, Clone, Copy, Debug)]

--- a/pictorus-blocks/src/core_blocks/derivative_block.rs
+++ b/pictorus-blocks/src/core_blocks/derivative_block.rs
@@ -1,6 +1,4 @@
-use crate::matrix_ext::MatrixNalgebraExt;
-use num_traits::One;
-use paste::paste;
+use crate::{matrix_ext::MatrixNalgebraExt, traits::Float};
 use pictorus_traits::{HasIc, Matrix, Pass, ProcessBlock};
 
 /// Compute the discrete derivative of a signal using a sliding window of samples.
@@ -22,112 +20,108 @@ impl<const N: usize, T: Pass + Default + Copy> Default for DerivativeBlock<T, N>
     }
 }
 
-macro_rules! impl_process {
-    ($type:ty) => {
-        paste! {
-        impl<const N: usize> ProcessBlock for DerivativeBlock< $type, N>
-        {
-            type Inputs = $type;
-            type Output = $type;
-            type Parameters = Parameters<$type>;
+impl<T: Float, const N: usize> ProcessBlock for DerivativeBlock<T, N> {
+    type Inputs = T;
+    type Output = T;
+    type Parameters = Parameters<T>;
 
-            fn process<'b>(
-                &'b mut self,
-                _parameters: &Self::Parameters,
-                context: &dyn pictorus_traits::Context,
-                inputs: pictorus_traits::PassBy<'_, Self::Inputs>,
-            ) -> pictorus_traits::PassBy<'b, Self::Output> {
-                // store the current input in the sample buffer
-                self.samples[self.sample_index] = inputs;
+    fn process<'b>(
+        &'b mut self,
+        _parameters: &Self::Parameters,
+        context: &dyn pictorus_traits::Context,
+        inputs: pictorus_traits::PassBy<'_, Self::Inputs>,
+    ) -> pictorus_traits::PassBy<'b, Self::Output> {
+        // store the current input in the sample buffer
+        self.samples[self.sample_index] = inputs;
 
-                // increment the sample index, wrapping at N (and setting initial_accumulation to false)
-                self.sample_index += 1;
-                if self.sample_index >= N {
-                    self.sample_index = 0;
-                    self.initial_accumulation = false;
-                }
-
-                // Only set the output when initial accumulation is done, otherwise use the IC
-                if !self.initial_accumulation {
-                    self.output = (inputs - self.samples[self.sample_index])
-                        / ((N as $type - $type::one()) * context.timestep().expect("timestep should never be None outside of Initial Accumulation phase").[<as_secs_ $type>]());
-                }
-
-                self.output.as_by()
-            }
-
-            fn buffer(&self) -> pictorus_traits::PassBy<'_, Self::Output> {
-                self.output.as_by()
-            }
+        // increment the sample index, wrapping at N (and setting initial_accumulation to false)
+        self.sample_index += 1;
+        if self.sample_index >= N {
+            self.sample_index = 0;
+            self.initial_accumulation = false;
         }
 
-        impl<const N: usize> HasIc for DerivativeBlock<$type, N>
-        {
-            fn new(parameters: &Self::Parameters) -> Self {
-                DerivativeBlock::<$type, N> {
-                    samples: [0.0; N],
-                    sample_index: 0,
-                    initial_accumulation: true,
-                    output: parameters.ic,
-                }
-            }
+        // Only set the output when initial accumulation is done, otherwise use the IC
+        if !self.initial_accumulation {
+            self.output = (inputs - self.samples[self.sample_index])
+                / ((T::from_usize(N).unwrap() - T::one())
+                    * T::from_duration(context.timestep().expect(
+                        "timestep should never be None outside of Initial Accumulation phase",
+                    )));
         }
 
-        impl<const N: usize, const NCOLS: usize, const NROWS: usize> ProcessBlock for DerivativeBlock< Matrix<NROWS, NCOLS, $type>, N>
-        {
-            type Inputs = Matrix<NROWS, NCOLS, $type>;
-            type Output = Matrix<NROWS, NCOLS, $type>;
-            type Parameters = Parameters<Matrix<NROWS, NCOLS, $type>>;
-
-            fn process<'b>(
-                &'b mut self,
-                _parameters: &Self::Parameters,
-                context: &dyn pictorus_traits::Context,
-                inputs: pictorus_traits::PassBy<'_, Self::Inputs>,
-            ) -> pictorus_traits::PassBy<'b, Self::Output> {
-                // store the current input in the sample buffer
-                self.samples[self.sample_index] = *inputs;
-
-                // increment the sample index, wrapping at N (and setting initial_accumulation to false)
-                self.sample_index += 1;
-                if self.sample_index >= N {
-                    self.sample_index = 0;
-                    self.initial_accumulation = false;
-                }
-
-                // Only set the output when initial accumulation is done, otherwise use the IC
-                if !self.initial_accumulation {
-                    let output =
-                     (inputs.as_view() - self.samples[self.sample_index].as_view())
-                        / ((N as $type - $type::one()) * context.timestep().expect("timestep should never be None outside of Initial Accumulation phase").[<as_secs_ $type>]());
-                    self.output.as_view_mut().copy_from(&output);
-                }
-
-                &self.output
-            }
-
-            fn buffer(&self) -> pictorus_traits::PassBy<'_, Self::Output> {
-                self.output.as_by()
-            }
-        }
-
-        impl<const N: usize, const NCOLS: usize, const NROWS: usize> HasIc for DerivativeBlock<Matrix<NROWS, NCOLS, $type>, N>
-        {
-            fn new(parameters: &Self::Parameters) -> Self {
-                DerivativeBlock::<Matrix<NROWS, NCOLS, $type>, N> {
-                    samples: [Matrix::zeroed(); N],
-                    sample_index: 0,
-                    initial_accumulation: true,
-                    output: parameters.ic,
-                }
-            }
-        }
+        self.output.as_by()
     }
-    };
+
+    fn buffer(&self) -> pictorus_traits::PassBy<'_, Self::Output> {
+        self.output.as_by()
+    }
 }
 
-impl_process!(f64);
-impl_process!(f32);
+impl<T: Float, const N: usize> HasIc for DerivativeBlock<T, N> {
+    fn new(parameters: &Self::Parameters) -> Self {
+        DerivativeBlock::<T, N> {
+            samples: [T::zero(); N],
+            sample_index: 0,
+            initial_accumulation: true,
+            output: parameters.ic,
+        }
+    }
+}
+
+impl<T: Float, const N: usize, const NCOLS: usize, const NROWS: usize> ProcessBlock
+    for DerivativeBlock<Matrix<NROWS, NCOLS, T>, N>
+{
+    type Inputs = Matrix<NROWS, NCOLS, T>;
+    type Output = Matrix<NROWS, NCOLS, T>;
+    type Parameters = Parameters<Matrix<NROWS, NCOLS, T>>;
+
+    fn process<'b>(
+        &'b mut self,
+        _parameters: &Self::Parameters,
+        context: &dyn pictorus_traits::Context,
+        inputs: pictorus_traits::PassBy<'_, Self::Inputs>,
+    ) -> pictorus_traits::PassBy<'b, Self::Output> {
+        // store the current input in the sample buffer
+        self.samples[self.sample_index] = *inputs;
+
+        // increment the sample index, wrapping at N (and setting initial_accumulation to false)
+        self.sample_index += 1;
+        if self.sample_index >= N {
+            self.sample_index = 0;
+            self.initial_accumulation = false;
+        }
+
+        // Only set the output when initial accumulation is done, otherwise use the IC
+        if !self.initial_accumulation {
+            let output = (inputs.as_view() - self.samples[self.sample_index].as_view())
+                / ((T::from_usize(N).unwrap() - T::one())
+                    * T::from_duration(context.timestep().expect(
+                        "timestep should never be None outside of Initial Accumulation phase",
+                    )));
+            self.output.as_view_mut().copy_from(&output);
+        }
+
+        &self.output
+    }
+
+    fn buffer(&self) -> pictorus_traits::PassBy<'_, Self::Output> {
+        self.output.as_by()
+    }
+}
+
+impl<T: Float, const N: usize, const NCOLS: usize, const NROWS: usize> HasIc
+    for DerivativeBlock<Matrix<NROWS, NCOLS, T>, N>
+{
+    fn new(parameters: &Self::Parameters) -> Self {
+        DerivativeBlock::<Matrix<NROWS, NCOLS, T>, N> {
+            samples: [Matrix::zeroed(); N],
+            sample_index: 0,
+            initial_accumulation: true,
+            output: parameters.ic,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Parameters<T: Pass> {

--- a/pictorus-blocks/src/core_blocks/pid_block.rs
+++ b/pictorus-blocks/src/core_blocks/pid_block.rs
@@ -80,7 +80,10 @@ where
         DerivativeParameters { ic: parameters.ic }
     }
 }
-
+// The Generics here are made more complicated because this block contains an IntegralBlock and DerivativeBlock.
+// It needs to enforce its own bounds as well as those of the sub-blocks. `ComponentOps` is the trait this block defines
+// itself. The first two sections of the where clause are the bounds for the sub-blocks. And the last section is the bound
+// for the Integral's `Apply` trait.
 impl<T: ComponentOps, R: Scalar, const ND_SAMPLES: usize> ProcessBlock
     for PidBlock<T, R, ND_SAMPLES>
 where

--- a/pictorus-blocks/src/core_blocks/pid_block.rs
+++ b/pictorus-blocks/src/core_blocks/pid_block.rs
@@ -130,11 +130,6 @@ where
     }
 }
 
-// TODO: This is currently only implemented for f64 types. The IntegralBlock
-// and DerivativeBlock are implemented using very different approaches: integral
-// block uses a trait-based approach, and derivative block uses macros. I think if we
-// consolidated our approach for these 3 blocks we could make this simpler and more generic.
-// Ideally we could just have a blanket impl for <const ND_SAMPLES: usize, T: ComponentOps>.
 impl<T: ComponentOps, R: Scalar, const ND_SAMPLES: usize> HasIc for PidBlock<T, R, ND_SAMPLES>
 where
     DerivativeBlock<T, ND_SAMPLES>:

--- a/pictorus-blocks/src/core_blocks/pid_block.rs
+++ b/pictorus-blocks/src/core_blocks/pid_block.rs
@@ -80,6 +80,7 @@ where
         DerivativeParameters { ic: parameters.ic }
     }
 }
+
 impl<T: ComponentOps, R: Scalar, const ND_SAMPLES: usize> ProcessBlock
     for PidBlock<T, R, ND_SAMPLES>
 where
@@ -134,20 +135,13 @@ where
 // block uses a trait-based approach, and derivative block uses macros. I think if we
 // consolidated our approach for these 3 blocks we could make this simpler and more generic.
 // Ideally we could just have a blanket impl for <const ND_SAMPLES: usize, T: ComponentOps>.
-impl<const ND_SAMPLES: usize, R: Scalar> HasIc for PidBlock<f64, R, ND_SAMPLES> {
-    fn new(parameters: &Self::Parameters) -> Self {
-        let integrator_params = Self::integrator_params(parameters);
-        let derivative_params = Self::derivative_params(parameters);
-        Self {
-            buffer: parameters.ic,
-            integrator: IntegralBlock::new(&integrator_params),
-            derivative: DerivativeBlock::new(&derivative_params),
-        }
-    }
-}
-
-impl<const ND_SAMPLES: usize, const NROWS: usize, const NCOLS: usize, R: Scalar> HasIc
-    for PidBlock<Matrix<NROWS, NCOLS, f64>, R, ND_SAMPLES>
+impl<T: ComponentOps, R: Scalar, const ND_SAMPLES: usize> HasIc for PidBlock<T, R, ND_SAMPLES>
+where
+    DerivativeBlock<T, ND_SAMPLES>:
+        ProcessBlock<Output = T, Inputs = T, Parameters = DerivativeParameters<T>> + HasIc,
+    IntegralBlock<(T, R)>:
+        ProcessBlock<Output = T, Inputs = (T, R), Parameters = IntegralParameters<(T, R)>> + HasIc,
+    (T, R): IntegralApply<Output = T, Float = T::Float> + for<'a> Pass<By<'a> = (PassBy<'a, T>, R)>,
 {
     fn new(parameters: &Self::Parameters) -> Self {
         let integrator_params = Self::integrator_params(parameters);
@@ -159,7 +153,6 @@ impl<const ND_SAMPLES: usize, const NROWS: usize, const NCOLS: usize, R: Scalar>
         }
     }
 }
-
 // It would be nice to have these types of common operators defined somewhere reusable
 // I.e. mixed scalar/matrix addition, multiplication, etc. This would reduce a lot
 // of repetition in block implementations
@@ -326,6 +319,26 @@ mod tests {
     }
 
     #[test]
+    fn test_pid_f32_scalar_with_ic() {
+        let mut runtime = StubRuntime::new(StubContext::new(
+            Duration::ZERO,
+            None,
+            Duration::from_secs_f64(1.0),
+        ));
+        let params = Parameters::new(5.0, 1.0, 2.0, 3.0, 10.0);
+        let mut block = PidBlock::<f32, bool, 2>::new(&params);
+
+        let res = block.process(&params, &runtime.context(), (0.0, false));
+        assert_relative_eq!(res, 20.0, max_relative = 0.01);
+        runtime.tick();
+
+        // p: 2, i: 5 + 4 = 9, d: 6
+        let res = block.process(&params, &runtime.context(), (2.0, false));
+        assert_relative_eq!(res, 17.0, max_relative = 0.01);
+        assert_relative_eq!(block.buffer(), 17.0, max_relative = 0.01);
+    }
+
+    #[test]
     fn test_p_matrix() {
         let mut runtime = StubRuntime::new(StubContext::new(
             Duration::ZERO,
@@ -469,6 +482,44 @@ mod tests {
         ));
         let params = Parameters::new(Matrix::zeroed(), 1.0, 2.0, 3.0, 10.0);
         let mut block = PidBlock::<Matrix<2, 2, f64>, bool, 2>::new(&params);
+
+        let input = Matrix {
+            data: [[0.0, 0.0], [0.0, 0.0]],
+        };
+        let res = block.process(&params, &runtime.context(), (&input, false));
+        let expected = Matrix {
+            data: [[0.0, 0.0], [0.0, 0.0]],
+        };
+        assert_eq!(res, &expected);
+        assert_eq!(
+            block.buffer().data.as_flattened(),
+            expected.data.as_flattened()
+        );
+        runtime.tick();
+
+        let input = Matrix {
+            data: [[1.0, 2.0], [3.0, 4.0]],
+        };
+        let res = block.process(&params, &runtime.context(), (&input, false));
+        let expected = Matrix {
+            data: [[6.0, 12.0], [18.0, 24.0]],
+        };
+        assert_eq!(res, &expected);
+        assert_eq!(
+            block.buffer().data.as_flattened(),
+            expected.data.as_flattened()
+        );
+    }
+
+    #[test]
+    fn test_pid_matrix_f32() {
+        let mut runtime = StubRuntime::new(StubContext::new(
+            Duration::ZERO,
+            None,
+            Duration::from_secs_f64(1.0),
+        ));
+        let params = Parameters::new(Matrix::zeroed(), 1.0, 2.0, 3.0, 10.0);
+        let mut block = PidBlock::<Matrix<2, 2, f32>, bool, 2>::new(&params);
 
         let input = Matrix {
             data: [[0.0, 0.0], [0.0, 0.0]],

--- a/pictorus-blocks/src/core_blocks/timer_block.rs
+++ b/pictorus-blocks/src/core_blocks/timer_block.rs
@@ -1,4 +1,6 @@
-use pictorus_traits::{PassBy, ProcessBlock, Scalar};
+use pictorus_traits::{PassBy, ProcessBlock};
+
+use crate::traits::{Float, Scalar};
 
 #[derive(strum::EnumString)]
 pub enum Method {
@@ -7,20 +9,20 @@ pub enum Method {
 }
 
 /// Parameters for the TimerBlock
-pub struct Parameters {
+pub struct Parameters<O: Float> {
     /// Method of the TimerBlock: CountDown or StopWatch. CountDown will count down from
     /// the countdown_time_s, while StopWatch will count up from 0.
     pub method: Method,
     /// If the TimerBlock is interruptable. If this is true and the trigger is > 0, the timer will restart.
     pub interruptable: bool,
     /// The time in seconds to count down from. Only used if method is CountDown.
-    pub countdown_time_s: f64,
+    pub countdown_time_s: O,
 }
 
-impl Parameters {
-    pub fn new(method: &str, interruptable: bool, countdown_time_s: f64) -> Parameters {
+impl<O: Float> Parameters<O> {
+    pub fn new(method: &str, interruptable: bool, countdown_time_s: O) -> Parameters<O> {
         Parameters {
-            method: method.parse().expect("Faile to parse Timer Method"),
+            method: method.parse().expect("Failed to parse Timer Method"),
             interruptable,
             countdown_time_s,
         }
@@ -35,44 +37,47 @@ impl Parameters {
 /// or count up without ever restarting.
 ///
 /// This block is useful for tracking how much time has passed since an event for logical conditions.
-pub struct TimerBlock<T> {
-    buffer: T,
+pub struct TimerBlock<T, O = T> {
+    buffer: O,
     timer_running: bool,
-    start_time_s: T,
+    start_time_s: O,
+    phantom: core::marker::PhantomData<T>,
 }
 
-impl<T> Default for TimerBlock<T>
+impl<T, O> Default for TimerBlock<T, O>
 where
-    T: Scalar + num_traits::Zero,
+    T: Scalar,
+    O: Float,
 {
     fn default() -> Self {
         Self {
-            buffer: T::zero(),
+            buffer: O::zero(),
             timer_running: false,
-            start_time_s: T::zero(),
+            start_time_s: O::zero(),
+            phantom: core::marker::PhantomData,
         }
     }
 }
 
-impl TimerBlock<f64> {
-    fn _do_countdown(&mut self, time_since_start: f64, countdown_time_s: f64) {
+impl<T: Scalar, O: Float> TimerBlock<T, O> {
+    fn _do_countdown(&mut self, time_since_start: O, countdown_time_s: O) {
         if time_since_start < countdown_time_s {
             self.buffer = countdown_time_s - time_since_start;
         } else {
-            self.buffer = 0.0;
+            self.buffer = O::zero();
             self.timer_running = false;
         }
     }
 
-    fn _do_stopwatch(&mut self, time_since_start: f64) {
+    fn _do_stopwatch(&mut self, time_since_start: O) {
         self.buffer = time_since_start;
     }
 }
 
-impl ProcessBlock for TimerBlock<f64> {
-    type Inputs = f64;
-    type Output = f64;
-    type Parameters = Parameters;
+impl<T: Scalar, O: Float> ProcessBlock for TimerBlock<T, O> {
+    type Inputs = T;
+    type Output = O;
+    type Parameters = Parameters<O>;
 
     fn process(
         &mut self,
@@ -80,9 +85,9 @@ impl ProcessBlock for TimerBlock<f64> {
         context: &dyn pictorus_traits::Context,
         input: PassBy<Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
-        let time = context.time().as_secs_f64();
+        let time = O::from_duration(context.time());
 
-        let trigger_high = input > 0.0;
+        let trigger_high = input.is_truthy();
         // Early exit if not running and input trigger is false
         if !self.timer_running && !trigger_high {
             return self.buffer;
@@ -290,5 +295,31 @@ mod tests {
         let output = block.process(&p, &runtime.context(), 0.0);
         assert_eq!(block.buffer(), 96.0);
         assert_eq!(output, 96.0);
+    }
+
+    #[test]
+    fn test_f32_output_type() {
+        let mut runtime = StubRuntime::default();
+        runtime.set_time(time::Duration::from_secs(42));
+        let mut block: TimerBlock<f32, f32> = Default::default();
+        let params = Parameters::new("CountDown", false, 5.0);
+        let output = block.process(&params, &runtime.context(), 1.0);
+        assert_eq!(output, 5.0);
+    }
+
+    #[test]
+    fn test_mixed_types() {
+        let mut runtime = StubRuntime::default();
+        runtime.set_time(time::Duration::from_secs(42));
+        let mut block: TimerBlock<f32, f64> = Default::default();
+        let params = Parameters::new("CountDown", false, 5.0);
+        let output = block.process(&params, &runtime.context(), 1.0);
+        assert_eq!(output, 5.0);
+
+        let mut block: TimerBlock<bool, f64> = Default::default();
+        let params = Parameters::new("CountDown", false, 5.0);
+
+        let output = block.process(&params, &runtime.context(), true);
+        assert_eq!(output, 5.0);
     }
 }

--- a/pictorus-blocks/src/std_blocks/system_time_block.rs
+++ b/pictorus-blocks/src/std_blocks/system_time_block.rs
@@ -1,37 +1,51 @@
 use chrono::{DateTime, Datelike, Local, Timelike};
+use num_traits::AsPrimitive;
 use pictorus_traits::{GeneratorBlock, PassBy};
+
+use crate::traits::Float;
 
 /// This block can be used in `std` environments to get the current system time.
 /// The time output can be in different formats, such as epoch time, second, minute, hour, day of the month, day of the year, month, or year.
-pub struct SystemTimeBlock {
-    output: f64,
+pub struct SystemTimeBlock<O: Float = f64> {
+    output: O,
     start_time: DateTime<Local>,
 }
 
-impl Default for SystemTimeBlock {
+impl<O: Float> Default for SystemTimeBlock<O> {
     fn default() -> Self {
         Self {
-            output: 0.0,
+            output: O::zero(),
             start_time: Local::now(),
         }
     }
 }
 
-fn get_output_value(time: DateTime<Local>, method: SystemTimeEnum) -> f64 {
+fn get_output_value<O: Float>(time: DateTime<Local>, method: SystemTimeEnum) -> O
+where
+    i64: AsPrimitive<O>,
+    i32: AsPrimitive<O>,
+    u32: AsPrimitive<O>,
+{
+    // As casts are technically lossy but should be ok for the ranges of values we expect here
     match method {
-        SystemTimeEnum::Epoch => time.timestamp() as f64,
-        SystemTimeEnum::Second => time.second().into(),
-        SystemTimeEnum::Minute => time.minute().into(),
-        SystemTimeEnum::Hour => time.hour().into(),
-        SystemTimeEnum::DayLunar => time.day().into(),
-        SystemTimeEnum::DayOrdinal => time.ordinal().into(),
-        SystemTimeEnum::Month => time.month().into(),
-        SystemTimeEnum::Year => time.year().into(),
+        SystemTimeEnum::Epoch => time.timestamp().as_(),
+        SystemTimeEnum::Second => time.second().as_(),
+        SystemTimeEnum::Minute => time.minute().as_(),
+        SystemTimeEnum::Hour => time.hour().as_(),
+        SystemTimeEnum::DayLunar => time.day().as_(),
+        SystemTimeEnum::DayOrdinal => time.ordinal().as_(),
+        SystemTimeEnum::Month => time.month().as_(),
+        SystemTimeEnum::Year => time.year().as_(),
     }
 }
 
-impl GeneratorBlock for SystemTimeBlock {
-    type Output = f64;
+impl<O: Float> GeneratorBlock for SystemTimeBlock<O>
+where
+    i64: AsPrimitive<O>,
+    i32: AsPrimitive<O>,
+    u32: AsPrimitive<O>,
+{
+    type Output = O;
     type Parameters = Parameters;
 
     fn generate(
@@ -88,14 +102,48 @@ mod tests {
     #[test]
     fn test_get_output_value() {
         let time = Local::now();
-        let epoch = get_output_value(time, SystemTimeEnum::Epoch);
-        let second = get_output_value(time, SystemTimeEnum::Second);
-        let minute = get_output_value(time, SystemTimeEnum::Minute);
-        let hour = get_output_value(time, SystemTimeEnum::Hour);
-        let day_lunar = get_output_value(time, SystemTimeEnum::DayLunar);
-        let day_ordinal = get_output_value(time, SystemTimeEnum::DayOrdinal);
-        let month = get_output_value(time, SystemTimeEnum::Month);
-        let year = get_output_value(time, SystemTimeEnum::Year);
+        let epoch: f32 = get_output_value(time, SystemTimeEnum::Epoch);
+        assert!(epoch.is_finite());
+        let second: f32 = get_output_value(time, SystemTimeEnum::Second);
+        assert!(second.is_finite());
+        let minute: f32 = get_output_value(time, SystemTimeEnum::Minute);
+        assert!(minute.is_finite());
+        let hour: f32 = get_output_value(time, SystemTimeEnum::Hour);
+        assert!(hour.is_finite());
+        let day_lunar: f32 = get_output_value(time, SystemTimeEnum::DayLunar);
+        assert!(day_lunar.is_finite());
+        let day_ordinal: f32 = get_output_value(time, SystemTimeEnum::DayOrdinal);
+        assert!(day_ordinal.is_finite());
+        let month: f32 = get_output_value(time, SystemTimeEnum::Month);
+        assert!(month.is_finite());
+        let year: f32 = get_output_value(time, SystemTimeEnum::Year);
+        assert!(year.is_finite());
+
+        assert_eq!(epoch, time.timestamp() as f32);
+        assert_eq!(second, time.second() as f32);
+        assert_eq!(minute, time.minute() as f32);
+        assert_eq!(hour, time.hour() as f32);
+        assert_eq!(day_lunar, time.day() as f32);
+        assert_eq!(day_ordinal, time.ordinal() as f32);
+        assert_eq!(month, time.month() as f32);
+        assert_eq!(year, time.year() as f32);
+
+        let epoch: f64 = get_output_value(time, SystemTimeEnum::Epoch);
+        assert!(epoch.is_finite());
+        let second: f64 = get_output_value(time, SystemTimeEnum::Second);
+        assert!(second.is_finite());
+        let minute: f64 = get_output_value(time, SystemTimeEnum::Minute);
+        assert!(minute.is_finite());
+        let hour: f64 = get_output_value(time, SystemTimeEnum::Hour);
+        assert!(hour.is_finite());
+        let day_lunar: f64 = get_output_value(time, SystemTimeEnum::DayLunar);
+        assert!(day_lunar.is_finite());
+        let day_ordinal: f64 = get_output_value(time, SystemTimeEnum::DayOrdinal);
+        assert!(day_ordinal.is_finite());
+        let month: f64 = get_output_value(time, SystemTimeEnum::Month);
+        assert!(month.is_finite());
+        let year: f64 = get_output_value(time, SystemTimeEnum::Year);
+        assert!(year.is_finite());
 
         assert_eq!(epoch, time.timestamp() as f64);
         assert_eq!(second, time.second() as f64);
@@ -109,7 +157,7 @@ mod tests {
 
     #[test]
     fn test_system_time_default_buffer_no_panic() {
-        let block = SystemTimeBlock::default();
+        let block: SystemTimeBlock = SystemTimeBlock::default();
         assert_eq!(block.buffer(), 0.0);
     }
 

--- a/pictorus-blocks/src/std_blocks/system_time_block.rs
+++ b/pictorus-blocks/src/std_blocks/system_time_block.rs
@@ -1,51 +1,37 @@
 use chrono::{DateTime, Datelike, Local, Timelike};
-use num_traits::AsPrimitive;
 use pictorus_traits::{GeneratorBlock, PassBy};
-
-use crate::traits::Float;
 
 /// This block can be used in `std` environments to get the current system time.
 /// The time output can be in different formats, such as epoch time, second, minute, hour, day of the month, day of the year, month, or year.
-pub struct SystemTimeBlock<O: Float = f64> {
-    output: O,
+pub struct SystemTimeBlock {
+    output: f64,
     start_time: DateTime<Local>,
 }
 
-impl<O: Float> Default for SystemTimeBlock<O> {
+impl Default for SystemTimeBlock {
     fn default() -> Self {
         Self {
-            output: O::zero(),
+            output: 0.0,
             start_time: Local::now(),
         }
     }
 }
 
-fn get_output_value<O: Float>(time: DateTime<Local>, method: SystemTimeEnum) -> O
-where
-    i64: AsPrimitive<O>,
-    i32: AsPrimitive<O>,
-    u32: AsPrimitive<O>,
-{
-    // As casts are technically lossy but should be ok for the ranges of values we expect here
+fn get_output_value(time: DateTime<Local>, method: SystemTimeEnum) -> f64 {
     match method {
-        SystemTimeEnum::Epoch => time.timestamp().as_(),
-        SystemTimeEnum::Second => time.second().as_(),
-        SystemTimeEnum::Minute => time.minute().as_(),
-        SystemTimeEnum::Hour => time.hour().as_(),
-        SystemTimeEnum::DayLunar => time.day().as_(),
-        SystemTimeEnum::DayOrdinal => time.ordinal().as_(),
-        SystemTimeEnum::Month => time.month().as_(),
-        SystemTimeEnum::Year => time.year().as_(),
+        SystemTimeEnum::Epoch => time.timestamp() as f64,
+        SystemTimeEnum::Second => time.second().into(),
+        SystemTimeEnum::Minute => time.minute().into(),
+        SystemTimeEnum::Hour => time.hour().into(),
+        SystemTimeEnum::DayLunar => time.day().into(),
+        SystemTimeEnum::DayOrdinal => time.ordinal().into(),
+        SystemTimeEnum::Month => time.month().into(),
+        SystemTimeEnum::Year => time.year().into(),
     }
 }
 
-impl<O: Float> GeneratorBlock for SystemTimeBlock<O>
-where
-    i64: AsPrimitive<O>,
-    i32: AsPrimitive<O>,
-    u32: AsPrimitive<O>,
-{
-    type Output = O;
+impl GeneratorBlock for SystemTimeBlock {
+    type Output = f64;
     type Parameters = Parameters;
 
     fn generate(
@@ -102,48 +88,14 @@ mod tests {
     #[test]
     fn test_get_output_value() {
         let time = Local::now();
-        let epoch: f32 = get_output_value(time, SystemTimeEnum::Epoch);
-        assert!(epoch.is_finite());
-        let second: f32 = get_output_value(time, SystemTimeEnum::Second);
-        assert!(second.is_finite());
-        let minute: f32 = get_output_value(time, SystemTimeEnum::Minute);
-        assert!(minute.is_finite());
-        let hour: f32 = get_output_value(time, SystemTimeEnum::Hour);
-        assert!(hour.is_finite());
-        let day_lunar: f32 = get_output_value(time, SystemTimeEnum::DayLunar);
-        assert!(day_lunar.is_finite());
-        let day_ordinal: f32 = get_output_value(time, SystemTimeEnum::DayOrdinal);
-        assert!(day_ordinal.is_finite());
-        let month: f32 = get_output_value(time, SystemTimeEnum::Month);
-        assert!(month.is_finite());
-        let year: f32 = get_output_value(time, SystemTimeEnum::Year);
-        assert!(year.is_finite());
-
-        assert_eq!(epoch, time.timestamp() as f32);
-        assert_eq!(second, time.second() as f32);
-        assert_eq!(minute, time.minute() as f32);
-        assert_eq!(hour, time.hour() as f32);
-        assert_eq!(day_lunar, time.day() as f32);
-        assert_eq!(day_ordinal, time.ordinal() as f32);
-        assert_eq!(month, time.month() as f32);
-        assert_eq!(year, time.year() as f32);
-
-        let epoch: f64 = get_output_value(time, SystemTimeEnum::Epoch);
-        assert!(epoch.is_finite());
-        let second: f64 = get_output_value(time, SystemTimeEnum::Second);
-        assert!(second.is_finite());
-        let minute: f64 = get_output_value(time, SystemTimeEnum::Minute);
-        assert!(minute.is_finite());
-        let hour: f64 = get_output_value(time, SystemTimeEnum::Hour);
-        assert!(hour.is_finite());
-        let day_lunar: f64 = get_output_value(time, SystemTimeEnum::DayLunar);
-        assert!(day_lunar.is_finite());
-        let day_ordinal: f64 = get_output_value(time, SystemTimeEnum::DayOrdinal);
-        assert!(day_ordinal.is_finite());
-        let month: f64 = get_output_value(time, SystemTimeEnum::Month);
-        assert!(month.is_finite());
-        let year: f64 = get_output_value(time, SystemTimeEnum::Year);
-        assert!(year.is_finite());
+        let epoch = get_output_value(time, SystemTimeEnum::Epoch);
+        let second = get_output_value(time, SystemTimeEnum::Second);
+        let minute = get_output_value(time, SystemTimeEnum::Minute);
+        let hour = get_output_value(time, SystemTimeEnum::Hour);
+        let day_lunar = get_output_value(time, SystemTimeEnum::DayLunar);
+        let day_ordinal = get_output_value(time, SystemTimeEnum::DayOrdinal);
+        let month = get_output_value(time, SystemTimeEnum::Month);
+        let year = get_output_value(time, SystemTimeEnum::Year);
 
         assert_eq!(epoch, time.timestamp() as f64);
         assert_eq!(second, time.second() as f64);
@@ -157,7 +109,7 @@ mod tests {
 
     #[test]
     fn test_system_time_default_buffer_no_panic() {
-        let block: SystemTimeBlock = SystemTimeBlock::default();
+        let block = SystemTimeBlock::default();
         assert_eq!(block.buffer(), 0.0);
     }
 

--- a/pictorus-blocks/src/traits.rs
+++ b/pictorus-blocks/src/traits.rs
@@ -25,50 +25,120 @@ pub trait Scalar:
     /// Returns true if the scalar is truthy
     /// Truthiness is defined as not equal to zero
     fn is_truthy(&self) -> bool;
+
+    fn from_bool(value: bool) -> Self;
 }
 impl Scalar for bool {
     fn is_truthy(&self) -> bool {
         *self
+    }
+
+    fn from_bool(value: bool) -> Self {
+        value
     }
 }
 impl Scalar for u8 {
     fn is_truthy(&self) -> bool {
         *self != 0
     }
+
+    fn from_bool(value: bool) -> Self {
+        if value {
+            1
+        } else {
+            0
+        }
+    }
 }
 impl Scalar for i8 {
     fn is_truthy(&self) -> bool {
         *self != 0
+    }
+
+    fn from_bool(value: bool) -> Self {
+        if value {
+            1
+        } else {
+            0
+        }
     }
 }
 impl Scalar for u16 {
     fn is_truthy(&self) -> bool {
         *self != 0
     }
+
+    fn from_bool(value: bool) -> Self {
+        if value {
+            1
+        } else {
+            0
+        }
+    }
 }
 impl Scalar for i16 {
     fn is_truthy(&self) -> bool {
         *self != 0
+    }
+
+    fn from_bool(value: bool) -> Self {
+        if value {
+            1
+        } else {
+            0
+        }
     }
 }
 impl Scalar for u32 {
     fn is_truthy(&self) -> bool {
         *self != 0
     }
+
+    fn from_bool(value: bool) -> Self {
+        if value {
+            1
+        } else {
+            0
+        }
+    }
 }
 impl Scalar for i32 {
     fn is_truthy(&self) -> bool {
         *self != 0
+    }
+
+    fn from_bool(value: bool) -> Self {
+        if value {
+            1
+        } else {
+            0
+        }
     }
 }
 impl Scalar for f32 {
     fn is_truthy(&self) -> bool {
         *self != 0.0
     }
+
+    fn from_bool(value: bool) -> Self {
+        if value {
+            1.0
+        } else {
+            0.0
+        }
+    }
 }
 impl Scalar for f64 {
     fn is_truthy(&self) -> bool {
         *self != 0.0
+    }
+
+    fn from_bool(value: bool) -> Self {
+        if value {
+            1.0
+        } else {
+            0.0
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds `f32` for every block that was `f64` only except for blocks where it doesn't apply. This is based on past investigation of the blocks.

The only remaining blocks without `f32` support should be the following:  BytesLiteral, I2cInput, I2cOutput, SerialReceive, SpiReceive, UdpReceive, UdpTransmit, and Fmu. These all don't logically make sense to mess with since they either deal only with ByteSliceSignal signals, or for FMU `f64` is the only officially supported data type.