### PR TITLE
Flush out blocks generics for the wider set of scalars where possible

### DIFF
--- a/pictorus-blocks/src/alloc_blocks/bytes_pack_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/bytes_pack_block.rs
@@ -1,5 +1,5 @@
 use crate::byte_data::{parse_byte_data_spec, try_pack_data, ByteOrderSpec, DataType};
-use crate::traits::{Float, Scalar};
+use crate::traits::Scalar;
 use alloc::vec::Vec;
 use num_traits::AsPrimitive;
 use pictorus_traits::{ByteSliceSignal, Pass, PassBy, ProcessBlock};
@@ -61,7 +61,7 @@ pub trait AppendBytes: Scalar {
 
 impl<F> AppendBytes for F
 where
-    F: Float
+    F: Scalar
         + AsPrimitive<u8>
         + AsPrimitive<i8>
         + AsPrimitive<u16>
@@ -253,6 +253,91 @@ mod tests {
         let expected = {
             let mut expected = Vec::new();
             expected.write_i8(inputs as i8).unwrap();
+            expected
+        };
+
+        let output = block.process(&params, &context, inputs);
+        assert_eq!(output, expected.as_slice());
+        assert_eq!(block.buffer(), expected.as_slice());
+    }
+
+    #[test]
+    fn test_bytes_pack_block_1_input_u8_exact() {
+        let context = StubContext::default();
+        let params = Parameters::new(&["U8:BigEndian"]);
+        let mut block = BytesPackBlock::<u8>::default();
+
+        let output = block.process(&params, &context, 255u8);
+        assert_eq!(output, [255u8].as_slice());
+        assert_eq!(block.buffer(), [255u8].as_slice());
+    }
+
+    #[test]
+    fn test_bytes_pack_block_1_input_i16_negative() {
+        let context = StubContext::default();
+        let params = Parameters::new(&["I16:LittleEndian"]);
+        let mut block = BytesPackBlock::<i16>::default();
+
+        let expected = {
+            let mut expected = Vec::new();
+            expected
+                .write_i16::<byteorder::LittleEndian>(-12345)
+                .unwrap();
+            expected
+        };
+
+        let output = block.process(&params, &context, -12345i16);
+        assert_eq!(output, expected.as_slice());
+        assert_eq!(block.buffer(), expected.as_slice());
+    }
+
+    #[test]
+    fn test_bytes_pack_block_1_input_i64_beyond_f64_precision() {
+        // An i64 input larger than 2^53 packs exactly; routing it through an f64
+        // signal (the only option before int support) would have rounded it.
+        let context = StubContext::default();
+        let params = Parameters::new(&["I64:BigEndian"]);
+        let mut block = BytesPackBlock::<i64>::default();
+        let value = (1i64 << 53) + 1;
+
+        let expected = {
+            let mut expected = Vec::new();
+            expected.write_i64::<byteorder::BigEndian>(value).unwrap();
+            expected
+        };
+
+        let output = block.process(&params, &context, value);
+        assert_eq!(output, expected.as_slice());
+        assert_eq!(block.buffer(), expected.as_slice());
+    }
+
+    #[test]
+    fn test_bytes_pack_block_int_truncating_spec() {
+        // An input wider than its pack spec truncates with native `as` cast semantics.
+        let context = StubContext::default();
+        let params = Parameters::new(&["U8:BigEndian"]);
+        let mut block = BytesPackBlock::<u32>::default();
+
+        let output = block.process(&params, &context, 300u32);
+        assert_eq!(output, [300u32 as u8].as_slice());
+    }
+
+    #[test]
+    fn test_bytes_pack_block_mixed_input_types() {
+        let context = StubContext::default();
+        let params = Parameters::new(&["U8:BigEndian", "F32:BigEndian", "I16:LittleEndian"]);
+        let mut block = BytesPackBlock::<(u8, f32, i16)>::default();
+        let inputs = (42u8, 3.5f32, -1000i16);
+
+        let expected = {
+            let mut expected = Vec::new();
+            expected.write_u8(inputs.0).unwrap();
+            expected
+                .write_f32::<byteorder::BigEndian>(inputs.1)
+                .unwrap();
+            expected
+                .write_i16::<byteorder::LittleEndian>(inputs.2)
+                .unwrap();
             expected
         };
 

--- a/pictorus-blocks/src/alloc_blocks/bytes_pack_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/bytes_pack_block.rs
@@ -312,6 +312,26 @@ mod tests {
     }
 
     #[test]
+    fn test_bytes_pack_block_1_input_u64_beyond_f64_precision() {
+        // A u64 input larger than 2^53 (and above i64::MAX) packs exactly; routing it
+        // through an f64 signal (the only option before int support) would have rounded it.
+        let context = StubContext::default();
+        let params = Parameters::new(&["U64:BigEndian"]);
+        let mut block = BytesPackBlock::<u64>::default();
+        let value = u64::MAX - 1;
+
+        let expected = {
+            let mut expected = Vec::new();
+            expected.write_u64::<byteorder::BigEndian>(value).unwrap();
+            expected
+        };
+
+        let output = block.process(&params, &context, value);
+        assert_eq!(output, expected.as_slice());
+        assert_eq!(block.buffer(), expected.as_slice());
+    }
+
+    #[test]
     fn test_bytes_pack_block_int_truncating_spec() {
         // An input wider than its pack spec truncates with native `as` cast semantics.
         let context = StubContext::default();

--- a/pictorus-blocks/src/alloc_blocks/switch_block.rs
+++ b/pictorus-blocks/src/alloc_blocks/switch_block.rs
@@ -109,8 +109,8 @@ pub trait ApplyInto<C: Scalar, const N: usize>: Pass + DefaultStorage {
     );
 }
 
-impl<C: Scalar, const N: usize> ApplyInto<C, N> for C {
-    fn apply_into(condition: C, cases: &[C; N], inputs: &[PassBy<C>; N], dest: &mut C) {
+impl<C: Scalar, S: Scalar, const N: usize> ApplyInto<C, N> for S {
+    fn apply_into(condition: C, cases: &[C; N], inputs: &[PassBy<S>; N], dest: &mut S) {
         for (idx, case) in cases.iter().enumerate() {
             if condition == *case {
                 let res = inputs[idx];
@@ -123,14 +123,14 @@ impl<C: Scalar, const N: usize> ApplyInto<C, N> for C {
     }
 }
 
-impl<C: Scalar, const NROWS: usize, const NCOLS: usize, const N: usize> ApplyInto<C, N>
-    for Matrix<NROWS, NCOLS, C>
+impl<C: Scalar, S: Scalar, const NROWS: usize, const NCOLS: usize, const N: usize> ApplyInto<C, N>
+    for Matrix<NROWS, NCOLS, S>
 {
     fn apply_into(
         condition: C,
         cases: &[C; N],
-        inputs: &[PassBy<Matrix<NROWS, NCOLS, C>>; N],
-        dest: &mut Matrix<NROWS, NCOLS, C>,
+        inputs: &[PassBy<Matrix<NROWS, NCOLS, S>>; N],
+        dest: &mut Matrix<NROWS, NCOLS, S>,
     ) {
         for (idx, case) in cases.iter().enumerate() {
             if condition == *case {
@@ -414,6 +414,70 @@ mod tests {
         let expected: Matrix<3, 3, f64> = Matrix::from_element(2.0);
         assert_eq!(output, &expected);
         assert_eq!(block.buffer(), &expected);
+    }
+
+    #[test]
+    fn test_switch_block_bool_condition_scalars() {
+        let ctxt = StubContext::default();
+
+        let mut block = SwitchBlock::<(bool, f32, f32)>::default();
+        let parameters = Parameters::new([true, false]);
+
+        let input = (true, 1.5f32, 2.5f32);
+        let output = block.process(&parameters, &ctxt, input);
+        assert_eq!(output, 1.5);
+        assert_eq!(block.buffer(), output);
+
+        let input = (false, 1.5f32, 2.5f32);
+        let output = block.process(&parameters, &ctxt, input);
+        assert_eq!(output, 2.5);
+        assert_eq!(block.buffer(), output);
+    }
+
+    #[test]
+    fn test_switch_block_int_condition_scalars() {
+        let ctxt = StubContext::default();
+
+        let mut block = SwitchBlock::<(u8, f64, f64, f64)>::default();
+        let parameters = Parameters::new([10u8, 20u8, 30u8]);
+
+        let input = (20u8, 1.0, 2.0, 3.0);
+        let output = block.process(&parameters, &ctxt, input);
+        assert_eq!(output, 2.0);
+        assert_eq!(block.buffer(), output);
+
+        // No match falls through to the last input
+        let input = (99u8, 1.0, 2.0, 3.0);
+        let output = block.process(&parameters, &ctxt, input);
+        assert_eq!(output, 3.0);
+        assert_eq!(block.buffer(), output);
+    }
+
+    #[test]
+    fn test_switch_block_int_condition_matrices() {
+        let ctxt = StubContext::default();
+
+        let mut block = SwitchBlock::<(i32, Matrix<2, 2, f32>, Matrix<2, 2, f32>)>::default();
+        let parameters = Parameters::new([-1, 1]);
+
+        let input = (-1, &Matrix::from_element(1.0), &Matrix::from_element(2.0));
+        let output = block.process(&parameters, &ctxt, input);
+        let expected: Matrix<2, 2, f32> = Matrix::from_element(1.0);
+        assert_eq!(output, &expected);
+        assert_eq!(block.buffer(), &expected);
+    }
+
+    #[test]
+    fn test_switch_block_int_condition_bytes() {
+        let ctxt = StubContext::default();
+
+        let mut block = SwitchBlock::<(u16, ByteSliceSignal, ByteSliceSignal)>::default();
+        let parameters = Parameters::new([100u16, 200u16]);
+
+        let input = (200u16, b"foo".as_slice(), b"bar".as_slice());
+        let output = block.process(&parameters, &ctxt, input);
+        assert_eq!(output, b"bar");
+        assert_eq!(block.buffer(), b"bar".as_slice());
     }
 
     #[test]

--- a/pictorus-blocks/src/byte_data.rs
+++ b/pictorus-blocks/src/byte_data.rs
@@ -246,8 +246,7 @@ pub fn try_pack_data<T, Endian: ByteOrder>(
     data_type: DataType,
 ) -> Result<usize, ByteDataError>
 where
-    T: Float
-        + AsPrimitive<u8>
+    T: AsPrimitive<u8>
         + AsPrimitive<i8>
         + AsPrimitive<u16>
         + AsPrimitive<i16>

--- a/pictorus-blocks/src/core_blocks/abs_block.rs
+++ b/pictorus-blocks/src/core_blocks/abs_block.rs
@@ -181,15 +181,46 @@ mod tests {
     }
     test_abs_block!(f32, f64, i8, i16, i32, i64);
 
-    #[test]
-    #[should_panic]
-    fn overflow_quirk() {
-        // According to num_traits docs this should return `::MIN` for signed integers, but instead it appears to panic:
-        // https://docs.rs/num-traits/latest/num_traits/sign/trait.Signed.html#tymethod.abs
-        let mut block = AbsBlock::<i8>::default();
-        let context = StubContext::default();
+    // Two's complement signed integers represent -2^(n-1) to 2^(n-1) - 1, so |iN::MIN|
+    // exceeds iN::MAX and cannot be represented (e.g. -128 is i8::MIN but i8::MAX is 127).
+    // Every signed integer type therefore panics on abs(MIN), while abs(MAX) is always fine.
+    //
+    // Note: the num_traits docs say `Signed::abs` should return `::MIN` in this case, but it
+    // panics instead (in both debug and release, since num_traits is compiled with
+    // overflow-checks): https://docs.rs/num-traits/latest/num_traits/sign/trait.Signed.html#tymethod.abs
+    macro_rules! test_abs_signed_limits {
+        // Convenience call to generate a call to the main macro for every type in the list
+        ($type:ty, $($other_types:ty),*) => {
+            test_abs_signed_limits!($type);
+            test_abs_signed_limits!($($other_types),*);
+        };
+        ($type:ty) => {
+            paste! {
+                #[test]
+                #[should_panic]
+                fn [<overflow_quirk_min_ $type>]() {
+                    let mut block = AbsBlock::<$type>::default();
+                    let context = StubContext::default();
 
-        let output = block.process(&Parameter::new(), &context, i8::MIN);
-        assert_eq!(output, -128i8);
+                    let output = block.process(&Parameter::new(), &context, <$type>::MIN);
+                    assert_eq!(output, <$type>::MIN);
+                }
+
+                #[test]
+                fn [<abs_max_works_ $type>]() {
+                    let mut block = AbsBlock::<$type>::default();
+                    let context = StubContext::default();
+
+                    let output = block.process(&Parameter::new(), &context, <$type>::MAX);
+                    assert_eq!(output, <$type>::MAX);
+
+                    // MIN + 1 is the most negative value whose absolute value is representable
+                    let output = block.process(&Parameter::new(), &context, <$type>::MIN + 1);
+                    assert_eq!(output, <$type>::MAX);
+                }
+            }
+        };
     }
+
+    test_abs_signed_limits!(i8, i16, i32, i64);
 }

--- a/pictorus-blocks/src/core_blocks/abs_block.rs
+++ b/pictorus-blocks/src/core_blocks/abs_block.rs
@@ -1,6 +1,6 @@
-use crate::matrix_ext::MatrixNalgebraExt;
-use num_traits::Float;
-use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
+use crate::traits::Scalar;
+use num_traits::Signed;
+use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 pub struct Parameter {}
 
@@ -32,61 +32,56 @@ where
     }
 }
 
-macro_rules! impl_abs_block {
-    ($type:ty) => {
-        impl ProcessBlock for AbsBlock<$type>
-        where
-            $type: Scalar,
-        {
-            type Inputs = $type;
-            type Output = $type;
-            type Parameters = Parameter;
+impl<T: Scalar + Signed> ProcessBlock for AbsBlock<T> {
+    type Inputs = T;
+    type Output = T;
+    type Parameters = Parameter;
 
-            fn process<'b>(
-                &'b mut self,
-                _parameters: &Self::Parameters,
-                _context: &dyn pictorus_traits::Context,
-                inputs: pictorus_traits::PassBy<'_, Self::Inputs>,
-            ) -> pictorus_traits::PassBy<'b, Self::Output> {
-                let output = Float::abs(inputs);
-                self.buffer = output;
-                output
-            }
+    fn process<'b>(
+        &'b mut self,
+        _parameters: &Self::Parameters,
+        _context: &dyn pictorus_traits::Context,
+        inputs: PassBy<'_, Self::Inputs>,
+    ) -> PassBy<'b, Self::Output> {
+        let output = Signed::abs(&inputs);
+        self.buffer = output;
+        output
+    }
 
-            fn buffer(&self) -> PassBy<'_, Self::Output> {
-                self.buffer.as_by()
-            }
-        }
-
-        impl<const ROWS: usize, const COLS: usize> ProcessBlock
-            for AbsBlock<Matrix<ROWS, COLS, $type>>
-        where
-            $type: Scalar,
-        {
-            type Inputs = Matrix<ROWS, COLS, $type>;
-            type Output = Matrix<ROWS, COLS, $type>;
-            type Parameters = Parameter;
-
-            fn process(
-                &mut self,
-                _parameters: &Self::Parameters,
-                _context: &dyn pictorus_traits::Context,
-                input: PassBy<Self::Inputs>,
-            ) -> PassBy<'_, Self::Output> {
-                let abs = input.as_view().abs();
-                self.buffer = Matrix::<ROWS, COLS, $type>::from_view(&abs.as_view());
-                &self.buffer
-            }
-
-            fn buffer(&self) -> PassBy<'_, Self::Output> {
-                self.buffer.as_by()
-            }
-        }
-    };
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
 
-impl_abs_block!(f32);
-impl_abs_block!(f64);
+impl<const ROWS: usize, const COLS: usize, T: Scalar + Signed> ProcessBlock
+    for AbsBlock<Matrix<ROWS, COLS, T>>
+{
+    type Inputs = Matrix<ROWS, COLS, T>;
+    type Output = Matrix<ROWS, COLS, T>;
+    type Parameters = Parameter;
+
+    fn process(
+        &mut self,
+        _parameters: &Self::Parameters,
+        _context: &dyn pictorus_traits::Context,
+        input: PassBy<Self::Inputs>,
+    ) -> PassBy<'_, Self::Output> {
+        for (elem, &val) in self
+            .buffer
+            .data
+            .as_flattened_mut()
+            .iter_mut()
+            .zip(input.data.as_flattened().iter())
+        {
+            *elem = val.abs();
+        }
+        &self.buffer
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -96,10 +91,16 @@ mod tests {
     use paste::paste;
 
     macro_rules! test_abs_block {
-        ($name:ident, $type:ty) => {
+        ( $type:ty, $($other_types:ty),* ) => {
+            test_abs_block!($type);
+            $(
+                test_abs_block!($other_types);
+            )*
+        };
+        ( $type:ty) => {
             paste! {
                 #[test]
-                fn [<test_abs_block_default_buffer_ $name>]() {
+                fn [<test_abs_block_default_buffer_ $type>]() {
                     let block = AbsBlock::<$type>::default();
                     assert_eq!(block.buffer(), <$type>::default());
 
@@ -108,7 +109,7 @@ mod tests {
                 }
 
                 #[test]
-                fn [<test_abs_block_scalar_ $name>]()
+                fn [<test_abs_block_scalar_ $type>]()
                 {
                     let mut block = AbsBlock::<$type>::default();
                     let context = StubContext::default();
@@ -123,7 +124,7 @@ mod tests {
                 }
 
                 #[test]
-                fn [<test_abs_block_vector_1x2_ $name>]() {
+                fn [<test_abs_block_vector_1x2_ $type>]() {
                     let mut block = AbsBlock::<Matrix<1, 2, $type>>::default();
                     let context = StubContext::default();
                     let input = Matrix {
@@ -139,7 +140,7 @@ mod tests {
                 }
 
                 #[test]
-                fn [<test_abs_block_vector_2x1_ $name>]() {
+                fn [<test_abs_block_vector_2x1_ $type>]() {
                     let mut block = AbsBlock::<Matrix<2, 1, $type>>::default();
                     let context = StubContext::default();
                     let input = Matrix {
@@ -155,7 +156,7 @@ mod tests {
                 }
 
                 #[test]
-                fn [<test_abs_block_matrix_ $name>]() {
+                fn [<test_abs_block_matrix_ $type>]() {
                     let mut block = AbsBlock::<Matrix<2, 2, $type>>::default();
                     let context = StubContext::default();
                     let input = Matrix {
@@ -178,7 +179,17 @@ mod tests {
             }
         };
     }
+    test_abs_block!(f32, f64, i8, i16, i32, i64);
 
-    test_abs_block!(f32, f32);
-    test_abs_block!(f64, f64);
+    #[test]
+    #[should_panic]
+    fn overflow_quirk() {
+        // According to num_traits docs this should return `::MIN` for signed integers, but instead it appears to panic:
+        // https://docs.rs/num-traits/latest/num_traits/sign/trait.Signed.html#tymethod.abs
+        let mut block = AbsBlock::<i8>::default();
+        let context = StubContext::default();
+
+        let output = block.process(&Parameter::new(), &context, i8::MIN);
+        assert_eq!(output, -128i8);
+    }
 }

--- a/pictorus-blocks/src/core_blocks/aggregate_block.rs
+++ b/pictorus-blocks/src/core_blocks/aggregate_block.rs
@@ -1,5 +1,6 @@
-use crate::matrix_ext::MatrixNalgebraExt;
-use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
+use crate::traits::Scalar;
+use num_traits::AsPrimitive;
+use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Block for performing an aggregation operation (i.e. sum, min, max) on input data.
 pub struct AggregateBlock<T: Apply> {
@@ -50,70 +51,66 @@ pub trait Apply: Pass {
     ) -> PassBy<'s, Self::Output>;
 }
 
-macro_rules! scalar_impls {
-    () => {};
-    ($type:ty, $($rest:tt),+) => {
-        scalar_impls!($type);
-        scalar_impls!($($rest),+);
-    };
-    ($type:ty) => {
-        impl Apply for $type {
-            type Output = $type;
+impl<T: Scalar> Apply for T {
+    type Output = T;
 
-            fn apply<'s>(
-                store: &mut Self::Output,
-                input: PassBy<Self>,
-                _method: AggregateMethod,
-            ) -> PassBy<'s, Self::Output> {
-                *store = input;
-                input
-            }
-        }
-    };
-}
-scalar_impls!(f64, f32); // We could also just easily add u8, u16 and bool here but they wouldn't have equivalent matrix impls
-
-macro_rules! float_matrix_impl {
-    ($type:ty) => {
-        impl<const NROWS: usize, const NCOLS: usize> Apply for Matrix<NROWS, NCOLS, $type> {
-            type Output = $type;
-
-            fn apply<'s>(
-                store: &mut Self::Output,
-                input: PassBy<Self>,
-                method: AggregateMethod,
-            ) -> PassBy<'s, Self::Output> {
-                let view = input.as_view();
-                let output = match method {
-                    AggregateMethod::Sum => view.sum(),
-                    AggregateMethod::Mean => view.mean(),
-                    AggregateMethod::Median => {
-                        // Have to copy the data to the stack so we can sort it
-                        let mut data = *input;
-                        let data = data.data.as_flattened_mut();
-                        view.iter().enumerate().for_each(|(i, &x)| data[i] = x);
-                        data.sort_unstable_by(|a, b| {
-                            a.partial_cmp(b).expect("NaNs are not supported")
-                        });
-                        let mid = data.len() / 2;
-                        if data.len() % 2 == 0 {
-                            (data[mid - 1] + data[mid]) / Self::Output::from(2u8)
-                        } else {
-                            data[mid]
-                        }
-                    }
-                    AggregateMethod::Min => view.min(),
-                    AggregateMethod::Max => view.max(),
-                };
-                *store = output;
-                output
-            }
-        }
-    };
+    fn apply<'s>(
+        store: &mut Self::Output,
+        input: PassBy<Self>,
+        _method: AggregateMethod,
+    ) -> PassBy<'s, Self::Output> {
+        *store = input;
+        input
+    }
 }
 
-float_matrix_impl!(f64);
-float_matrix_impl!(f32);
+impl<const NROWS: usize, const NCOLS: usize, T: Scalar + num_traits::Num + num_traits::Bounded>
+    Apply for Matrix<NROWS, NCOLS, T>
+where
+    usize: AsPrimitive<T>,
+    Matrix<NROWS, NCOLS, T>: Copy,
+{
+    type Output = T;
+
+    fn apply<'s>(
+        store: &mut Self::Output,
+        input: PassBy<Self>,
+        method: AggregateMethod,
+    ) -> PassBy<'s, Self::Output> {
+        let elems = input.data.as_flattened();
+        let elems_len = elems.len();
+        *store = match method {
+            AggregateMethod::Sum => elems.iter().fold(T::default(), |acc, x| acc + *x),
+            AggregateMethod::Mean => {
+                elems.iter().fold(T::default(), |acc, x| acc + *x) / elems_len.as_()
+            }
+            AggregateMethod::Max => {
+                elems
+                    .iter()
+                    .fold(T::min_value(), |acc, x| if *x > acc { *x } else { acc })
+            }
+            AggregateMethod::Min => {
+                elems
+                    .iter()
+                    .fold(T::max_value(), |acc, x| if *x < acc { *x } else { acc })
+            }
+            AggregateMethod::Median => {
+                let mut sorted = *input;
+                let sorted = sorted.data.as_flattened_mut();
+                sorted.sort_unstable_by(|a, b| {
+                    a.partial_cmp(b).expect("NaNs and INFs are not supported")
+                });
+                let mid = sorted.len() / 2;
+                if sorted.len() % 2 == 0 {
+                    (sorted[mid - 1] + sorted[mid]) / (T::one() + T::one())
+                } else {
+                    sorted[mid]
+                }
+            }
+        };
+        *store
+    }
+}
 
 /// Represents the method of aggregation to be performed.
 #[derive(Debug, Clone, Copy, PartialEq, strum::EnumString)]
@@ -148,6 +145,22 @@ mod tests {
     use alloc::str::FromStr;
     use approx::assert_relative_eq;
 
+    const PARAM_MEDIAN: Parameters = Parameters {
+        method: AggregateMethod::Median,
+    };
+    const PARAM_MIN: Parameters = Parameters {
+        method: AggregateMethod::Min,
+    };
+    const PARAM_MAX: Parameters = Parameters {
+        method: AggregateMethod::Max,
+    };
+    const PARAM_SUM: Parameters = Parameters {
+        method: AggregateMethod::Sum,
+    };
+    const PARAM_MEAN: Parameters = Parameters {
+        method: AggregateMethod::Mean,
+    };
+
     #[test]
     fn test_aggregate_default_buffer_no_panic() {
         let block = AggregateBlock::<Matrix<4, 7, f64>>::default();
@@ -158,13 +171,10 @@ mod tests {
     fn test_aggregate_sum_f32() {
         let mut block = AggregateBlock::<Matrix<4, 7, f32>>::default();
         let context = StubContext::default();
-        let params = Parameters {
-            method: AggregateMethod::Sum,
-        };
         let input: Matrix<4, 7, f32> = Matrix {
             data: [[1.0; 4]; 7],
         };
-        let output = block.process(&params, &context, &input);
+        let output = block.process(&PARAM_SUM, &context, &input);
         assert_relative_eq!(output, 28.0);
         assert_relative_eq!(block.buffer(), output);
     }
@@ -173,13 +183,10 @@ mod tests {
     fn test_aggregate_sum_f64() {
         let mut block = AggregateBlock::<Matrix<4, 7, f64>>::default();
         let context = StubContext::default();
-        let params = Parameters {
-            method: AggregateMethod::Sum,
-        };
         let input: Matrix<4, 7, f64> = Matrix {
             data: [[1.0; 4]; 7],
         };
-        let output = block.process(&params, &context, &input);
+        let output = block.process(&PARAM_SUM, &context, &input);
         assert_relative_eq!(output, 28.0);
         assert_relative_eq!(block.buffer(), output);
     }
@@ -188,14 +195,11 @@ mod tests {
     fn test_aggregate_max_f64() {
         let mut block = AggregateBlock::<Matrix<4, 7, f64>>::default();
         let context = StubContext::default();
-        let params = Parameters {
-            method: AggregateMethod::Max,
-        };
         let mut input: Matrix<4, 7, f64> = Matrix {
             data: [[1.0; 4]; 7],
         };
         input.data[5][3] = 42.0;
-        let output = block.process(&params, &context, &input);
+        let output = block.process(&PARAM_MAX, &context, &input);
         assert_relative_eq!(output, 42.0);
         assert_relative_eq!(block.buffer(), output);
     }
@@ -204,14 +208,11 @@ mod tests {
     fn test_aggregate_min_f64() {
         let mut block = AggregateBlock::<Matrix<4, 7, f64>>::default();
         let context = StubContext::default();
-        let params = Parameters {
-            method: AggregateMethod::Min,
-        };
         let mut input: Matrix<4, 7, f64> = Matrix {
             data: [[11.0; 4]; 7],
         };
         input.data[1][2] = 10.99;
-        let output = block.process(&params, &context, &input);
+        let output = block.process(&PARAM_MIN, &context, &input);
         assert_relative_eq!(output, 10.99);
         assert_relative_eq!(block.buffer(), output);
     }
@@ -220,15 +221,12 @@ mod tests {
     fn test_aggregate_mean_f64() {
         let mut block = AggregateBlock::<Matrix<4, 7, f64>>::default();
         let context = StubContext::default();
-        let params = Parameters {
-            method: AggregateMethod::Mean,
-        };
         let mut input: Matrix<4, 7, f64> = Matrix::zeroed();
         for (idx, elem) in input.data.as_flattened_mut().iter_mut().enumerate() {
             *elem = idx as f64;
         }
 
-        let output = block.process(&params, &context, &input);
+        let output = block.process(&PARAM_MEAN, &context, &input);
         assert_relative_eq!(output, 13.5);
         assert_relative_eq!(block.buffer(), output);
     }
@@ -237,17 +235,73 @@ mod tests {
     fn test_aggregate_median_f64() {
         let mut block = AggregateBlock::<Matrix<4, 7, f64>>::default();
         let context = StubContext::default();
-        let params = Parameters {
-            method: AggregateMethod::Median,
-        };
         let mut input: Matrix<4, 7, f64> = Matrix::zeroed();
         for (idx, elem) in input.data.as_flattened_mut().iter_mut().enumerate() {
             *elem = idx as f64;
         }
 
-        let output = block.process(&params, &context, &input);
+        let output = block.process(&PARAM_MEDIAN, &context, &input);
         assert_relative_eq!(output, 13.5);
         assert_relative_eq!(block.buffer(), output);
+    }
+
+    #[test]
+    fn test_smattering_of_types() {
+        let context = StubContext::default();
+
+        let mut block = AggregateBlock::<Matrix<2, 2, u8>>::default();
+        let input = Matrix {
+            data: [[1, 2], [3, 4]],
+        };
+        let output = block.process(&PARAM_MEDIAN, &context, &input);
+        assert_eq!(output, 2);
+        let output = block.process(&PARAM_MEAN, &context, &input);
+        assert_eq!(output, 2);
+
+        let mut block = AggregateBlock::<Matrix<2, 2, i32>>::default();
+        let input = Matrix {
+            data: [[-34, 200], [31, 4]],
+        };
+        let output = block.process(&PARAM_MIN, &context, &input);
+        assert_eq!(output, -34);
+
+        let mut block = AggregateBlock::<Matrix<2, 2, i8>>::default();
+        let input = Matrix {
+            data: [[-34, 127], [31, 4]],
+        };
+        let output = block.process(&PARAM_MAX, &context, &input);
+        assert_eq!(output, 127);
+
+        let mut block = AggregateBlock::<Matrix<2, 2, u32>>::default();
+        let input = Matrix {
+            data: [[34, 127], [31, 4]],
+        };
+        let output = block.process(&PARAM_SUM, &context, &input);
+        assert_eq!(output, 196);
+    }
+
+    #[test]
+    #[should_panic]
+    fn overflow_in_add_panics() {
+        let mut block = AggregateBlock::<Matrix<2, 2, u8>>::default();
+        let input = Matrix {
+            data: [[34, 127], [128, 4]],
+        };
+        let context = StubContext::default();
+        let output = block.process(&PARAM_SUM, &context, &input);
+        assert_eq!(output, 196);
+    }
+
+    #[test]
+    #[should_panic]
+    fn overflow_in_mean_panics() {
+        let mut block = AggregateBlock::<Matrix<2, 2, u8>>::default();
+        let input = Matrix {
+            data: [[34, 127], [128, 4]],
+        };
+        let context = StubContext::default();
+        let output = block.process(&PARAM_MEAN, &context, &input);
+        assert_eq!(output, 196);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/aggregate_block.rs
+++ b/pictorus-blocks/src/core_blocks/aggregate_block.rs
@@ -96,9 +96,8 @@ where
             }
             AggregateMethod::Median => {
                 let mut sorted = *input;
-                let sorted = sorted.data.as_flattened_mut();
                 sorted.sort_unstable_by(|a, b| {
-                    a.partial_cmp(b).expect("NaNs and INFs are not supported")
+                    a.partial_cmp(b).expect("NaNs are not supported")
                 });
                 let mid = sorted.len() / 2;
                 if sorted.len() % 2 == 0 {

--- a/pictorus-blocks/src/core_blocks/aggregate_block.rs
+++ b/pictorus-blocks/src/core_blocks/aggregate_block.rs
@@ -96,9 +96,8 @@ where
             }
             AggregateMethod::Median => {
                 let mut sorted = *input;
-                sorted.sort_unstable_by(|a, b| {
-                    a.partial_cmp(b).expect("NaNs are not supported")
-                });
+                let sorted = sorted.data.as_flattened_mut();
+                sorted.sort_unstable_by(|a, b| a.partial_cmp(b).expect("NaNs are not supported"));
                 let mid = sorted.len() / 2;
                 if sorted.len() % 2 == 0 {
                     (sorted[mid - 1] + sorted[mid]) / (T::one() + T::one())

--- a/pictorus-blocks/src/core_blocks/arg_min_max_block.rs
+++ b/pictorus-blocks/src/core_blocks/arg_min_max_block.rs
@@ -61,14 +61,7 @@ pub trait Apply: Pass {
 }
 
 trait ArgMinMaxScalar: Scalar + PartialOrd + Zero + FromPrimitive {}
-impl ArgMinMaxScalar for f32 {}
-impl ArgMinMaxScalar for f64 {}
-impl ArgMinMaxScalar for i8 {}
-impl ArgMinMaxScalar for i16 {}
-impl ArgMinMaxScalar for i32 {}
-impl ArgMinMaxScalar for u8 {}
-impl ArgMinMaxScalar for u16 {}
-impl ArgMinMaxScalar for u32 {}
+impl<S> ArgMinMaxScalar for S where S: crate::traits::Scalar + Zero + FromPrimitive {}
 
 impl<T: ArgMinMaxScalar> Apply for T {
     type Output = T;
@@ -140,6 +133,7 @@ impl Parameters {
 mod tests {
     use super::*;
     use crate::testing::StubContext;
+    use paste::paste;
 
     #[test]
     fn test_default_buffer_no_panic() {
@@ -186,4 +180,53 @@ mod tests {
         assert_eq!(output, 1.0);
         assert_eq!(block.buffer(), output);
     }
+
+    macro_rules! test_arg_min_max {
+        // Convenience call to generate a call to the main macro for every type in the list
+        ($type:ty, $($other_types:ty),*) => {
+            test_arg_min_max!($type);
+            test_arg_min_max!($($other_types),*);
+        };
+        ($type:ty) => {
+            paste! {
+                #[test]
+                fn [<test_arg_min_max_scalar_ $type>]() {
+                    let mut block = ArgMinMaxBlock::<$type>::default();
+                    let context = StubContext::default();
+                    let params = Parameters::new("Min");
+                    // A scalar input always yields index 0
+                    let output = block.process(&params, &context, 7 as $type);
+                    assert_eq!(output, 0 as $type);
+                    assert_eq!(block.buffer(), output);
+                }
+
+                #[test]
+                fn [<test_arg_min_max_matrix_ $type>]() {
+                    let context = StubContext::default();
+                    let mut block = ArgMinMaxBlock::<Matrix<2, 3, $type>>::default();
+                    // | 11  13  15 |
+                    // | 12   4  16 |
+                    // Min is 4 at linear index 3, max is 16 at linear index 5
+                    let input = Matrix {
+                        data: [
+                            [11 as $type, 12 as $type],
+                            [13 as $type, 4 as $type],
+                            [15 as $type, 16 as $type],
+                        ],
+                    };
+                    let params = Parameters::new("Min");
+                    let output = block.process(&params, &context, &input);
+                    assert_eq!(output, 3 as $type);
+                    assert_eq!(block.buffer(), output);
+
+                    let params = Parameters::new("Max");
+                    let output = block.process(&params, &context, &input);
+                    assert_eq!(output, 5 as $type);
+                    assert_eq!(block.buffer(), output);
+                }
+            }
+        };
+    }
+
+    test_arg_min_max!(f32, f64, i8, i16, i32, i64, u8, u16, u32, u64);
 }

--- a/pictorus-blocks/src/core_blocks/bias_block.rs
+++ b/pictorus-blocks/src/core_blocks/bias_block.rs
@@ -1,34 +1,33 @@
-use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Promote, Promotion, Scalar};
+use crate::traits::Scalar;
+use core::ops::Add;
+use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Outputs the input data with an added bias (offset).
-pub struct BiasBlock<B, T>
+pub struct BiasBlock<T>
 where
-    B: Scalar,
-    T: Apply<B>,
+    T: Apply,
 {
-    buffer: T::Output,
+    buffer: T,
 }
 
-impl<B, T> Default for BiasBlock<B, T>
+impl<T> Default for BiasBlock<T>
 where
-    B: Scalar,
-    T: Apply<B> + Default,
+    T: Apply,
 {
     fn default() -> Self {
         Self {
-            buffer: <T::Output>::default(),
+            buffer: T::default(),
         }
     }
 }
 
-impl<B, T> ProcessBlock for BiasBlock<B, T>
+impl<T> ProcessBlock for BiasBlock<T>
 where
-    B: Scalar,
-    T: Apply<B> + Default,
+    T: Apply,
 {
     type Inputs = T;
-    type Output = T::Output;
-    type Parameters = Parameters<B>;
+    type Output = T;
+    type Parameters = Parameters<T::Offset>;
 
     fn process(
         &mut self,
@@ -36,8 +35,7 @@ where
         _context: &dyn pictorus_traits::Context,
         input: PassBy<Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
-        let output = T::apply(&mut self.buffer, input, parameters.offset);
-        output
+        T::apply(&mut self.buffer, input, parameters.offset)
     }
 
     fn buffer(&self) -> PassBy<'_, Self::Output> {
@@ -45,69 +43,45 @@ where
     }
 }
 
-pub trait Apply<B: Scalar>: Pass {
-    type Output: Pass + Default;
+pub trait Apply: Pass + Default {
+    /// The scalar type of the offset parameter. Matches the element type for
+    /// matrix signals and the signal type itself for scalar signals.
+    type Offset: Scalar;
 
     fn apply<'s>(
-        store: &'s mut Self::Output,
+        store: &'s mut Self,
         input: PassBy<Self>,
-        offset: B,
-    ) -> PassBy<'s, Self::Output>;
+        offset: Self::Offset,
+    ) -> PassBy<'s, Self>;
 }
 
-impl<B> Apply<B> for f64
+impl<S> Apply for S
 where
-    B: Promote<f64> + Scalar,
+    S: Scalar + Add<Output = S>,
 {
-    type Output = Promotion<B, f64>;
+    type Offset = S;
 
-    fn apply<'s>(
-        store: &'s mut Self::Output,
-        input: PassBy<Self>,
-        offset: B,
-    ) -> PassBy<'s, Self::Output> {
-        let output =
-            <B as Promote<f64>>::promote_left(offset) + <B as Promote<f64>>::promote_right(input);
+    fn apply<'s>(store: &'s mut Self, input: PassBy<Self>, offset: S) -> PassBy<'s, Self> {
+        let output = input + offset;
         *store = output;
         output
     }
 }
 
-impl<B> Apply<B> for f32
+impl<const NROWS: usize, const NCOLS: usize, S> Apply for Matrix<NROWS, NCOLS, S>
 where
-    B: Promote<f32> + Scalar,
+    S: Scalar + Apply<Offset = S>,
 {
-    type Output = Promotion<B, f32>;
+    type Offset = S;
 
-    fn apply<'s>(
-        store: &'s mut Self::Output,
-        input: PassBy<Self>,
-        offset: B,
-    ) -> PassBy<'s, Self::Output> {
-        let output =
-            <B as Promote<f32>>::promote_left(offset) + <B as Promote<f32>>::promote_right(input);
-        *store = output;
-        output
-    }
-}
-
-impl<const NROWS: usize, const NCOLS: usize, B, T> Apply<B> for Matrix<NROWS, NCOLS, T>
-where
-    T: Scalar,
-    B: Promote<T>,
-{
-    type Output = Matrix<NROWS, NCOLS, Promotion<B, T>>;
-
-    fn apply<'s>(
-        store: &'s mut Self::Output,
-        input: PassBy<Self>,
-        offset: B,
-    ) -> PassBy<'s, Self::Output> {
-        for i in 0..NROWS {
-            for j in 0..NCOLS {
-                store.data[j][i] = <B as Promote<T>>::promote_left(offset)
-                    + <B as Promote<T>>::promote_right(input.data[j][i]);
-            }
+    fn apply<'s>(store: &'s mut Self, input: PassBy<Self>, offset: S) -> PassBy<'s, Self> {
+        for (elem, &val) in store
+            .data
+            .as_flattened_mut()
+            .iter_mut()
+            .zip(input.data.as_flattened().iter())
+        {
+            S::apply(elem, val, offset);
         }
         store
     }
@@ -134,30 +108,20 @@ mod tests {
     use super::*;
     use crate::testing::StubContext;
     use approx::assert_relative_eq;
+    use paste::paste;
 
     #[test]
     fn test_bias_default_buffer_no_panic() {
-        let block = BiasBlock::<f64, f64>::default();
+        let block = BiasBlock::<f64>::default();
         assert_eq!(block.buffer(), 0.0);
 
-        let block = BiasBlock::<f64, Matrix<2, 2, f64>>::default();
+        let block = BiasBlock::<Matrix<2, 2, f64>>::default();
         assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
     }
 
     #[test]
-    fn test_bias_scalar() {
-        let mut block = BiasBlock::<f64, f64>::default();
-        let parameters = Parameters::new(3.0);
-        let context = StubContext::default();
-
-        let output = block.process(&parameters, &context, 2.0);
-        assert_eq!(output, 5.0);
-        assert_eq!(block.buffer(), output);
-    }
-
-    #[test]
     fn test_bias_scalar_to_pass() {
-        let mut block = BiasBlock::<f64, f64>::default();
+        let mut block = BiasBlock::<f64>::default();
         let parameters = Parameters::new(3.0);
         let context = StubContext::default();
 
@@ -166,29 +130,56 @@ mod tests {
         assert_relative_eq!(block.buffer(), -0.1);
     }
 
-    #[test]
-    fn test_bias_matrix() {
-        let mut block = BiasBlock::<f64, Matrix<2, 2, f64>>::default();
-        let context = StubContext::default();
-        let input = Matrix {
-            data: [[1.0, 2.0], [3.0, 4.0]],
+    macro_rules! test_bias_block {
+        // Convenience call to generate a call to the main macro for every type in the list
+        ($type:ty, $($other_types:ty),*) => {
+            test_bias_block!($type);
+            test_bias_block!($($other_types),*);
         };
-        let parameters = Parameters::new(2.0);
-        let output = block.process(&parameters, &context, &input);
-        assert_eq!(output.data, [[3.0, 4.0], [5.0, 6.0]]);
-        assert_eq!(block.buffer().data, [[3.0, 4.0], [5.0, 6.0]]);
+        ($type:ty) => {
+            paste! {
+                #[test]
+                fn [<test_bias_scalar_ $type>]() {
+                    let mut block = BiasBlock::<$type>::default();
+                    let parameters = Parameters::new(3 as $type);
+                    let context = StubContext::default();
+
+                    let output = block.process(&parameters, &context, 2 as $type);
+                    assert_eq!(output, 5 as $type);
+                    assert_eq!(block.buffer(), output);
+                }
+
+                #[test]
+                fn [<test_bias_matrix_ $type>]() {
+                    let mut block = BiasBlock::<Matrix<2, 2, $type>>::default();
+                    let context = StubContext::default();
+                    let input = Matrix {
+                        data: [[1 as $type, 2 as $type], [3 as $type, 4 as $type]],
+                    };
+                    let parameters = Parameters::new(2 as $type);
+                    let output = block.process(&parameters, &context, &input);
+                    let expected = [
+                        [3 as $type, 4 as $type],
+                        [5 as $type, 6 as $type],
+                    ];
+                    assert_eq!(output.data, expected);
+                    assert_eq!(block.buffer().data, expected);
+                }
+            }
+        };
     }
 
+    test_bias_block!(f32, f64, i8, i16, i32, i64, u8, u16, u32, u64);
+
     #[test]
-    fn test_bias_matrix_to_pass() {
-        let mut block = BiasBlock::<f64, Matrix<2, 2, f64>>::default();
+    #[should_panic]
+    fn overflow_panics() {
+        // Native integer addition overflow panics in debug builds (wraps in release).
+        let mut block = BiasBlock::<u8>::default();
+        let parameters = Parameters::new(1u8);
         let context = StubContext::default();
-        let input = Matrix {
-            data: [[1.0, 2.0], [3.0, 4.0]],
-        };
-        let parameters = Parameters::new(2.0);
-        let output = block.process(&parameters, &context, &input);
-        assert_eq!(output.data, [[3.0, 4.0], [5.0, 6.0]]);
-        assert_eq!(block.buffer().data, [[3.0, 4.0], [5.0, 6.0]]);
+
+        let output = block.process(&parameters, &context, u8::MAX);
+        assert_eq!(output, u8::MIN);
     }
 }

--- a/pictorus-blocks/src/core_blocks/bias_block.rs
+++ b/pictorus-blocks/src/core_blocks/bias_block.rs
@@ -3,6 +3,9 @@ use core::ops::Add;
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Outputs the input data with an added bias (offset).
+///
+/// The offset parameter is the same type as the input signal (the element type for
+/// matrix signals). To apply an offset of a different type, cast the input signal first.
 pub struct BiasBlock<T>
 where
     T: Apply,
@@ -181,5 +184,18 @@ mod tests {
 
         let output = block.process(&parameters, &context, u8::MAX);
         assert_eq!(output, u8::MIN);
+    }
+
+    #[test]
+    #[should_panic]
+    fn negative_overflow_panics() {
+        // -100 + -100 = -200 underflows i8::MIN; native integer addition panics in
+        // debug builds (wraps in release).
+        let mut block = BiasBlock::<i8>::default();
+        let parameters = Parameters::new(-100i8);
+        let context = StubContext::default();
+
+        let output = block.process(&parameters, &context, -100i8);
+        assert_eq!(output, 56);
     }
 }

--- a/pictorus-blocks/src/core_blocks/bit_shift_block.rs
+++ b/pictorus-blocks/src/core_blocks/bit_shift_block.rs
@@ -214,4 +214,29 @@ mod tests {
     }
 
     test_bit_shift!(f64, f32, i8, i16, i32, i64, u8, u16, u32, u64);
+
+    #[test]
+    #[should_panic]
+    fn shift_amount_exceeds_width_panics() {
+        // Shifting by an amount >= the type's bit width panics in debug builds
+        // (the shift amount wraps in release).
+        let mut block = BitShiftBlock::<u8>::default();
+        let context = StubContext::default();
+        let params = Parameters::new("Left", 8);
+        let output = block.process(&params, &context, 1u8);
+        assert_eq!(output, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn float_shift_amount_exceeds_cast_width_panics() {
+        // Floats shift through a cast to i32 (f32) / i64 (f64), so the panic threshold
+        // is the *cast* integer type's bit width — 32 for f32 — not anything about the
+        // float itself. Panics in debug builds, wraps in release.
+        let mut block = BitShiftBlock::<f32>::default();
+        let context = StubContext::default();
+        let params = Parameters::new("Left", 32);
+        let output = block.process(&params, &context, 1.0f32);
+        assert_eq!(output, 0.0);
+    }
 }

--- a/pictorus-blocks/src/core_blocks/bit_shift_block.rs
+++ b/pictorus-blocks/src/core_blocks/bit_shift_block.rs
@@ -1,5 +1,5 @@
 use num_traits::NumCast;
-use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
+use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
 
 /// Shifts the bits of the input by a specified number of positions to the left or right.
 ///
@@ -8,7 +8,7 @@ pub struct BitShiftBlock<T>
 where
     T: Apply,
 {
-    buffer: T::Output,
+    buffer: T,
 }
 
 impl<T> Default for BitShiftBlock<T>
@@ -17,7 +17,7 @@ where
 {
     fn default() -> Self {
         Self {
-            buffer: T::Output::default(),
+            buffer: T::default(),
         }
     }
 }
@@ -49,7 +49,7 @@ where
     T: Apply,
 {
     type Inputs = T;
-    type Output = T::Output;
+    type Output = T;
     type Parameters = Parameters;
 
     fn process(
@@ -67,26 +67,35 @@ where
     }
 }
 
-pub trait Apply: Pass {
-    type Output: Pass + Default;
-
-    fn apply<'s>(
-        store: &'s mut Self::Output,
-        input: PassBy<Self>,
-        params: &Parameters,
-    ) -> PassBy<'s, Self::Output>;
+pub trait Apply: Pass + Default {
+    fn apply<'s>(store: &'s mut Self, input: PassBy<Self>, params: &Parameters)
+        -> PassBy<'s, Self>;
 }
 
 macro_rules! impl_bit_shift_apply {
-    ($type:ty, $cast_type:ty) => {
+    ($type:ty) => {
         impl Apply for $type {
-            type Output = $type;
-
             fn apply<'s>(
-                store: &'s mut Self::Output,
+                store: &'s mut Self,
                 input: PassBy<Self>,
                 params: &Parameters,
-            ) -> PassBy<'s, Self::Output> {
+            ) -> PassBy<'s, Self> {
+                let output = match params.direction {
+                    ShiftDirection::Left => input << params.bits,
+                    ShiftDirection::Right => input >> params.bits,
+                };
+                *store = output;
+                output
+            }
+        }
+    };
+    ($type:ty, $cast_type:ty) => {
+        impl Apply for $type {
+            fn apply<'s>(
+                store: &'s mut Self,
+                input: PassBy<Self>,
+                params: &Parameters,
+            ) -> PassBy<'s, Self> {
                 let input = input as $cast_type;
                 let output = match params.direction {
                     ShiftDirection::Left => input << params.bits,
@@ -96,36 +105,38 @@ macro_rules! impl_bit_shift_apply {
                 output
             }
         }
-
-        impl<const NROWS: usize, const NCOLS: usize> Apply for Matrix<NROWS, NCOLS, $type> {
-            type Output = Matrix<NROWS, NCOLS, $type>;
-
-            fn apply<'s>(
-                store: &'s mut Self::Output,
-                input: PassBy<Self>,
-                params: &Parameters,
-            ) -> PassBy<'s, Self::Output> {
-                for i in 0..NROWS {
-                    for j in 0..NCOLS {
-                        let input_val = input.data[j][i] as $cast_type;
-                        let res = match params.direction {
-                            ShiftDirection::Left => input_val << params.bits,
-                            ShiftDirection::Right => input_val >> params.bits,
-                        } as $type;
-                        store.data[j][i] = res;
-                    }
-                }
-                store
-            }
-        }
     };
 }
 
-impl_bit_shift_apply!(i8, i8);
-impl_bit_shift_apply!(i16, i16);
-impl_bit_shift_apply!(i32, i32);
+impl<const NROWS: usize, const NCOLS: usize, T: Scalar> Apply for Matrix<NROWS, NCOLS, T>
+where
+    T: Apply,
+{
+    fn apply<'s>(
+        store: &'s mut Self,
+        input: PassBy<Self>,
+        params: &Parameters,
+    ) -> PassBy<'s, Self> {
+        for i in 0..NROWS {
+            for j in 0..NCOLS {
+                let input_val = input.data[j][i];
+                T::apply(&mut store.data[j][i], input_val.as_by(), params);
+            }
+        }
+        store
+    }
+}
+
 impl_bit_shift_apply!(f32, i32);
 impl_bit_shift_apply!(f64, i64);
+impl_bit_shift_apply!(i8);
+impl_bit_shift_apply!(i16);
+impl_bit_shift_apply!(i32);
+impl_bit_shift_apply!(i64);
+impl_bit_shift_apply!(u8);
+impl_bit_shift_apply!(u16);
+impl_bit_shift_apply!(u32);
+impl_bit_shift_apply!(u64);
 
 #[cfg(test)]
 mod tests {
@@ -134,6 +145,11 @@ mod tests {
     use paste::paste;
 
     macro_rules! test_bit_shift {
+        // Convenience call to generate a call to the main macro for every type in the list
+        ($type:ty, $($other_types:ty),*) => {
+            test_bit_shift!($type);
+            test_bit_shift!($($other_types),*);
+        };
         ($type:ty) => {
             paste! {
                 #[test]
@@ -197,9 +213,5 @@ mod tests {
         };
     }
 
-    test_bit_shift!(i8);
-    test_bit_shift!(i16);
-    test_bit_shift!(i32);
-    test_bit_shift!(f32);
-    test_bit_shift!(f64);
+    test_bit_shift!(f64, f32, i8, i16, i32, i64, u8, u16, u32, u64);
 }

--- a/pictorus-blocks/src/core_blocks/bitwise_operator_block.rs
+++ b/pictorus-blocks/src/core_blocks/bitwise_operator_block.rs
@@ -87,6 +87,8 @@ impl_bitwise_operator_simple!(u16);
 impl_bitwise_operator_simple!(i16);
 impl_bitwise_operator_simple!(u32);
 impl_bitwise_operator_simple!(i32);
+impl_bitwise_operator_simple!(u64);
+impl_bitwise_operator_simple!(i64);
 
 // Impl for float types that require casting to integer before applying the operation
 impl BitOperations<f32> for f32 {
@@ -444,6 +446,8 @@ mod test {
     test_bitwise_operator!(i16);
     test_bitwise_operator!(u32);
     test_bitwise_operator!(i32);
+    test_bitwise_operator!(u64);
+    test_bitwise_operator!(i64);
     test_bitwise_operator!(f32);
     test_bitwise_operator!(f64);
 }

--- a/pictorus-blocks/src/core_blocks/clamp_block.rs
+++ b/pictorus-blocks/src/core_blocks/clamp_block.rs
@@ -89,6 +89,8 @@ impl_clamp_block!(i16);
 impl_clamp_block!(u16);
 impl_clamp_block!(i32);
 impl_clamp_block!(u32);
+impl_clamp_block!(i64);
+impl_clamp_block!(u64);
 impl_clamp_block!(f32);
 impl_clamp_block!(f64);
 
@@ -179,6 +181,7 @@ mod test {
 
     impl_clamp_block_test_negatives!(f64, f64);
     impl_clamp_block_test_negatives!(f32, f32);
+    impl_clamp_block_test_negatives!(i64, i64);
     impl_clamp_block_test_negatives!(i32, i32);
     impl_clamp_block_test_negatives!(i16, i16);
     impl_clamp_block_test_negatives!(i8, i8);
@@ -237,6 +240,8 @@ mod test {
 
     impl_clamp_block_test_positives!(f64, f64);
     impl_clamp_block_test_positives!(f32, f32);
+    impl_clamp_block_test_positives!(i64, i64);
+    impl_clamp_block_test_positives!(u64, u64);
     impl_clamp_block_test_positives!(u32, u32);
     impl_clamp_block_test_positives!(i32, i32);
     impl_clamp_block_test_positives!(i16, i16);

--- a/pictorus-blocks/src/core_blocks/compare_to_value_block.rs
+++ b/pictorus-blocks/src/core_blocks/compare_to_value_block.rs
@@ -250,6 +250,7 @@ mod tests {
     test_compare_to_value!(i8, u8, i16, u16, i32, u32, i64, u64, f32, f64);
 
     #[test]
+    #[allow(clippy::bool_assert_comparison)]
     fn test_compare_to_value_bool() {
         let mut parameters = Parameter::new("Equal", true);
         let context = StubContext::default();

--- a/pictorus-blocks/src/core_blocks/compare_to_value_block.rs
+++ b/pictorus-blocks/src/core_blocks/compare_to_value_block.rs
@@ -113,8 +113,11 @@ impl_compare_to_value_block!(i16);
 impl_compare_to_value_block!(u16);
 impl_compare_to_value_block!(i32);
 impl_compare_to_value_block!(u32);
+impl_compare_to_value_block!(i64);
+impl_compare_to_value_block!(u64);
 impl_compare_to_value_block!(f32);
 impl_compare_to_value_block!(f64);
+impl_compare_to_value_block!(bool);
 
 #[cfg(test)]
 mod tests {
@@ -133,10 +136,15 @@ mod tests {
     }
 
     macro_rules! test_compare_to_value {
-        ($name:ident, $type:ty) => {
+         // Convenience call to generate a call to the main macro for every type in the list
+        ($type:ty, $($other_types:ty),*) => {
+            test_compare_to_value!($type);
+            test_compare_to_value!($($other_types),*);
+        };
+        ($type:ty) => {
             paste! {
                 #[test]
-                fn [<test_compare_by_value_scalar_ $name>]() {
+                fn [<test_compare_by_value_scalar_ $type>]() {
                     /*
                         Compares an input of 1 to a scalar value of 1 for all comparison types.
                     */
@@ -176,7 +184,7 @@ mod tests {
                 }
 
                 #[test]
-                fn [<test_compare_by_value_matrix_ $name>]() {
+                fn [<test_compare_by_value_matrix_ $type>]() {
                     /*
                         Compares an input [[1, 0], [0, 2]] to a scalar value of 1 for all comparison types.
                     */
@@ -239,12 +247,58 @@ mod tests {
         };
     }
 
-    test_compare_to_value!(i8, i8);
-    test_compare_to_value!(u8, u8);
-    test_compare_to_value!(i16, i16);
-    test_compare_to_value!(u16, u16);
-    test_compare_to_value!(i32, i32);
-    test_compare_to_value!(u32, u32);
-    test_compare_to_value!(f32, f32);
-    test_compare_to_value!(f64, f64);
+    test_compare_to_value!(i8, u8, i16, u16, i32, u32, i64, u64, f32, f64);
+
+    #[test]
+    fn test_compare_to_value_bool() {
+        let mut parameters = Parameter::new("Equal", true);
+        let context = StubContext::default();
+
+        let mut block = CompareToValueBlock::<bool>::default();
+
+        let output = block.process(&parameters, &context, true);
+        assert_eq!(output, true);
+        assert_eq!(block.buffer(), output);
+
+        parameters.comparison_type = ComparisonType::NotEqual;
+        let output = block.process(&parameters, &context, false);
+        assert_eq!(output, true);
+        assert_eq!(block.buffer(), true);
+
+        // false < true == true and true < true == false
+        parameters.comparison_type = ComparisonType::LessThan;
+        let output = block.process(&parameters, &context, false);
+        assert_eq!(output, true);
+        assert_eq!(block.buffer(), true);
+        let output = block.process(&parameters, &context, true);
+        assert_eq!(output, false);
+        assert_eq!(block.buffer(), false);
+
+        // false <= true == true and true <= true == true
+        parameters.comparison_type = ComparisonType::LessOrEqual;
+        let output = block.process(&parameters, &context, false);
+        assert_eq!(output, true);
+        assert_eq!(block.buffer(), true);
+        let output = block.process(&parameters, &context, true);
+        assert_eq!(output, true);
+        assert_eq!(block.buffer(), true);
+
+        // false > true == false and true > true == false
+        parameters.comparison_type = ComparisonType::GreaterThan;
+        let output = block.process(&parameters, &context, false);
+        assert_eq!(output, false);
+        assert_eq!(block.buffer(), false);
+        let output = block.process(&parameters, &context, true);
+        assert_eq!(output, false);
+        assert_eq!(block.buffer(), false);
+
+        // false >= true == false and true >= true == true
+        parameters.comparison_type = ComparisonType::GreaterOrEqual;
+        let output = block.process(&parameters, &context, false);
+        assert_eq!(output, false);
+        assert_eq!(block.buffer(), false);
+        let output = block.process(&parameters, &context, true);
+        assert_eq!(output, true);
+        assert_eq!(block.buffer(), true);
+    }
 }

--- a/pictorus-blocks/src/core_blocks/cross_product_block.rs
+++ b/pictorus-blocks/src/core_blocks/cross_product_block.rs
@@ -1,4 +1,5 @@
-use crate::matrix_ext::MatrixNalgebraExt;
+use crate::traits::Scalar;
+use core::ops::{Mul, Sub};
 use pictorus_traits::{Context, Matrix, Pass, PassBy};
 
 pub struct Parameters {
@@ -66,43 +67,48 @@ pub trait Apply: Pass + Sized {
         -> PassBy<'s, Self::Output>;
 }
 
-macro_rules! float_matrix_impl {
-    ($type:ty) => {
-        impl Apply for (Matrix<1, 3, $type>, Matrix<1, 3, $type>) {
-            type Output = Matrix<1, 3, $type>;
+/// Cross product over the flattened elements of two 3-element vectors.
+/// Both 1x3 and 3x1 matrices store their elements contiguously in the same order.
+fn cross3<S>(a: &[S], b: &[S], out: &mut [S])
+where
+    S: Scalar + Mul<Output = S> + Sub<Output = S>,
+{
+    out[0] = a[1] * b[2] - a[2] * b[1];
+    out[1] = a[2] * b[0] - a[0] * b[2];
+    out[2] = a[0] * b[1] - a[1] * b[0];
+}
+
+macro_rules! impl_cross_product {
+    ($nrows:literal, $ncols:literal) => {
+        impl<S> Apply for (Matrix<$nrows, $ncols, S>, Matrix<$nrows, $ncols, S>)
+        where
+            S: Scalar + Mul<Output = S> + Sub<Output = S>,
+        {
+            type Output = Matrix<$nrows, $ncols, S>;
 
             fn apply<'s>(
                 store: &'s mut Self::Output,
                 inputs: PassBy<'_, Self>,
             ) -> PassBy<'s, Self::Output> {
-                let cross = inputs.0.as_view().cross(&inputs.1.as_view());
-                *store = Matrix::<1, 3, $type>::from_view(&cross.as_view());
-                store
-            }
-        }
-
-        impl Apply for (Matrix<3, 1, $type>, Matrix<3, 1, $type>) {
-            type Output = Matrix<3, 1, $type>;
-
-            fn apply<'s>(
-                store: &'s mut Self::Output,
-                inputs: PassBy<'_, Self>,
-            ) -> PassBy<'s, Self::Output> {
-                let cross = inputs.0.as_view().cross(&inputs.1.as_view());
-                *store = Matrix::<3, 1, $type>::from_view(&cross.as_view());
+                cross3(
+                    inputs.0.data.as_flattened(),
+                    inputs.1.data.as_flattened(),
+                    store.data.as_flattened_mut(),
+                );
                 store
             }
         }
     };
 }
 
-float_matrix_impl!(f64);
-float_matrix_impl!(f32);
+impl_cross_product!(1, 3);
+impl_cross_product!(3, 1);
 
 #[cfg(test)]
 mod tests {
 
     use crate::testing::StubContext;
+    use paste::paste;
     use pictorus_traits::ProcessBlock;
 
     use super::*;
@@ -113,102 +119,102 @@ mod tests {
         assert_eq!(block.buffer(), &Matrix::<1, 3, f64>::zeroed());
     }
 
-    #[test]
-    fn test_vector_cross_f64_blockdata_1x3() {
-        let context = StubContext::default();
-        let p = Parameters::new();
-        let mut cross_block =
-            CrossProductBlock::<(Matrix<1, 3, f64>, Matrix<1, 3, f64>)>::default();
-        let input1: Matrix<1, 3, f64> = Matrix {
-            data: [[1.0], [0.0], [0.0]],
+    macro_rules! test_cross_product {
+        // Convenience call to generate a call to the main macro for every type in the list
+        ($type:ty, $($other_types:ty),*) => {
+            test_cross_product!($type);
+            test_cross_product!($($other_types),*);
         };
-        let input2: Matrix<1, 3, f64> = Matrix {
-            data: [[0.0], [1.0], [0.0]],
-        };
-        cross_block.process(&p, &context, (&input1, &input2));
+        ($type:ty) => {
+            paste! {
+                #[test]
+                fn [<test_vector_cross_unit_1x3_ $type>]() {
+                    // x cross y = z, no negative intermediates so valid for unsigned types
+                    let context = StubContext::default();
+                    let p = Parameters::new();
+                    let mut cross_block =
+                        CrossProductBlock::<(Matrix<1, 3, $type>, Matrix<1, 3, $type>)>::default();
+                    let input1: Matrix<1, 3, $type> = Matrix {
+                        data: [[1 as $type], [0 as $type], [0 as $type]],
+                    };
+                    let input2: Matrix<1, 3, $type> = Matrix {
+                        data: [[0 as $type], [1 as $type], [0 as $type]],
+                    };
+                    let output = cross_block.process(&p, &context, (&input1, &input2));
+                    assert_eq!(output.data, [[0 as $type], [0 as $type], [1 as $type]]);
+                    assert_eq!(cross_block.buffer().data, [[0 as $type], [0 as $type], [1 as $type]]);
+                }
 
-        assert_eq!(cross_block.buffer().data, [[0.0], [0.0], [1.0]]);
+                #[test]
+                fn [<test_vector_cross_unit_3x1_ $type>]() {
+                    let context = StubContext::default();
+                    let p = Parameters::new();
+                    let mut cross_block =
+                        CrossProductBlock::<(Matrix<3, 1, $type>, Matrix<3, 1, $type>)>::default();
+                    let input1: Matrix<3, 1, $type> = Matrix {
+                        data: [[1 as $type, 0 as $type, 0 as $type]],
+                    };
+                    let input2: Matrix<3, 1, $type> = Matrix {
+                        data: [[0 as $type, 1 as $type, 0 as $type]],
+                    };
+                    let output = cross_block.process(&p, &context, (&input1, &input2));
+                    assert_eq!(output.data, [[0 as $type, 0 as $type, 1 as $type]]);
+                    assert_eq!(cross_block.buffer().data, [[0 as $type, 0 as $type, 1 as $type]]);
+                }
+            }
+        };
     }
 
-    #[test]
-    fn test_vector_cross_f64_blockdata_3x1() {
-        let context = StubContext::default();
-        let p = Parameters::new();
-        let mut cross_block =
-            CrossProductBlock::<(Matrix<3, 1, f64>, Matrix<3, 1, f64>)>::default();
-        let input1: Matrix<3, 1, f64> = Matrix {
-            data: [[1.0, 0.0, 0.0]],
-        };
-        let input2: Matrix<3, 1, f64> = Matrix {
-            data: [[0.0, 1.0, 0.0]],
-        };
-        cross_block.process(&p, &context, (&input1, &input2));
+    test_cross_product!(f32, f64, i8, i16, i32, i64, u8, u16, u32, u64);
 
-        assert_eq!(cross_block.buffer().data, [[0.0, 0.0, 1.0]]);
+    macro_rules! test_cross_product_signed {
+        // Convenience call to generate a call to the main macro for every type in the list
+        ($type:ty, $($other_types:ty),*) => {
+            test_cross_product_signed!($type);
+            test_cross_product_signed!($($other_types),*);
+        };
+        ($type:ty) => {
+            paste! {
+                #[test]
+                fn [<test_vector_cross_signed_ $type>]() {
+                    // (2,3,4) cross (5,6,7) = (-3, 6, -3)
+                    let context = StubContext::default();
+                    let p = Parameters::new();
+                    let mut cross_block =
+                        CrossProductBlock::<(Matrix<1, 3, $type>, Matrix<1, 3, $type>)>::default();
+                    let input1: Matrix<1, 3, $type> = Matrix {
+                        data: [[2 as $type], [3 as $type], [4 as $type]],
+                    };
+                    let input2: Matrix<1, 3, $type> = Matrix {
+                        data: [[5 as $type], [6 as $type], [7 as $type]],
+                    };
+                    let output = cross_block.process(&p, &context, (&input1, &input2));
+                    assert_eq!(
+                        output.data,
+                        [[-3 as $type], [6 as $type], [-3 as $type]]
+                    );
+                }
+            }
+        };
     }
 
-    #[test]
-    fn test_vector_cross_f64_1x3() {
-        let context = StubContext::default();
-        let p = Parameters::new();
-        let mut cross_block =
-            CrossProductBlock::<(Matrix<1, 3, f64>, Matrix<1, 3, f64>)>::default();
-        let input1: Matrix<1, 3, f64> = Matrix {
-            data: [[1.0], [0.0], [0.0]],
-        };
-        let input2: Matrix<1, 3, f64> = Matrix {
-            data: [[0.0], [1.0], [0.0]],
-        };
-        let output = *cross_block.process(&p, &context, (&input1, &input2));
-        assert_eq!(output.data, [[0.0], [0.0], [1.0]]);
-        assert_eq!(cross_block.buffer(), &output);
-    }
+    test_cross_product_signed!(f32, f64, i8, i16, i32, i64);
 
     #[test]
-    fn test_vector_cross_f64_3x1() {
+    #[should_panic]
+    fn underflow_panics_unsigned() {
+        // y cross x = -z, which underflows unsigned types and panics in debug builds
+        // (wraps in release).
         let context = StubContext::default();
         let p = Parameters::new();
-        let mut cross_block =
-            CrossProductBlock::<(Matrix<3, 1, f64>, Matrix<3, 1, f64>)>::default();
-        let input1: Matrix<3, 1, f64> = Matrix {
-            data: [[1.0, 0.0, 0.0]],
+        let mut cross_block = CrossProductBlock::<(Matrix<1, 3, u8>, Matrix<1, 3, u8>)>::default();
+        let input1: Matrix<1, 3, u8> = Matrix {
+            data: [[0], [1], [0]],
         };
-        let input2: Matrix<3, 1, f64> = Matrix {
-            data: [[0.0, 1.0, 0.0]],
+        let input2: Matrix<1, 3, u8> = Matrix {
+            data: [[1], [0], [0]],
         };
         let output = cross_block.process(&p, &context, (&input1, &input2));
-        assert_eq!(output.data, [[0.0, 0.0, 1.0]]);
-    }
-
-    #[test]
-    fn test_vector_cross_f32_1x3() {
-        let context = StubContext::default();
-        let p = Parameters::new();
-        let mut cross_block =
-            CrossProductBlock::<(Matrix<1, 3, f32>, Matrix<1, 3, f32>)>::default();
-        let input1: Matrix<1, 3, f32> = Matrix {
-            data: [[1.0], [0.0], [0.0]],
-        };
-        let input2: Matrix<1, 3, f32> = Matrix {
-            data: [[0.0], [1.0], [0.0]],
-        };
-        let output = cross_block.process(&p, &context, (&input1, &input2));
-        assert_eq!(output.data, [[0.0], [0.0], [1.0]]);
-    }
-
-    #[test]
-    fn test_vector_cross_f32_3x1() {
-        let context = StubContext::default();
-        let p = Parameters::new();
-        let mut cross_block =
-            CrossProductBlock::<(Matrix<3, 1, f32>, Matrix<3, 1, f32>)>::default();
-        let input1: Matrix<3, 1, f32> = Matrix {
-            data: [[1.0, 0.0, 0.0]],
-        };
-        let input2: Matrix<3, 1, f32> = Matrix {
-            data: [[0.0, 1.0, 0.0]],
-        };
-        let output = cross_block.process(&p, &context, (&input1, &input2));
-        assert_eq!(output.data, [[0.0, 0.0, 1.0]]);
+        assert_eq!(output.data, [[0], [0], [u8::MAX]]);
     }
 }

--- a/pictorus-blocks/src/core_blocks/cross_product_block.rs
+++ b/pictorus-blocks/src/core_blocks/cross_product_block.rs
@@ -202,6 +202,25 @@ mod tests {
 
     #[test]
     #[should_panic]
+    fn multiplication_overflow_panics() {
+        // The first output element computes 16 * 16 = 256, which overflows i8 in the
+        // multiply step (before any subtraction). Native arithmetic panics in debug
+        // builds (wraps in release).
+        let context = StubContext::default();
+        let p = Parameters::new();
+        let mut cross_block = CrossProductBlock::<(Matrix<1, 3, i8>, Matrix<1, 3, i8>)>::default();
+        let input1: Matrix<1, 3, i8> = Matrix {
+            data: [[0], [16], [0]],
+        };
+        let input2: Matrix<1, 3, i8> = Matrix {
+            data: [[0], [0], [16]],
+        };
+        let output = cross_block.process(&p, &context, (&input1, &input2));
+        assert_eq!(output.data, [[0], [0], [0]]);
+    }
+
+    #[test]
+    #[should_panic]
     fn underflow_panics_unsigned() {
         // y cross x = -z, which underflows unsigned types and panics in debug builds
         // (wraps in release).

--- a/pictorus-blocks/src/core_blocks/deadband_block.rs
+++ b/pictorus-blocks/src/core_blocks/deadband_block.rs
@@ -1,6 +1,7 @@
+use num_traits::Zero;
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
-use crate::traits::MatrixOps;
+use crate::{traits::MatrixOps, Scalar};
 
 pub struct Parameters<T> {
     // Lower limit of the deadband
@@ -36,60 +37,52 @@ where
     }
 }
 
-macro_rules! impl_deadband_block {
-    ($type:ty) => {
-        impl ProcessBlock for DeadbandBlock<$type> {
-            type Inputs = $type;
-            type Output = $type;
-            type Parameters = Parameters<$type>;
+impl<S: Scalar + PartialOrd<S> + Default + Zero> ProcessBlock for DeadbandBlock<S> {
+    type Inputs = S;
+    type Output = S;
+    type Parameters = Parameters<S>;
 
-            fn process(
-                &mut self,
-                parameters: &Self::Parameters,
-                _context: &dyn pictorus_traits::Context,
-                input: PassBy<Self::Inputs>,
-            ) -> PassBy<'_, Self::Output> {
-                let in_deadband = input < parameters.upper_limit && input > parameters.lower_limit;
-                let res = if in_deadband { 0.0 } else { input };
-                self.buffer = res;
-                self.buffer
-            }
+    fn process(
+        &mut self,
+        parameters: &Self::Parameters,
+        _context: &dyn pictorus_traits::Context,
+        input: PassBy<Self::Inputs>,
+    ) -> PassBy<'_, Self::Output> {
+        let in_deadband = input < parameters.upper_limit && input > parameters.lower_limit;
+        let res = if in_deadband { S::zero() } else { input };
+        self.buffer = res;
+        self.buffer
+    }
 
-            fn buffer(&self) -> PassBy<'_, Self::Output> {
-                self.buffer.as_by()
-            }
-        }
-
-        impl<const ROWS: usize, const COLS: usize> ProcessBlock
-            for DeadbandBlock<Matrix<ROWS, COLS, $type>>
-        {
-            type Inputs = Matrix<ROWS, COLS, $type>;
-            type Output = Matrix<ROWS, COLS, $type>;
-            type Parameters = Parameters<$type>;
-
-            fn process(
-                &mut self,
-                parameters: &Self::Parameters,
-                _context: &dyn pictorus_traits::Context,
-                input: PassBy<Self::Inputs>,
-            ) -> PassBy<'_, Self::Output> {
-                self.buffer = Matrix::zeroed();
-                input.for_each(|v, c, r| {
-                    let in_deadband = v < parameters.upper_limit && v > parameters.lower_limit;
-                    self.buffer.data[c][r] = if in_deadband { 0.0 } else { v };
-                });
-                &self.buffer
-            }
-
-            fn buffer(&self) -> PassBy<'_, Self::Output> {
-                self.buffer.as_by()
-            }
-        }
-    };
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
 }
+impl<S: Scalar + PartialOrd<S> + Default + Zero, const NROWS: usize, const NCOLS: usize>
+    ProcessBlock for DeadbandBlock<Matrix<NROWS, NCOLS, S>>
+{
+    type Inputs = Matrix<NROWS, NCOLS, S>;
+    type Output = Matrix<NROWS, NCOLS, S>;
+    type Parameters = Parameters<S>;
 
-impl_deadband_block!(f32);
-impl_deadband_block!(f64);
+    fn process(
+        &mut self,
+        parameters: &Self::Parameters,
+        _context: &dyn pictorus_traits::Context,
+        input: PassBy<Self::Inputs>,
+    ) -> PassBy<'_, Self::Output> {
+        self.buffer = Matrix::zeroed();
+        input.for_each(|v, c, r| {
+            let in_deadband = v < parameters.upper_limit && v > parameters.lower_limit;
+            self.buffer.data[c][r] = if in_deadband { S::zero() } else { v };
+        });
+        &self.buffer
+    }
+
+    fn buffer(&self) -> PassBy<'_, Self::Output> {
+        self.buffer.as_by()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -107,62 +100,79 @@ mod tests {
     }
 
     macro_rules! test_deadband_block {
+         // Convenience call to generate a call to the main macro for every type in the list
+        ($type:ty, $($other_types:ty),*) => {
+            test_deadband_block!($type);
+            test_deadband_block!($($other_types),*);
+        };
         ($type:ty) => {
             paste! {
                 #[test]
                 fn [<test_deadband_block_ $type>]() {
+                    let (lower_limit,  upper_limit) = if (<$type>::MIN as f64).lt(&0.0) {
+                        ((0 - 10) as $type,  10 as $type)
+                    } else {
+                        (10 as $type,  20 as $type)
+                    };
+
+                    const ZERO: $type = 0 as $type;
                     let mut block = DeadbandBlock::<$type>::default();
-                    let parameters = Parameters::new(-1.0, 1.0);
+                    let parameters = Parameters::new(lower_limit, upper_limit);
                     let ctxt = StubContext::default();
 
                     // Anything exactly at the deadband limits maintains data
-                    let input = -1.0;
+                    let input = lower_limit;
                     let output = block.process(&parameters, &ctxt, input);
-                    assert_eq!(output, -1.0);
+                    assert_eq!(output, lower_limit);
                     assert_eq!(block.buffer(), output);
 
-                    let input = 1.0;
+                    let input = upper_limit;
                     let output = block.process(&parameters, &ctxt, input);
-                    assert_eq!(output, 1.0);
+                    assert_eq!(output, upper_limit);
 
                     // Anything between the deadband is set to zero.
-                    let input = -0.999;
+                    let input = lower_limit + 1 as $type;
                     let output = block.process(&parameters, &ctxt, input);
-                    assert_eq!(output, 0.0);
+                    assert_eq!(output, ZERO);
 
-                    let input = 0.0;
+                    let input = ZERO;
                     let output = block.process(&parameters, &ctxt, input);
-                    assert_eq!(output, 0.0);
+                    assert_eq!(output, ZERO);
 
-                    let input = 0.999;
+                    let input = upper_limit - 1 as $type;
                     let output = block.process(&parameters, &ctxt, input);
-                    assert_eq!(output, 0.0);
+                    assert_eq!(output, ZERO);
                 }
 
                 #[test]
                 fn [<test_deadband_block_matrix_ $type>]() {
+                    let (lower_limit,  upper_limit) = if (<$type>::MIN as f64).lt(&0.0) {
+                        ((0-10) as $type,  10 as $type)
+                    } else {
+                        (10 as $type,  20 as $type)
+                    };
+                    const ZERO: $type = 0 as $type;
                     let mut block = DeadbandBlock::<Matrix<2, 2, $type>>::default();
-                    let parameters = Parameters::new(-1.0, 1.0);
+                    let parameters = Parameters::new(lower_limit, upper_limit);
                     let ctxt = StubContext::default();
 
                     // Anything exactly at the deadband limits maintains data
                     let input = Matrix {
-                        data: [[-1.0, 1.0], [1.0, -1.0]],
+                        data: [[lower_limit, upper_limit], [upper_limit, lower_limit]],
                     };
                     let output = block.process(&parameters, &ctxt, &input);
-                    assert_eq!(output.data, [[-1.0, 1.0], [1.0, -1.0]]);
+                    assert_eq!(output.data, [[lower_limit, upper_limit], [upper_limit, lower_limit]]);
 
                     // Anything between the deadband is set to zero.
                     let input = Matrix {
-                        data: [[-0.999, 0.0], [0.0, 0.999]],
+                        data: [[lower_limit + 1 as $type, ZERO], [ZERO, upper_limit - 1 as $type]],
                     };
                     let output = block.process(&parameters, &ctxt, &input);
-                    assert_eq!(output.data, [[0.0, 0.0], [0.0, 0.0]]);
+                    assert_eq!(output.data, [[ZERO, ZERO], [ZERO, ZERO]]);
                 }
             }
         };
     }
 
-    test_deadband_block!(f32);
-    test_deadband_block!(f64);
+    test_deadband_block!(f32, f64, i8, i16, i32, i64, u8, u16, u32, u64);
 }

--- a/pictorus-blocks/src/core_blocks/gain_block.rs
+++ b/pictorus-blocks/src/core_blocks/gain_block.rs
@@ -3,6 +3,9 @@ use core::ops::Mul;
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Multiplies the input by a gain factor.
+///
+/// The gain parameter is the same type as the input signal (the element type for
+/// matrix signals). To apply a gain of a different type, cast the input signal first.
 pub struct GainBlock<T>
 where
     T: Apply,
@@ -169,5 +172,18 @@ mod tests {
 
         let output = block.process(&parameters, &context, 128u8);
         assert_eq!(output, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn negative_overflow_panics() {
+        // -100 * 2 = -200 underflows i8::MIN; native integer multiplication panics in
+        // debug builds (wraps in release).
+        let mut block = GainBlock::<i8>::default();
+        let parameters = Parameters::new(2i8);
+        let context = StubContext::default();
+
+        let output = block.process(&parameters, &context, -100i8);
+        assert_eq!(output, 56);
     }
 }

--- a/pictorus-blocks/src/core_blocks/gain_block.rs
+++ b/pictorus-blocks/src/core_blocks/gain_block.rs
@@ -1,34 +1,33 @@
-use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Promote, Promotion, Scalar};
+use crate::traits::Scalar;
+use core::ops::Mul;
+use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Multiplies the input by a gain factor.
-pub struct GainBlock<G, T>
+pub struct GainBlock<T>
 where
-    G: Scalar,
-    T: Apply<G>,
+    T: Apply,
 {
-    buffer: T::Output,
+    buffer: T,
 }
 
-impl<G, T> Default for GainBlock<G, T>
+impl<T> Default for GainBlock<T>
 where
-    G: Scalar,
-    T: Apply<G>,
+    T: Apply,
 {
     fn default() -> Self {
         Self {
-            buffer: <T::Output>::default(),
+            buffer: T::default(),
         }
     }
 }
 
-impl<G, T> ProcessBlock for GainBlock<G, T>
+impl<T> ProcessBlock for GainBlock<T>
 where
-    G: Scalar,
-    T: Apply<G>,
+    T: Apply,
 {
     type Inputs = T;
-    type Output = T::Output;
-    type Parameters = Parameters<G>;
+    type Output = T;
+    type Parameters = Parameters<T::Gain>;
 
     fn process(
         &mut self,
@@ -36,8 +35,7 @@ where
         _context: &dyn pictorus_traits::Context,
         input: PassBy<Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
-        let output = T::apply(&mut self.buffer, input, parameters.gain);
-        output
+        T::apply(&mut self.buffer, input, parameters.gain)
     }
 
     fn buffer(&self) -> PassBy<'_, Self::Output> {
@@ -45,73 +43,42 @@ where
     }
 }
 
-pub trait Apply<G: Scalar>: Pass {
-    type Output: Pass + Default;
+pub trait Apply: Pass + Default {
+    /// The scalar type of the gain parameter. Matches the element type for
+    /// matrix signals and the signal type itself for scalar signals.
+    type Gain: Scalar;
 
-    fn apply<'s>(
-        store: &'s mut Self::Output,
-        input: PassBy<Self>,
-        gain: G,
-    ) -> PassBy<'s, Self::Output>;
+    fn apply<'s>(store: &'s mut Self, input: PassBy<Self>, gain: Self::Gain) -> PassBy<'s, Self>;
 }
 
-impl<G> Apply<G> for f64
+impl<S> Apply for S
 where
-    G: Promote<f64> + Scalar,
+    S: Scalar + Mul<Output = S>,
 {
-    type Output = Promotion<G, f64>;
-    fn apply<'s>(
-        store: &'s mut Self::Output,
-        input: PassBy<Self>,
-        gain: G,
-    ) -> PassBy<'s, Self::Output> {
-        let output =
-            <G as Promote<f64>>::promote_left(gain) * <G as Promote<f64>>::promote_right(input);
+    type Gain = S;
+
+    fn apply<'s>(store: &'s mut Self, input: PassBy<Self>, gain: S) -> PassBy<'s, Self> {
+        let output = input * gain;
         *store = output;
         output
     }
 }
 
-impl<T> Apply<T> for f32
+impl<const NROWS: usize, const NCOLS: usize, S> Apply for Matrix<NROWS, NCOLS, S>
 where
-    T: Promote<f32> + Scalar,
+    S: Scalar + Apply<Gain = S>,
 {
-    type Output = Promotion<T, f32>;
-    fn apply<'s>(
-        store: &'s mut Self::Output,
-        input: PassBy<Self>,
-        gain: T,
-    ) -> PassBy<'s, Self::Output> {
-        let output =
-            <T as Promote<f32>>::promote_left(gain) * <T as Promote<f32>>::promote_right(input);
-        *store = output;
-        output
-    }
-}
+    type Gain = S;
 
-impl<const NROWS: usize, const NCOLS: usize, G, T> Apply<G> for Matrix<NROWS, NCOLS, T>
-where
-    T: Scalar,
-    G: Promote<T>,
-    T: Promote<G>,
-{
-    type Output = Matrix<NROWS, NCOLS, Promotion<G, T>>;
-
-    fn apply<'s>(
-        store: &'s mut Self::Output,
-        input: PassBy<Self>,
-        gain: G,
-    ) -> PassBy<'s, Self::Output> {
-        *store = Matrix::zeroed();
-        store
+    fn apply<'s>(store: &'s mut Self, input: PassBy<Self>, gain: S) -> PassBy<'s, Self> {
+        for (elem, &val) in store
             .data
             .as_flattened_mut()
             .iter_mut()
-            .enumerate()
-            .for_each(|(i, lhs)| {
-                *lhs = <G as Promote<T>>::promote_right(input.data.as_flattened()[i])
-                    * <G as Promote<T>>::promote_left(gain);
-            });
+            .zip(input.data.as_flattened().iter())
+        {
+            S::apply(elem, val, gain);
+        }
         store
     }
 }
@@ -130,61 +97,77 @@ impl<G: Scalar> Parameters<G> {
 mod tests {
     use super::*;
     use crate::testing::StubContext;
+    use paste::paste;
 
     #[test]
     fn test_gain_default_buffer_no_panic() {
-        let block = GainBlock::<f64, f64>::default();
+        let block = GainBlock::<f64>::default();
         assert_eq!(block.buffer(), 0.0);
 
-        let block = GainBlock::<f64, Matrix<2, 2, f64>>::default();
+        let block = GainBlock::<Matrix<2, 2, f64>>::default();
         assert_eq!(block.buffer(), &Matrix::<2, 2, f64>::zeroed());
     }
 
-    #[test]
-    fn test_gain_scalar() {
-        let mut block = GainBlock::<f64, f64>::default();
-        let context = StubContext::default();
-        let input = 1.0;
-        let parameters = Parameters::new(2.0);
-        let output = block.process(&parameters, &context, input);
-        assert_eq!(output, 2.0);
-        assert_eq!(block.buffer(), output);
-    }
-
-    #[test]
-    fn test_gain_matrix() {
-        let mut block = GainBlock::<f64, Matrix<2, 2, f64>>::default();
-        let context = StubContext::default();
-        let input = Matrix {
-            data: [[1.0, 2.0], [3.0, 4.0]],
+    macro_rules! test_gain_block {
+        // Convenience call to generate a call to the main macro for every type in the list
+        ($type:ty, $($other_types:ty),*) => {
+            test_gain_block!($type);
+            test_gain_block!($($other_types),*);
         };
-        let parameters = Parameters::new(2.0);
-        let output = block.process(&parameters, &context, &input);
-        assert_eq!(output.data, [[2.0, 4.0], [6.0, 8.0]]);
-        assert_eq!(block.buffer().data, [[2.0, 4.0], [6.0, 8.0]]);
-    }
+        ($type:ty) => {
+            paste! {
+                #[test]
+                fn [<test_gain_scalar_ $type>]() {
+                    let mut block = GainBlock::<$type>::default();
+                    let context = StubContext::default();
+                    let input = 3 as $type;
+                    let parameters = Parameters::new(2 as $type);
+                    let output = block.process(&parameters, &context, input);
+                    assert_eq!(output, 6 as $type);
+                    assert_eq!(block.buffer(), output);
+                }
 
-    #[test]
-    fn test_scalar_with_to_pass() {
-        let mut block = GainBlock::<f64, f64>::default();
-        let context = StubContext::default();
-        let input = 1.0;
-        let parameters = Parameters::new(2.0);
-        let output = block.process(&parameters, &context, input);
-        assert_eq!(output, 2.0);
-        assert_eq!(block.buffer(), 2.0);
-    }
-
-    #[test]
-    fn test_matrix_with_to_pass() {
-        let mut block = GainBlock::<f64, Matrix<2, 2, f64>>::default();
-        let context = StubContext::default();
-        let input = Matrix {
-            data: [[1.0, 3.0], [2.0, 4.0]],
+                #[test]
+                fn [<test_gain_matrix_ $type>]() {
+                    let mut block = GainBlock::<Matrix<2, 2, $type>>::default();
+                    let context = StubContext::default();
+                    let input = Matrix {
+                        data: [[1 as $type, 2 as $type], [3 as $type, 4 as $type]],
+                    };
+                    let parameters = Parameters::new(2 as $type);
+                    let output = block.process(&parameters, &context, &input);
+                    let expected = [
+                        [2 as $type, 4 as $type],
+                        [6 as $type, 8 as $type],
+                    ];
+                    assert_eq!(output.data, expected);
+                    assert_eq!(block.buffer().data, expected);
+                }
+            }
         };
-        let parameters = Parameters::new(2.0);
-        let output = block.process(&parameters, &context, &input);
-        assert_eq!(output.data, [[2.0, 6.0], [4.0, 8.0]]);
-        assert_eq!(block.buffer().data, [[2.0, 6.0], [4.0, 8.0]]);
+    }
+
+    test_gain_block!(f32, f64, i8, i16, i32, i64, u8, u16, u32, u64);
+
+    #[test]
+    fn test_gain_negative() {
+        let mut block = GainBlock::<i32>::default();
+        let context = StubContext::default();
+        let parameters = Parameters::new(-3);
+        let output = block.process(&parameters, &context, 7);
+        assert_eq!(output, -21);
+        assert_eq!(block.buffer(), -21);
+    }
+
+    #[test]
+    #[should_panic]
+    fn overflow_panics() {
+        // Native integer multiplication overflow panics in debug builds (wraps in release).
+        let mut block = GainBlock::<u8>::default();
+        let parameters = Parameters::new(2u8);
+        let context = StubContext::default();
+
+        let output = block.process(&parameters, &context, 128u8);
+        assert_eq!(output, 0);
     }
 }

--- a/pictorus-blocks/src/core_blocks/not_block.rs
+++ b/pictorus-blocks/src/core_blocks/not_block.rs
@@ -1,3 +1,4 @@
+use crate::traits::Scalar;
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 #[derive(strum::EnumString, Clone, Copy)]
@@ -11,7 +12,7 @@ pub struct NotBlock<T>
 where
     T: Apply,
 {
-    buffer: T::Output,
+    buffer: T,
 }
 
 impl<T> Default for NotBlock<T>
@@ -20,7 +21,7 @@ where
 {
     fn default() -> Self {
         Self {
-            buffer: T::Output::default(),
+            buffer: T::default(),
         }
     }
 }
@@ -30,7 +31,7 @@ where
     T: Apply,
 {
     type Inputs = T;
-    type Output = T::Output;
+    type Output = T;
     type Parameters = Parameters;
 
     fn process(
@@ -48,24 +49,12 @@ where
     }
 }
 
-pub trait Apply: Pass {
-    type Output: Pass + Default;
-
-    fn apply<'s>(
-        store: &'s mut Self::Output,
-        input: PassBy<Self>,
-        method: NotMethod,
-    ) -> PassBy<'s, Self::Output>;
+pub trait Apply: Pass + Default {
+    fn apply<'s>(store: &'s mut Self, input: PassBy<Self>, method: NotMethod) -> PassBy<'s, Self>;
 }
 
 impl Apply for bool {
-    type Output = bool;
-
-    fn apply<'s>(
-        store: &'s mut Self::Output,
-        input: PassBy<Self>,
-        method: NotMethod,
-    ) -> PassBy<'s, Self::Output> {
+    fn apply<'s>(store: &'s mut Self, input: PassBy<Self>, method: NotMethod) -> PassBy<'s, Self> {
         let output = match method {
             NotMethod::Logical => !input,
             NotMethod::Bitwise => !input,
@@ -75,14 +64,47 @@ impl Apply for bool {
     }
 }
 
-impl<const NROWS: usize, const NCOLS: usize> Apply for Matrix<NROWS, NCOLS, bool> {
-    type Output = Matrix<NROWS, NCOLS, bool>;
+macro_rules! impl_not_apply {
+    ($type:ty) => {
+        impl Apply for $type {
+            fn apply<'s>(
+                store: &'s mut Self,
+                input: PassBy<Self>,
+                method: NotMethod,
+            ) -> PassBy<'s, Self> {
+                let output = match method {
+                    NotMethod::Logical => Self::from_bool(!input.is_truthy()),
+                    NotMethod::Bitwise => !input,
+                };
+                *store = output;
+                output
+            }
+        }
+    };
+    ($type:ty, $cast_type:ty) => {
+        impl Apply for $type {
+            fn apply<'s>(
+                store: &'s mut Self,
+                input: PassBy<Self>,
+                method: NotMethod,
+            ) -> PassBy<'s, Self> {
+                let output = match method {
+                    NotMethod::Logical => Self::from_bool(!input.is_truthy()),
+                    NotMethod::Bitwise => !(input as $cast_type) as $type,
+                };
+                *store = output;
+                output
+            }
+        }
+    };
+}
 
-    fn apply<'s>(
-        store: &'s mut Self::Output,
-        input: PassBy<Self>,
-        method: NotMethod,
-    ) -> PassBy<'s, Self::Output> {
+impl<T: Apply + Pass + Scalar, const NROWS: usize, const NCOLS: usize> Apply
+    for Matrix<NROWS, NCOLS, T>
+where
+    for<'a> Matrix<NROWS, NCOLS, T>: Pass<By<'a> = &'a Self>,
+{
+    fn apply<'s>(store: &'s mut Self, input: PassBy<Self>, method: NotMethod) -> PassBy<'s, Self> {
         *store = Matrix::zeroed();
         store
             .data
@@ -91,71 +113,10 @@ impl<const NROWS: usize, const NCOLS: usize> Apply for Matrix<NROWS, NCOLS, bool
             .enumerate()
             .for_each(|(i, lhs)| {
                 let input_val = input.data.as_flattened()[i];
-                *lhs = match method {
-                    NotMethod::Logical => !input_val,
-                    NotMethod::Bitwise => !input_val,
-                };
+                T::apply(lhs, input_val, method);
             });
         store
     }
-}
-
-macro_rules! impl_not_apply {
-    ($type:ty, $cast_type:ty) => {
-        impl Apply for $type {
-            type Output = $type;
-
-            fn apply<'s>(
-                store: &'s mut Self::Output,
-                input: PassBy<Self>,
-                method: NotMethod,
-            ) -> PassBy<'s, Self::Output> {
-                let output = match method {
-                    NotMethod::Logical => {
-                        if input == 0.0 {
-                            1.0
-                        } else {
-                            0.0
-                        }
-                    }
-                    NotMethod::Bitwise => !(input as $cast_type) as $type,
-                };
-                *store = output;
-                output
-            }
-        }
-
-        impl<const NROWS: usize, const NCOLS: usize> Apply for Matrix<NROWS, NCOLS, $type> {
-            type Output = Matrix<NROWS, NCOLS, $type>;
-
-            fn apply<'s>(
-                store: &'s mut Self::Output,
-                input: PassBy<Self>,
-                method: NotMethod,
-            ) -> PassBy<'s, Self::Output> {
-                *store = Matrix::zeroed();
-                store
-                    .data
-                    .as_flattened_mut()
-                    .iter_mut()
-                    .enumerate()
-                    .for_each(|(i, lhs)| {
-                        let input_val = input.data.as_flattened()[i];
-                        *lhs = match method {
-                            NotMethod::Logical => {
-                                if input_val == 0.0 {
-                                    1.0
-                                } else {
-                                    0.0
-                                }
-                            }
-                            NotMethod::Bitwise => !(input_val as $cast_type) as $type,
-                        };
-                    });
-                store
-            }
-        }
-    };
 }
 
 pub struct Parameters {
@@ -175,11 +136,20 @@ impl Parameters {
 
 impl_not_apply!(f32, i32);
 impl_not_apply!(f64, i64);
+impl_not_apply!(i32);
+impl_not_apply!(i64);
+impl_not_apply!(u32);
+impl_not_apply!(u64);
+impl_not_apply!(u8);
+impl_not_apply!(u16);
+impl_not_apply!(i8);
+impl_not_apply!(i16);
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::testing::StubContext;
+    use num_traits::{One, Zero};
     use paste::paste;
 
     #[test]
@@ -200,21 +170,13 @@ mod tests {
                     let context = StubContext::default();
                     let parameters = Parameters::new("Logical");
 
-                    let res = block.process(&parameters, &context, 1.0);
-                    assert_eq!(res, 0.0);
+                    let res = block.process(&parameters, &context, $type::one());
+                    assert_eq!(res, $type::zero());
                     assert_eq!(block.buffer(), res);
 
-                    let res = block.process(&parameters, &context, 0.0);
-                    assert_eq!(res, 1.0);
-                    assert_eq!(block.buffer(), 1.0);
-
-                    let res = block.process(&parameters, &context, -1.2);
-                    assert_eq!(res, 0.0);
-                    assert_eq!(block.buffer(), 0.0);
-
-                    let res = block.process(&parameters, &context, 1.2);
-                    assert_eq!(res, 0.0);
-                    assert_eq!(block.buffer(), 0.0);
+                    let res = block.process(&parameters, &context, $type::zero());
+                    assert_eq!(res, $type::one());
+                    assert_eq!(block.buffer(), $type::one());
                 }
 
                 #[test]
@@ -224,11 +186,11 @@ mod tests {
                     let parameters = Parameters::new("Logical");
 
                     let input = Matrix {
-                        data: [[1.0, 0.0, -1.2, 1.2]],
+                        data: [[$type::one(), $type::zero(), $type::one(), $type::one()]],
                     };
                     let res = block.process(&parameters, &context, &input);
-                    assert_eq!(res.data, [[0.0, 1.0, 0.0, 0.0]]);
-                    assert_eq!(block.buffer().data, [[0.0, 1.0, 0.0, 0.0]]);
+                    assert_eq!(res.data, [[$type::zero(), $type::one(), $type::zero(), $type::zero()]]);
+                    assert_eq!(block.buffer().data, [[$type::zero(), $type::one(), $type::zero(), $type::zero()]]);
                 }
 
                 #[test]
@@ -237,21 +199,21 @@ mod tests {
                     let context = StubContext::default();
                     let parameters = Parameters::new("Bitwise");
 
-                    let res = block.process(&parameters, &context, 1.0);
-                    assert_eq!(res, -2.0);
-                    assert_eq!(block.buffer(), -2.0);
+                    let res = block.process(&parameters, &context, 0b1 as $type);
+                    assert_eq!(res, !0b1 as $type);
+                    assert_eq!(block.buffer(), !0b1 as $type);
 
-                    let res = block.process(&parameters, &context, 42.0);
-                    assert_eq!(res, -43.0);
-                    assert_eq!(block.buffer(), -43.0);
+                    let res = block.process(&parameters, &context, 42 as $type);
+                    assert_eq!(res, !42 as $type);
+                    assert_eq!(block.buffer(), !42 as $type);
 
-                    let res = block.process(&parameters, &context, -1.2);
-                    assert_eq!(res, 0.0);
-                    assert_eq!(block.buffer(), 0.0);
+                    let res = block.process(&parameters, &context, -1i8 as $type);
+                    assert_eq!(res, !-1i8 as $type);
+                    assert_eq!(block.buffer(), !-1i8 as $type);
 
-                    let res = block.process(&parameters, &context, 1.2);
-                    assert_eq!(res, -2.0);
-                    assert_eq!(block.buffer(), -2.0);
+                    let res = block.process(&parameters, &context, 1 as $type);
+                    assert_eq!(res, !1 as $type);
+                    assert_eq!(block.buffer(), !1 as $type);
                 }
 
                 #[test]
@@ -261,11 +223,11 @@ mod tests {
                     let parameters = Parameters::new("Bitwise");
 
                     let input = Matrix {
-                        data: [[1.0, 42.0], [-1.2, 1.2]],
+                        data: [[1 as $type, 42 as $type], [-1i8 as $type, 1 as $type]],
                     };
                     let res = block.process(&parameters, &context, &input);
-                    assert_eq!(res.data, [[-2.0, -43.0], [0.0, -2.0]]);
-                    assert_eq!(block.buffer().data, [[-2.0, -43.0], [0.0, -2.0]]);
+                    assert_eq!(res.data, [[!1 as $type, !42 as $type], [!-1i8 as $type, !1 as $type]]);
+                    assert_eq!(block.buffer().data, [[!1 as $type, !42 as $type], [!-1i8 as $type, !1 as $type]]);
                 }
             }
         };
@@ -273,6 +235,14 @@ mod tests {
 
     test_not_block!(f32);
     test_not_block!(f64);
+    test_not_block!(i64);
+    test_not_block!(u64);
+    test_not_block!(i8);
+    test_not_block!(i16);
+    test_not_block!(i32);
+    test_not_block!(u8);
+    test_not_block!(u16);
+    test_not_block!(u32);
 
     #[test]
     fn test_scalar_bool() {

--- a/pictorus-blocks/src/core_blocks/product_block.rs
+++ b/pictorus-blocks/src/core_blocks/product_block.rs
@@ -101,6 +101,7 @@ mod tests {
     use super::*;
     use crate::testing::StubContext;
     use component::ParametersComponentWise;
+    use paste::paste;
     use pictorus_traits::Matrix;
 
     #[test]
@@ -237,5 +238,191 @@ mod tests {
 
         assert_eq!(output, &expected);
         assert_eq!(block.buffer(), &expected);
+    }
+
+    macro_rules! test_product_types {
+        // Convenience call to generate a call to the main macro for every type in the list
+        ($type:ty, $($other_types:ty),*) => {
+            test_product_types!($type);
+            test_product_types!($($other_types),*);
+        };
+        ($type:ty) => {
+            paste! {
+                #[test]
+                fn [<test_component_wise_scalar_ $type>]() {
+                    let context = StubContext::default();
+                    let mut block = ProductBlock::<($type, $type), ComponentWise>::default();
+
+                    // Multiply only
+                    let parameters = ParametersComponentWise::new([1.0, 1.0]);
+                    let output = block.process(&parameters, &context, (6 as $type, 2 as $type));
+                    assert_eq!(output, 12 as $type);
+                    assert_eq!(block.buffer(), output);
+
+                    // Multiply then divide, chosen to divide exactly for every type
+                    let parameters = ParametersComponentWise::new([1.0, -1.0]);
+                    let output = block.process(&parameters, &context, (12 as $type, 4 as $type));
+                    assert_eq!(output, 3 as $type);
+                    assert_eq!(block.buffer(), output);
+                }
+
+                #[test]
+                fn [<test_component_wise_matrix_ $type>]() {
+                    let context = StubContext::default();
+                    let mut block = ProductBlock::<
+                        (Matrix<2, 2, $type>, Matrix<2, 2, $type>),
+                        ComponentWise,
+                    >::default();
+                    let parameters = ParametersComponentWise::new([1.0, 1.0]);
+                    let output = block.process(
+                        &parameters,
+                        &context,
+                        (
+                            &Matrix {
+                                data: [[1 as $type, 2 as $type], [3 as $type, 4 as $type]],
+                            },
+                            &Matrix {
+                                data: [[5 as $type, 6 as $type], [7 as $type, 8 as $type]],
+                            },
+                        ),
+                    );
+                    let expected = Matrix {
+                        data: [[5 as $type, 12 as $type], [21 as $type, 32 as $type]],
+                    };
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
+                }
+
+                #[test]
+                fn [<test_component_wise_mixed_ $type>]() {
+                    let context = StubContext::default();
+                    let mut block =
+                        ProductBlock::<($type, Matrix<2, 2, $type>), ComponentWise>::default();
+                    let parameters = ParametersComponentWise::new([1.0, 1.0]);
+                    let output = block.process(
+                        &parameters,
+                        &context,
+                        (
+                            3 as $type,
+                            &Matrix {
+                                data: [[1 as $type, 2 as $type], [3 as $type, 4 as $type]],
+                            },
+                        ),
+                    );
+                    let expected = Matrix {
+                        data: [[3 as $type, 6 as $type], [9 as $type, 12 as $type]],
+                    };
+                    assert_eq!(output, &expected);
+                    assert_eq!(block.buffer(), &expected);
+                }
+            }
+        };
+    }
+
+    test_product_types!(f32, f64, i8, i16, i32, i64, u8, u16, u32, u64);
+
+    #[test]
+    fn test_matrix_mult_int() {
+        let context = StubContext::default();
+        let p = ParametersMatrixMult {};
+
+        // [[1, 2, 3], [4, 5, 6]] * [[7, 8], [9, 10], [11, 12]] = [[58, 64], [139, 154]]
+        let mut block =
+            ProductBlock::<(Matrix<2, 3, i32>, Matrix<3, 2, i32>), MatrixMultiply>::default();
+        let output = block.process(
+            &p,
+            &context,
+            (
+                &Matrix {
+                    data: [[1, 4], [2, 5], [3, 6]],
+                },
+                &Matrix {
+                    data: [[7, 9, 11], [8, 10, 12]],
+                },
+            ),
+        );
+        let expected = Matrix {
+            data: [[58, 139], [64, 154]],
+        };
+        assert_eq!(output, &expected);
+        assert_eq!(block.buffer(), &expected);
+
+        // [[1, 2], [3, 4]] * [[5, 6], [7, 8]] = [[19, 22], [43, 50]], fits in u8
+        let mut block =
+            ProductBlock::<(Matrix<2, 2, u8>, Matrix<2, 2, u8>), MatrixMultiply>::default();
+        let output = block.process(
+            &p,
+            &context,
+            (
+                &Matrix {
+                    data: [[1u8, 3], [2, 4]],
+                },
+                &Matrix {
+                    data: [[5u8, 7], [6, 8]],
+                },
+            ),
+        );
+        let expected = Matrix {
+            data: [[19u8, 43], [22, 50]],
+        };
+        assert_eq!(output, &expected);
+        assert_eq!(block.buffer(), &expected);
+    }
+
+    #[test]
+    fn test_component_wise_int_division_truncates() {
+        // Integer division truncates toward zero
+        let context = StubContext::default();
+        let mut block = ProductBlock::<(i32, i32), ComponentWise>::default();
+        let parameters = ParametersComponentWise::new([1.0, -1.0]);
+        let output = block.process(&parameters, &context, (7, 2));
+        assert_eq!(output, 3);
+    }
+
+    #[test]
+    fn test_component_wise_int_leading_divide() {
+        // The accumulator starts at one, so a leading divide computes 1 / x,
+        // which truncates to zero for any integer input > 1
+        let context = StubContext::default();
+        let mut block = ProductBlock::<(i32, i32), ComponentWise>::default();
+        let parameters = ParametersComponentWise::new([-1.0, 1.0]);
+        let output = block.process(&parameters, &context, (5, 10));
+        assert_eq!(output, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn int_division_by_zero_panics() {
+        // Integer division by zero panics in all build profiles (unlike float inf)
+        let context = StubContext::default();
+        let mut block = ProductBlock::<(i32, i32), ComponentWise>::default();
+        let parameters = ParametersComponentWise::new([1.0, -1.0]);
+        let output = block.process(&parameters, &context, (4, 0));
+        assert_eq!(output, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn int_multiply_overflow_panics() {
+        // 16 * 16 overflows u8; native arithmetic panics in debug builds (wraps in release).
+        let context = StubContext::default();
+        let mut block = ProductBlock::<(u8, u8), ComponentWise>::default();
+        let parameters = ParametersComponentWise::new([1.0, 1.0]);
+        let output = block.process(&parameters, &context, (16u8, 16u8));
+        assert_eq!(output, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn matrix_mult_overflow_panics() {
+        // Each output element is 16*16 + 16*16 = 512, which overflows u8;
+        // panics in debug builds (wraps in release).
+        let context = StubContext::default();
+        let p = ParametersMatrixMult {};
+        let mut block =
+            ProductBlock::<(Matrix<2, 2, u8>, Matrix<2, 2, u8>), MatrixMultiply>::default();
+        let input = Matrix { data: [[16u8; 2]; 2] };
+        let output = block.process(&p, &context, (&input, &input));
+        assert_eq!(output, &Matrix { data: [[0u8; 2]; 2] });
     }
 }

--- a/pictorus-blocks/src/core_blocks/product_block.rs
+++ b/pictorus-blocks/src/core_blocks/product_block.rs
@@ -414,6 +414,18 @@ mod tests {
 
     #[test]
     #[should_panic]
+    fn int_multiply_negative_overflow_panics() {
+        // -100 * 2 = -200 underflows i8::MIN; native integer multiplication panics in
+        // debug builds (wraps in release).
+        let context = StubContext::default();
+        let mut block = ProductBlock::<(i8, i8), ComponentWise>::default();
+        let parameters = ParametersComponentWise::new([1.0, 1.0]);
+        let output = block.process(&parameters, &context, (-100i8, 2i8));
+        assert_eq!(output, 56);
+    }
+
+    #[test]
+    #[should_panic]
     fn matrix_mult_overflow_panics() {
         // Each output element is 16*16 + 16*16 = 512, which overflows u8;
         // panics in debug builds (wraps in release).

--- a/pictorus-blocks/src/core_blocks/sum_block.rs
+++ b/pictorus-blocks/src/core_blocks/sum_block.rs
@@ -897,6 +897,20 @@ mod tests {
 
     #[test]
     #[should_panic]
+    fn signed_subtraction_negative_overflow_panics() {
+        // -100 - 100 = -200 underflows i8::MIN; native integer subtraction panics in
+        // debug builds (wraps in release).
+        let stub_context = StubContext::default();
+        let mut block = SumBlock::<(i8, i8)>::default();
+        let parameters = Parameters {
+            operations: [SumType::Addition, SumType::Subtraction],
+        };
+        let result = block.process(&parameters, &stub_context, (-100i8, 100i8));
+        assert_eq!(result, 56);
+    }
+
+    #[test]
+    #[should_panic]
     fn addition_overflow_panics() {
         // 200 + 100 overflows u8; native arithmetic panics in debug builds (wraps in release).
         let stub_context = StubContext::default();

--- a/pictorus-blocks/src/core_blocks/sum_block.rs
+++ b/pictorus-blocks/src/core_blocks/sum_block.rs
@@ -1,5 +1,6 @@
-use crate::matrix_ext::MatrixNalgebraExt;
-use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock, Scalar};
+use crate::traits::Scalar;
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 /// Sums (adds or subtracts) all inputs together.
 pub struct SumBlock<T: Summable> {
@@ -39,18 +40,11 @@ where
     }
 }
 
-trait SumScalar:
-    Scalar
-    + nalgebra::Scalar
-    + core::ops::Neg<Output = Self>
-    + core::ops::Add<Output = Self>
-    + core::ops::Sub<Output = Self>
-    + core::ops::AddAssign
-    + core::ops::SubAssign
+trait SumScalar: Scalar + Add<Output = Self> + Sub<Output = Self> + AddAssign + SubAssign {}
+impl<S> SumScalar for S where
+    S: Scalar + Add<Output = S> + Sub<Output = S> + AddAssign + SubAssign
 {
 }
-impl SumScalar for f32 {}
-impl SumScalar for f64 {}
 
 /// This trait is used to determine the output type of a sum operation
 /// between two types, most importantly it can be used recursively. To get the output type for
@@ -176,13 +170,15 @@ impl<const R: usize, const C: usize, S: SumScalar> SumInto<Matrix<R, C, S>> for 
         dest: &'a mut Option<Matrix<R, C, S>>,
     ) -> PassBy<'a, Matrix<R, C, S>> {
         let dest = dest.get_or_insert(Matrix::<R, C, S>::zeroed());
-        let orig_dest = dest.as_view().clone_owned();
-        match sum_type {
-            SumType::Addition => {
-                orig_dest.add_to(&input.as_view(), &mut dest.as_view_mut());
-            }
-            SumType::Subtraction => {
-                orig_dest.sub_to(&input.as_view(), &mut dest.as_view_mut());
+        for (elem, &val) in dest
+            .data
+            .as_flattened_mut()
+            .iter_mut()
+            .zip(input.data.as_flattened().iter())
+        {
+            match sum_type {
+                SumType::Addition => *elem += val,
+                SumType::Subtraction => *elem -= val,
             }
         }
         dest
@@ -197,16 +193,12 @@ impl<const R: usize, const C: usize, S: SumScalar> SumInto<Matrix<R, C, S>> for 
         dest: &'a mut Option<Matrix<R, C, S>>,
     ) -> PassBy<'a, Matrix<R, C, S>> {
         let dest = dest.get_or_insert(Matrix::<R, C, S>::zeroed());
-        let mut orig_dest = dest.as_view().clone_owned();
-        match sum_type {
-            SumType::Addition => {
-                orig_dest = orig_dest.add_scalar(input);
-            }
-            SumType::Subtraction => {
-                orig_dest = orig_dest.add_scalar(-input);
+        for elem in dest.data.as_flattened_mut() {
+            match sum_type {
+                SumType::Addition => *elem += input,
+                SumType::Subtraction => *elem -= input,
             }
         }
-        dest.as_view_mut().copy_from(&orig_dest);
         dest
     }
 }
@@ -469,6 +461,7 @@ mod tests {
     use super::*;
     use crate::testing::StubContext;
     use approx::assert_relative_eq;
+    use paste::paste;
 
     #[test]
     fn test_sum_default_buffer_no_panic() {
@@ -799,6 +792,120 @@ mod tests {
             result.data.as_flattened(),
             [[11.0, 13.0], [15.0, 17.0]].as_flattened()
         );
+    }
+
+    macro_rules! test_sum_types {
+        // Convenience call to generate a call to the main macro for every type in the list
+        ($type:ty, $($other_types:ty),*) => {
+            test_sum_types!($type);
+            test_sum_types!($($other_types),*);
+        };
+        ($type:ty) => {
+            paste! {
+                #[test]
+                fn [<test_sum_scalars_ $type>]() {
+                    let stub_context = StubContext::default();
+                    let mut block = SumBlock::<($type, $type)>::default();
+                    let input = (7 as $type, 3 as $type);
+
+                    let parameters = Parameters {
+                        operations: [SumType::Addition, SumType::Addition],
+                    };
+                    let result = block.process(&parameters, &stub_context, input);
+                    assert_eq!(result, 10 as $type);
+                    assert_eq!(block.buffer(), result);
+
+                    let parameters = Parameters {
+                        operations: [SumType::Addition, SumType::Subtraction],
+                    };
+                    let result = block.process(&parameters, &stub_context, input);
+                    assert_eq!(result, 4 as $type);
+                    assert_eq!(block.buffer(), result);
+                }
+
+                #[test]
+                fn [<test_sum_matrices_ $type>]() {
+                    let stub_context = StubContext::default();
+                    let mut block =
+                        SumBlock::<(Matrix<2, 2, $type>, Matrix<2, 2, $type>)>::default();
+                    let input = (
+                        &Matrix {
+                            data: [[5 as $type, 6 as $type], [7 as $type, 8 as $type]],
+                        },
+                        &Matrix {
+                            data: [[1 as $type, 2 as $type], [3 as $type, 4 as $type]],
+                        },
+                    );
+
+                    let parameters = Parameters {
+                        operations: [SumType::Addition, SumType::Addition],
+                    };
+                    let result = block.process(&parameters, &stub_context, input);
+                    assert_eq!(
+                        result.data,
+                        [[6 as $type, 8 as $type], [10 as $type, 12 as $type]]
+                    );
+
+                    let parameters = Parameters {
+                        operations: [SumType::Addition, SumType::Subtraction],
+                    };
+                    let result = block.process(&parameters, &stub_context, input);
+                    assert_eq!(
+                        result.data,
+                        [[4 as $type, 4 as $type], [4 as $type, 4 as $type]]
+                    );
+                }
+
+                #[test]
+                fn [<test_sum_mixed_ $type>]() {
+                    let stub_context = StubContext::default();
+                    let mut block = SumBlock::<($type, Matrix<2, 2, $type>)>::default();
+                    let input = (
+                        3 as $type,
+                        &Matrix {
+                            data: [[1 as $type, 2 as $type], [3 as $type, 4 as $type]],
+                        },
+                    );
+
+                    let parameters = Parameters {
+                        operations: [SumType::Addition, SumType::Addition],
+                    };
+                    let result = block.process(&parameters, &stub_context, input);
+                    assert_eq!(
+                        result.data,
+                        [[4 as $type, 5 as $type], [6 as $type, 7 as $type]]
+                    );
+                }
+            }
+        };
+    }
+
+    test_sum_types!(f32, f64, i8, i16, i32, i64, u8, u16, u32, u64);
+
+    #[test]
+    #[should_panic]
+    fn unsigned_subtraction_underflow_panics() {
+        // 3 - 7 underflows u8; native arithmetic panics in debug builds (wraps in release).
+        let stub_context = StubContext::default();
+        let mut block = SumBlock::<(u8, u8)>::default();
+        let parameters = Parameters {
+            operations: [SumType::Addition, SumType::Subtraction],
+        };
+        let result = block.process(&parameters, &stub_context, (3u8, 7u8));
+        assert_eq!(result, 252);
+    }
+
+    #[test]
+    #[should_panic]
+    fn addition_overflow_panics() {
+        // 200 + 100 overflows u8; native arithmetic panics in debug builds (wraps in release).
+        let stub_context = StubContext::default();
+        let mut block = SumBlock::<(u8, u8)>::default();
+        let parameters = Parameters {
+            operations: [SumType::Addition, SumType::Addition],
+        };
+        let result = block.process(&parameters, &stub_context, (200u8, 100u8));
+        assert_eq!(result, 44);
     }
 
     #[test]

--- a/pictorus-blocks/src/core_blocks/vector_norm_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_norm_block.rs
@@ -1,4 +1,6 @@
-use crate::matrix_ext::MatrixNalgebraExt;
+use crate::traits::Scalar;
+use core::marker::PhantomData;
+use num_traits::{AsPrimitive, Float};
 use pictorus_traits::{Matrix, Pass, PassBy, ProcessBlock};
 
 pub struct Parameters {}
@@ -19,30 +21,35 @@ impl Parameters {
 ///
 /// More specifically, it computes the Frobenius norm of a matrix, which is a generalization of the
 /// Euclidean norm for matrices.
-pub struct VectorNormBlock<T>
+///
+/// The input can be a matrix of any scalar type; the output is a selectable float type
+/// (`f64` by default) in which the sum of squares is accumulated.
+pub struct VectorNormBlock<T, O: Scalar = f64>
 where
-    T: Apply,
+    T: Apply<O>,
 {
-    buffer: T::Output,
+    buffer: O,
+    phantom: PhantomData<T>,
 }
 
-impl<T> Default for VectorNormBlock<T>
+impl<T, O: Scalar> Default for VectorNormBlock<T, O>
 where
-    T: Apply,
+    T: Apply<O>,
 {
     fn default() -> Self {
         Self {
-            buffer: T::Output::default(),
+            buffer: O::default(),
+            phantom: PhantomData,
         }
     }
 }
 
-impl<T> ProcessBlock for VectorNormBlock<T>
+impl<T, O: Scalar> ProcessBlock for VectorNormBlock<T, O>
 where
-    T: Apply,
+    T: Apply<O>,
 {
     type Inputs = T;
-    type Output = T::Output;
+    type Output = O;
     type Parameters = Parameters;
 
     fn process(
@@ -51,8 +58,7 @@ where
         _context: &dyn pictorus_traits::Context,
         inputs: PassBy<'_, Self::Inputs>,
     ) -> PassBy<'_, Self::Output> {
-        let output = T::apply(&mut self.buffer, inputs);
-        output
+        T::apply(&mut self.buffer, inputs)
     }
 
     fn buffer(&self) -> PassBy<'_, Self::Output> {
@@ -60,63 +66,29 @@ where
     }
 }
 
-pub trait Apply: Pass {
-    type Output: Pass + Default;
-
-    fn apply<'s>(store: &'s mut Self::Output, input: PassBy<Self>) -> PassBy<'s, Self::Output>;
+pub trait Apply<O: Scalar>: Pass {
+    fn apply<'s>(store: &'s mut O, input: PassBy<Self>) -> PassBy<'s, O>;
 }
 
-// Promote i8, u8, i16, u16, i32, and u32
-macro_rules! impl_vector_norm_apply {
-    ($type:ty, $otype:ty) => {
-        impl<const ROWS: usize, const COLS: usize> Apply for Matrix<ROWS, COLS, $type> {
-            type Output = $otype;
-
-            fn apply<'s>(
-                store: &'s mut Self::Output,
-                input: PassBy<Self>,
-            ) -> PassBy<'s, Self::Output> {
-                let mut output = Matrix::<ROWS, COLS, $otype>::zeroed();
-                for r in 0..ROWS {
-                    for c in 0..COLS {
-                        output.data[c][r] = input.data[c][r].into();
-                    }
-                }
-                let n = output.as_view().norm();
-                *store = n;
-                n
-            }
-        }
-    };
+impl<const ROWS: usize, const COLS: usize, T, O> Apply<O> for Matrix<ROWS, COLS, T>
+where
+    T: Scalar + AsPrimitive<O>,
+    O: Scalar + Float,
+{
+    fn apply<'s>(store: &'s mut O, input: PassBy<Self>) -> PassBy<'s, O> {
+        let sum_of_squares = input
+            .data
+            .as_flattened()
+            .iter()
+            .fold(O::zero(), |acc, &v| {
+                let val: O = v.as_();
+                acc + val * val
+            });
+        let n = sum_of_squares.sqrt();
+        *store = n;
+        n
+    }
 }
-
-impl_vector_norm_apply!(i8, f32);
-impl_vector_norm_apply!(u8, f32);
-impl_vector_norm_apply!(i16, f32);
-impl_vector_norm_apply!(u16, f32);
-impl_vector_norm_apply!(i32, f64);
-impl_vector_norm_apply!(u32, f64);
-
-// f32 and f64 don't need to be promoted
-macro_rules! impl_vector_norm {
-    ($type:ty) => {
-        impl<const ROWS: usize, const COLS: usize> Apply for Matrix<ROWS, COLS, $type> {
-            type Output = $type;
-
-            fn apply<'s>(
-                store: &'s mut Self::Output,
-                input: PassBy<Self>,
-            ) -> PassBy<'s, Self::Output> {
-                let n = input.as_view().norm();
-                *store = n;
-                n
-            }
-        }
-    };
-}
-
-impl_vector_norm!(f32);
-impl_vector_norm!(f64);
 
 #[cfg(test)]
 mod tests {
@@ -130,47 +102,68 @@ mod tests {
         assert_eq!(block.buffer(), 0.0);
     }
 
+    #[test]
+    fn test_vector_norm_default_output_type() {
+        // Output type param defaults to f64 for any input type
+        let mut block = VectorNormBlock::<Matrix<1, 2, i8>>::default();
+        let p = Parameters::new();
+        let c = StubContext::default();
+
+        let input = Matrix { data: [[3], [4]] };
+        let output: f64 = block.process(&p, &c, &input);
+        assert_eq!(output, 5.0);
+    }
+
     macro_rules! test_vector_norm {
-        ($type:ty) => {
+        // Convenience call to generate a call to the main macro for every pair in the list
+        ($type:ty : $otype:ty, $($rest_t:ty : $rest_o:ty),*) => {
+            test_vector_norm!($type : $otype);
+            test_vector_norm!($($rest_t : $rest_o),*);
+        };
+        ($type:ty : $otype:ty) => {
             paste! {
                 #[test]
-                fn [<test_vector_norm_ $type>]() {
-                    let mut block = VectorNormBlock::<Matrix<1, 2, $type>>::default();
+                fn [<test_vector_norm_ $type _to_ $otype>]() {
+                    let mut block = VectorNormBlock::<Matrix<1, 2, $type>, $otype>::default();
                     let p = Parameters::new();
                     let c = StubContext::default();
 
                     let input = Matrix {
-                        data: [[[<3_$type>]], [[<4 $type>]]]
+                        data: [[3 as $type], [4 as $type]]
                     };
 
                     let output = block.process(&p, &c, &input);
-                    assert_eq!(output, [<5 $type>].into());
+                    assert_eq!(output, 5 as $otype);
                     assert_eq!(block.buffer(), output);
                 }
 
                 #[test]
-                fn [<test_matrix_norm_ $type>]() {
-                    let mut block = VectorNormBlock::<Matrix<2, 2, $type>>::default();
+                fn [<test_matrix_norm_ $type _to_ $otype>]() {
+                    let mut block = VectorNormBlock::<Matrix<2, 2, $type>, $otype>::default();
                     let p = Parameters::new();
                     let c = StubContext::default();
 
                     let input = Matrix {
-                        data: [[[<3 $type>], [<3 $type>]], [[<3 $type>], [<3 $type>]]],
+                        data: [[3 as $type, 3 as $type], [3 as $type, 3 as $type]],
                     };
                     let output = block.process(&p, &c, &input);
-                    assert_eq!(output, [<6 $type>].into());
+                    assert_eq!(output, 6 as $otype);
                     assert_eq!(block.buffer(), output);
                 }
             }
         };
     }
 
-    test_vector_norm!(i8);
-    test_vector_norm!(u8);
-    test_vector_norm!(i16);
-    test_vector_norm!(u16);
-    test_vector_norm!(i32);
-    test_vector_norm!(u32);
-    test_vector_norm!(f32);
-    test_vector_norm!(f64);
+    test_vector_norm!(
+        i8: f32, i8: f64,
+        u8: f32, u8: f64,
+        i16: f32, i16: f64,
+        u16: f32, u16: f64,
+        i32: f32, i32: f64,
+        u32: f32, u32: f64,
+        i64: f32, i64: f64,
+        u64: f32, u64: f64,
+        f32: f32, f32: f64,
+        f64: f32, f64: f64
+    );
 }

--- a/pictorus-blocks/src/core_blocks/vector_sort_block.rs
+++ b/pictorus-blocks/src/core_blocks/vector_sort_block.rs
@@ -116,6 +116,8 @@ macro_rules! impl_vector_sort {
 
 impl_vector_sort!(f64);
 impl_vector_sort!(f32);
+impl_vector_sort!(i64);
+impl_vector_sort!(u64);
 impl_vector_sort!(i32);
 impl_vector_sort!(u32);
 impl_vector_sort!(i16);
@@ -234,6 +236,8 @@ mod tests {
 
     impl_vector_sort_tests!(f64);
     impl_vector_sort_tests!(f32);
+    impl_vector_sort_tests!(i64);
+    impl_vector_sort_tests!(u64);
     impl_vector_sort_tests!(i32);
     impl_vector_sort_tests!(u32);
     impl_vector_sort_tests!(i16);

--- a/pictorus-blocks/src/traits.rs
+++ b/pictorus-blocks/src/traits.rs
@@ -21,6 +21,7 @@ pub trait Scalar:
     + PartialEq
     + nalgebra::Scalar
     + SimdPartialOrd
+    + PartialOrd
 {
     /// Returns true if the scalar is truthy
     /// Truthiness is defined as not equal to zero


### PR DESCRIPTION
All blocks should be covered now. In a few cases this change exposes us to new opportunities to panic in cases of arithmetic overflow/underflow  (in debug builds it panics, in release builds it will wrap). I have annotated as many of these cases as I could identify with `#[should_fail]` unit tests so they are documented and  we can revisit them in the future


Of note the following were skipped or limited in their impls:
- System Time Block: the inability to represent unix time in most scalars means I left it alone
- ADC was skipped since I didn't think it made sense to have arbitrary casting in the block if the type retrieved from HW is always the same, it would probably be better to have people use a cast block. Worth noting that type from HW is not `f64`, it could make sense to go back at some point and make it output honest to what the HW outputs
- JSON Load: These come from json as `i64`/`u64`/`f64`, we are already doing a lossy conversion to `f64` for the interger cases, but by similar reasoning to ADC it figured it doesn't make sense to add conversion in the block that is essentially just a hidden cast block
- CanTX and CanRX: Again DBCs output types according to their call back ABI, we should look at these deeper at a later point
- Bytes Unpack: Again this feels like it requires some deeper effort/ thought. In an ideal world we would actually output the types taken out of the byte input. This however would require us going from `[f64; N]` output to a tuple based output so we could have mixed types. This would again limit us to how high our tuple imples of `Pass` go (8 outputs total counting is_valid). That limit is why we switched to the array impl in the first place